### PR TITLE
Add misc/evals/ per-skill evaluation home (M2.7)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- Brief description of what this PR changes. -->
+
+## If this PR adds a new skill
+
+- [ ] `skills/<skill>/SKILL.md` present and passes `make validate-<skill>` (run from `misc/evals/`)
+- [ ] `misc/evals/<skill>/triggering.json` authored (≥16 prompts; balanced positives and near-miss negatives)
+- [ ] `misc/evals/<skill>/evals.json` authored (≥2 realistic task prompts; every assertion tagged `TODO: human review` until tuned)
+- [ ] `misc/evals/<skill>/README.md` filled in (replaces `<REPLACE>` markers from the template)
+- [ ] `make check-evals-coverage` exits 0
+
+See [`misc/evals/README.md`](../misc/evals/README.md) for the capability catalogue and [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the full new-skill workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,10 +266,17 @@ See the `skill-creator` skill in `skills/skill-creator/SKILL.md` for the full gu
 
 1. Understand the skill with concrete examples
 2. Plan reusable contents (scripts, references, assets)
-3. Initialize: `python skills/skill-creator/scripts/init_skill.py <name> --path skills/`
-4. Edit SKILL.md and add references
-5. Package: `python skills/skill-creator/scripts/package_skill.py skills/<name>`
-6. Iterate based on real usage
+3. Hand-author `skills/<name>/SKILL.md` and any `references/` / `agents/` / `scripts/` / `assets/` subdirectories (no scaffolding script exists)
+4. Set up evals: `cd misc/evals && make init-evals SKILL=<name>`, then fill in the `<REPLACE>` markers in `triggering.json`, `evals.json`, and `README.md` — see [`misc/evals/README.md`](misc/evals/README.md)
+5. Validate: `make validate-<name>` (from `misc/evals/`) and `make check-evals-coverage`
+6. Package: `python skills/skill-creator/scripts/package_skill.py skills/<name>`
+7. Iterate based on real usage
+
+### Pre-PR checklist for new skills
+
+- [ ] `make validate-<name>` passes
+- [ ] `misc/evals/<name>/` has `triggering.json` (≥16 prompts, balanced), `evals.json` (≥2 task prompts), and a filled-in `README.md`
+- [ ] `make check-evals-coverage` exits 0
 
 ## Creating a New Steering Workflow
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ sample-apex-skills/
 ├── skills/       → 📚 Domain knowledge (EKS best practices, Terraform, skill creation)
 ├── steering/     → 🎯 Guided workflows (optional — structured engagement playbooks)
 ├── examples/     → 🏗️ Hands-on exercises (deployable labs with planted issues)
-└── misc/         → 🔧 Maintenance scripts (sync skills from sources, update cross-references)
+└── misc/         → 🔧 Maintenance and tooling
+    ├── evals/    → 🧪 Per-skill evaluation inputs (triggering + task prompts)
+    └── (scripts) → Sync skills from sources, update cross-references
 ```
 
 | Directory | Purpose | Think of it as... |
@@ -23,7 +25,7 @@ sample-apex-skills/
 | `skills/` | **What** the agent knows — reusable domain knowledge | An expert's brain |
 | `steering/` | **How** the agent runs an engagement — slash commands, questionnaires, checkpoints, routing | A senior SA's playbook |
 | `examples/` | **How** to try it — deploy, run APEX against it, see results | A workshop lab |
-| `misc/` | Maintenance tooling — keep skills in sync, update references | The toolbox |
+| `misc/` | Maintenance tooling and per-skill evaluation inputs | The toolbox |
 
 > **Key principle:** Skills provide the knowledge. Steering provides the structure.  
 
@@ -160,6 +162,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on:
 - How to create a new skill
 - How to create a new steering workflow
 - How to create a new example
+- How to add evals for a new skill
 
 ---
 

--- a/misc/README.md
+++ b/misc/README.md
@@ -3,6 +3,29 @@
 
 This folder contains miscellaneous scripts to help maintain this repo.  
 
+## Evaluate Skills
+
+Per-skill evaluation inputs (triggering tests and task prompts) live under [`evals/`](./evals/). These feed the tooling in [`skills/skill-creator/`](../skills/skill-creator/).
+
+**Check that every skill has an eval entry** (coverage — no live model needed):
+
+```bash
+cd evals
+make check-evals-coverage
+```
+
+Fails with a list of missing skills and a hint to run `make init-evals SKILL=<name>`. Exits 0 when every `skills/<name>/` (minus upstream-synced `skill-creator` and `terraform-skill`) has a matching `evals/<name>/`.
+
+**Evaluate all skills**:
+
+```bash
+cd evals
+make validate-all      # frontmatter + 64/1024-char limits (deterministic, no live model)
+make triggering-all    # triggering accuracy (requires live `claude -p` session)
+```
+
+`validate-all` is safe to run anywhere. `triggering-all` fans out across all 4 in-scope skills and takes minutes per skill — see [`evals/README.md`](./evals/README.md) for cost/time notes, per-skill targets, the full capability catalogue (A–K), and the onboarding path for adding a new skill.
+
 ## Update README - Skills and Steering  
 
 Various READMEs references Skills and Steering files. We do not want to have to manually edit everytime some change is made to either folder. Thus, created scripts to read the frontmatter of both and update the READMEs accordingly:  

--- a/misc/evals/.gitignore
+++ b/misc/evals/.gitignore
@@ -1,0 +1,5 @@
+# Ephemeral eval runs — never commit these
+*/workspace/
+*/workspace
+# Generated HTML reports
+*.html

--- a/misc/evals/Makefile
+++ b/misc/evals/Makefile
@@ -9,9 +9,11 @@
 #   make triggering-eks-recon MODEL=claude-sonnet-4-5
 #   make benchmark-eks-recon BENCHMARK_DIR=/abs/path/to/run-dir
 
-SKILLS         := eks-recon eks-best-practices eks-upgrader eks-mcp-server
+SHELL          := /bin/bash
+
 EVALS_ROOT     := $(CURDIR)
 REPO_ROOT      := $(abspath $(CURDIR)/../..)
+SKILLS         := $(shell find $(EVALS_ROOT) -maxdepth 1 -mindepth 1 -type d ! -name 'workspace' ! -name '_template' ! -name '.*' -printf '%f\n' | sort)
 SC_DIR         := $(REPO_ROOT)/skills/skill-creator
 MODEL          ?= claude-sonnet-4-5
 NUM_WORKERS    ?= 10
@@ -33,6 +35,7 @@ PACKAGE_T    := $(addprefix package-,$(SKILLS))
 REVIEW_T     := $(addprefix review-,$(SKILLS))
 
 .PHONY: help list-skills validate-all triggering-all \
+        init-evals check-evals-coverage \
         $(VALIDATE_T) $(TRIGGERING_T) $(OPTIMIZE_T) \
         $(BENCHMARK_T) $(REPORT_T) $(PACKAGE_T) $(REVIEW_T)
 
@@ -48,6 +51,10 @@ help:
 	@echo ""
 	@echo "Meta targets:"
 	@echo "  validate-all, triggering-all"
+	@echo ""
+	@echo "New-skill onboarding:"
+	@echo "  init-evals SKILL=<name>    scaffold misc/evals/<name>/ from _template/"
+	@echo "  check-evals-coverage       verify every skills/*/ has a misc/evals/*/ entry"
 	@echo ""
 	@echo "Overrides: MODEL, NUM_WORKERS, MAX_ITER, RUNS_PER_QUERY, WORKSPACE, BENCHMARK_DIR"
 
@@ -125,3 +132,45 @@ $(REVIEW_T): review-%:
 	  python3 $(SC_DIR)/eval-viewer/generate_review.py "$$WORKSPACE" \
 	    --skill-name $* \
 	    --static $(call workspace_dir,$*)/review.html
+
+# ---------- init-evals (scaffold a new misc/evals/<skill>/ from _template/) ----
+init-evals:
+	@if [ -z "$(SKILL)" ]; then \
+	  echo "usage: make init-evals SKILL=<skill-name>"; \
+	  exit 1; \
+	fi
+	@if [ -e "$(EVALS_ROOT)/$(SKILL)" ]; then \
+	  echo "error: $(EVALS_ROOT)/$(SKILL) already exists"; \
+	  exit 1; \
+	fi
+	@if [ ! -d "$(EVALS_ROOT)/_template" ]; then \
+	  echo "error: template dir not found: $(EVALS_ROOT)/_template"; \
+	  exit 1; \
+	fi
+	cp -r $(EVALS_ROOT)/_template $(EVALS_ROOT)/$(SKILL)
+	find $(EVALS_ROOT)/$(SKILL) -type f ! -name '.gitkeep' -exec sed -i.bak 's/<REPLACE>/$(SKILL)/g' {} +
+	find $(EVALS_ROOT)/$(SKILL) -name '*.bak' -delete
+	@echo ""
+	@echo "✓ Scaffolded $(EVALS_ROOT)/$(SKILL)/"
+	@echo ""
+	@echo "Next steps:"
+	@echo "  1. Edit $(EVALS_ROOT)/$(SKILL)/triggering.json — add 16+ trigger prompts"
+	@echo "  2. Edit $(EVALS_ROOT)/$(SKILL)/evals.json      — add 2-4 task prompts"
+	@echo "  3. Edit $(EVALS_ROOT)/$(SKILL)/README.md       — document the eval set"
+	@echo "  4. Run: make validate-$(SKILL)"
+
+# ---------- check-evals-coverage (every skills/*/ has a misc/evals/*/ entry) --
+check-evals-coverage:
+	@expected=$$(find $(REPO_ROOT)/skills -maxdepth 1 -mindepth 1 -type d -printf '%f\n' \
+	  | grep -vx skill-creator | grep -vx terraform-skill | sort); \
+	 found=$$(find $(EVALS_ROOT) -maxdepth 1 -mindepth 1 -type d -printf '%f\n' \
+	  | grep -vx _template | grep -vx workspace | sort); \
+	 missing=$$(comm -23 <(echo "$$expected") <(echo "$$found")); \
+	 if [ -n "$$missing" ]; then \
+	   echo "Missing misc/evals/ entries for:"; \
+	   echo "$$missing" | sed 's/^/  - /'; \
+	   echo ""; \
+	   echo "Run: make init-evals SKILL=<name>"; \
+	   exit 1; \
+	 fi; \
+	 echo "✓ All skills have misc/evals/ entries"

--- a/misc/evals/Makefile
+++ b/misc/evals/Makefile
@@ -1,0 +1,127 @@
+# misc/evals/Makefile — drives skill-creator eval machinery for the 4 in-scope skills.
+#
+# All module-mode scripts require cwd = skills/skill-creator/ (scripts/ is a Python
+# package with an empty __init__.py, so `python3 -m scripts.<name>` is mandatory).
+# Recipes `cd` into that directory before invoking Python, and pass eval-set / output
+# paths as absolute paths ($(EVALS_ROOT)/…) so the cwd change is invisible to callers.
+#
+# Override on the command line:
+#   make triggering-eks-recon MODEL=claude-sonnet-4-5
+#   make benchmark-eks-recon BENCHMARK_DIR=/abs/path/to/run-dir
+
+SKILLS         := eks-recon eks-best-practices eks-upgrader eks-mcp-server
+EVALS_ROOT     := $(CURDIR)
+REPO_ROOT      := $(abspath $(CURDIR)/../..)
+SC_DIR         := $(REPO_ROOT)/skills/skill-creator
+MODEL          ?= claude-sonnet-4-5
+NUM_WORKERS    ?= 10
+MAX_ITER       ?= 5
+RUNS_PER_QUERY ?= 3
+
+# Per-skill default locations (override with WORKSPACE=… / BENCHMARK_DIR=…)
+workspace_dir   = $(EVALS_ROOT)/$(1)/workspace
+benchmark_dir   = $(EVALS_ROOT)/$(1)/workspace
+triggering_json = $(EVALS_ROOT)/$(1)/triggering.json
+evals_json      = $(EVALS_ROOT)/$(1)/evals.json
+
+VALIDATE_T   := $(addprefix validate-,$(SKILLS))
+TRIGGERING_T := $(addprefix triggering-,$(SKILLS))
+OPTIMIZE_T   := $(addprefix optimize-,$(SKILLS))
+BENCHMARK_T  := $(addprefix benchmark-,$(SKILLS))
+REPORT_T     := $(addprefix report-,$(SKILLS))
+PACKAGE_T    := $(addprefix package-,$(SKILLS))
+REVIEW_T     := $(addprefix review-,$(SKILLS))
+
+.PHONY: help list-skills validate-all triggering-all \
+        $(VALIDATE_T) $(TRIGGERING_T) $(OPTIMIZE_T) \
+        $(BENCHMARK_T) $(REPORT_T) $(PACKAGE_T) $(REVIEW_T)
+
+help:
+	@echo "Per-skill targets (SKILL in: $(SKILLS)):"
+	@echo "  validate-<skill>    A  quick_validate.py          (deterministic)"
+	@echo "  triggering-<skill>  B  run_eval.py                 (LIVE — needs claude -p)"
+	@echo "  optimize-<skill>    D  run_loop.py                 (LIVE)"
+	@echo "  benchmark-<skill>   E  aggregate_benchmark.py      (deterministic)"
+	@echo "  report-<skill>      F  generate_report.py          (deterministic)"
+	@echo "  package-<skill>     G  package_skill.py            (deterministic)"
+	@echo "  review-<skill>      K  eval-viewer/generate_review --static  (deterministic)"
+	@echo ""
+	@echo "Meta targets:"
+	@echo "  validate-all, triggering-all"
+	@echo ""
+	@echo "Overrides: MODEL, NUM_WORKERS, MAX_ITER, RUNS_PER_QUERY, WORKSPACE, BENCHMARK_DIR"
+
+list-skills:
+	@echo $(SKILLS)
+
+# ---------- A  quick_validate (deterministic; plain script-mode) --------------
+$(VALIDATE_T): validate-%:
+	python3 $(SC_DIR)/scripts/quick_validate.py $(REPO_ROOT)/skills/$*
+
+validate-all: $(VALIDATE_T)
+
+# ---------- B  run_eval (LIVE) ------------------------------------------------
+$(TRIGGERING_T): triggering-%:
+	@test -f $(call triggering_json,$*) || \
+	  { echo "missing: $(call triggering_json,$*)"; exit 1; }
+	cd $(SC_DIR) && python3 -m scripts.run_eval \
+	  --eval-set   $(call triggering_json,$*) \
+	  --skill-path $(REPO_ROOT)/skills/$* \
+	  --num-workers $(NUM_WORKERS) \
+	  --runs-per-query $(RUNS_PER_QUERY) \
+	  --model $(MODEL)
+
+triggering-all: $(TRIGGERING_T)
+
+# ---------- D  run_loop (LIVE; iterative description optimizer) ---------------
+$(OPTIMIZE_T): optimize-%:
+	@test -f $(call triggering_json,$*) || \
+	  { echo "missing: $(call triggering_json,$*)"; exit 1; }
+	mkdir -p $(call workspace_dir,$*)
+	cd $(SC_DIR) && python3 -m scripts.run_loop \
+	  --eval-set   $(call triggering_json,$*) \
+	  --skill-path $(REPO_ROOT)/skills/$* \
+	  --model $(MODEL) \
+	  --max-iterations $(MAX_ITER) \
+	  --num-workers $(NUM_WORKERS) \
+	  --runs-per-query $(RUNS_PER_QUERY) \
+	  --results-dir $(call workspace_dir,$*) \
+	  --report none
+
+# ---------- E  aggregate_benchmark (deterministic) ----------------------------
+# Expects BENCHMARK_DIR to contain eval-*/<config>/run-*/grading.json.
+$(BENCHMARK_T): benchmark-%:
+	@: $${BENCHMARK_DIR:=$(call benchmark_dir,$*)} ; \
+	  test -d "$$BENCHMARK_DIR" || \
+	    { echo "benchmark dir not found: $$BENCHMARK_DIR"; \
+	      echo "pass BENCHMARK_DIR=<dir> containing eval-*/…/grading.json"; exit 1; } ; \
+	  cd $(SC_DIR) && python3 -m scripts.aggregate_benchmark "$$BENCHMARK_DIR" \
+	    --skill-name $* \
+	    --skill-path $(REPO_ROOT)/skills/$*
+
+# ---------- F  generate_report (deterministic; reads run_loop results JSON) ---
+# Expects RESULTS_JSON=<path to run_loop results.json>.
+$(REPORT_T): report-%:
+	@: $${RESULTS_JSON:=$(call workspace_dir,$*)/results.json} ; \
+	  test -f "$$RESULTS_JSON" || \
+	    { echo "results JSON not found: $$RESULTS_JSON"; \
+	      echo "pass RESULTS_JSON=<path> (default: <workspace>/results.json)"; exit 1; } ; \
+	  cd $(SC_DIR) && python3 -m scripts.generate_report "$$RESULTS_JSON" \
+	    --skill-name $* \
+	    -o $(call workspace_dir,$*)/report.html
+
+# ---------- G  package_skill (deterministic) ----------------------------------
+$(PACKAGE_T): package-%:
+	mkdir -p $(EVALS_ROOT)/$*/workspace
+	cd $(SC_DIR) && python3 -m scripts.package_skill $(REPO_ROOT)/skills/$* $(EVALS_ROOT)/$*/workspace
+
+# ---------- K  eval-viewer/generate_review --static (deterministic) -----------
+# Expects WORKSPACE to be a directory created by run_loop / run_eval.
+$(REVIEW_T): review-%:
+	@: $${WORKSPACE:=$(call workspace_dir,$*)} ; \
+	  test -d "$$WORKSPACE" || \
+	    { echo "workspace not found: $$WORKSPACE"; \
+	      echo "pass WORKSPACE=<dir> from a prior optimize-$* run"; exit 1; } ; \
+	  python3 $(SC_DIR)/eval-viewer/generate_review.py "$$WORKSPACE" \
+	    --skill-name $* \
+	    --static $(call workspace_dir,$*)/review.html

--- a/misc/evals/README.md
+++ b/misc/evals/README.md
@@ -28,6 +28,32 @@ misc/evals/<skill>/
 pip install pyyaml
 ```
 
+## Adding evals for a new skill
+
+Every skill in `skills/` must have a matching entry in `misc/evals/` (except upstream-synced skills: `skill-creator` and `terraform-skill`, which are maintained externally). The onboarding path is scripted:
+
+```bash
+cd misc/evals
+make init-evals SKILL=<your-skill>
+```
+
+This copies `_template/` to `misc/evals/<your-skill>/` and substitutes `<REPLACE>` → `<your-skill>` across every file. The resulting directory has:
+
+- `triggering.json` — 2-entry skeleton (1 positive + 1 negative). Expand to ≥16 prompts with balanced positives and near-miss negatives.
+- `evals.json` — 1-entry skeleton; add 2–4 realistic task prompts. Every assertion is tagged `TODO: human review` until a human tunes it.
+- `README.md` — fill in the four `<REPLACE>` sections (scope, neighbor-skill disambiguation, live-MCP caveat, how to run).
+- `files/` — empty; drop input fixtures here as prompts demand.
+
+To verify every skill has an eval entry:
+
+```bash
+make check-evals-coverage
+```
+
+Fails with a list of missing skills. Exits 0 when every `skills/<name>/` (minus the upstream-synced pair) has a corresponding `misc/evals/<name>/`.
+
+See `CONTRIBUTING.md` for the full new-skill workflow including when in the PR lifecycle these pieces land.
+
 ## The working-directory quirk
 
 `skills/skill-creator/scripts/__init__.py` exists (it marks `scripts/` as a Python package) and intra-package imports use `from scripts.xxx import yyy`. That forces **module-mode invocation** with cwd set to `skills/skill-creator/`:

--- a/misc/evals/README.md
+++ b/misc/evals/README.md
@@ -1,0 +1,193 @@
+# `misc/evals/` — per-skill evaluation home
+
+This directory hosts evaluation inputs for the four in-scope skills so every capability that `skills/skill-creator/` ships with has usable inputs per skill:
+
+- `eks-recon`
+- `eks-best-practices`
+- `eks-upgrader`
+- `eks-mcp-server`
+
+There is **no custom harness here.** The only new code is the top-level `Makefile`, which encodes the exact invocation patterns for `skill-creator`'s existing scripts. All eval logic lives upstream at `skills/skill-creator/`.
+
+## Per-skill layout
+
+```
+misc/evals/<skill>/
+├── triggering.json   # [{"query": str, "should_trigger": bool}, …]  — for run_eval / run_loop
+├── evals.json        # {skill_name, evals: [{id, prompt, expected_output, expectations?, files?}]} — for grader.md
+├── files/            # fixtures referenced from evals[].files (empty until needed)
+├── workspace/        # gitignored — run_loop / run_eval write results here
+└── README.md         # what the evals target, neighbour-skill disambiguation, live-MCP caveats
+```
+
+## Python dependencies
+
+`skill-creator`'s scripts don't ship a `requirements.txt`. The only third-party import is **PyYAML** (used by `quick_validate.py` and `package_skill.py`). Live-model scripts shell out to `claude -p` rather than using the Anthropic SDK, so the only pip install you need is:
+
+```bash
+pip install pyyaml
+```
+
+## The working-directory quirk
+
+`skills/skill-creator/scripts/__init__.py` exists (it marks `scripts/` as a Python package) and intra-package imports use `from scripts.xxx import yyy`. That forces **module-mode invocation** with cwd set to `skills/skill-creator/`:
+
+```bash
+cd skills/skill-creator
+python3 -m scripts.run_eval --eval-set <path> --skill-path skills/<skill> …
+```
+
+Running `python3 scripts/run_eval.py` directly fails with `ModuleNotFoundError: No module named 'scripts'`.
+
+The `Makefile` in this directory `cd`s to `skills/skill-creator/` before every `-m scripts.<name>` call and passes absolute paths to `--eval-set` / output dirs, so from your shell you can just run `make triggering-<skill>` from `misc/evals/` without thinking about it.
+
+Two exceptions:
+
+- `scripts/quick_validate.py` has no `scripts.` imports — it runs fine as `python3 scripts/quick_validate.py <skill>` (plain script-mode).
+- `eval-viewer/generate_review.py` lives outside the `scripts/` package — invoked directly as `python3 eval-viewer/generate_review.py …`.
+
+## Live-Claude vs deterministic
+
+| Capability | Needs live model? |
+|---|---|
+| A `quick_validate` | deterministic |
+| B `run_eval` | **live** (`claude -p`) |
+| C `improve_description` | **live** |
+| D `run_loop` | **live** |
+| E `aggregate_benchmark` | deterministic |
+| F `generate_report` | deterministic |
+| G `package_skill` | deterministic |
+| H `grader.md` (Task subagent) | **live** |
+| I `comparator.md` (Task subagent) | **live** |
+| J `analyzer.md` (Task subagent) | **live** |
+| K `generate_review --static` | deterministic |
+
+Live tools inherit Claude Code session auth — run them from a terminal that's logged into `claude -p`.
+
+## MCP-dependent skills
+
+`eks-recon` and `eks-mcp-server` are designed around the EKS MCP Server. When running **triggering** evals (B/D), MCP availability is not required — triggering tests the skill's description, not its body, so no EKS tools are invoked. When running **task** evals (H — grader against `evals.json` prompts), some prompts may need mocked fixtures in `files/` or a `live-only` marker if a real cluster is the only way to satisfy the expectation.
+
+Per-skill `README.md` calls out which prompts are safe to run without MCP.
+
+## Capability catalogue (A–K)
+
+All invocations run from `misc/evals/` via the `Makefile` targets shown. The direct command equivalents — the ones the Makefile expands to — are included for reference.
+
+### A — `quick_validate.py` (frontmatter + 64/1024-char limits)
+
+```bash
+make validate-<skill>
+# → python3 <repo>/skills/skill-creator/scripts/quick_validate.py <repo>/skills/<skill>
+```
+
+Output: one-line verdict on stdout. Exit 0 valid / 1 invalid. No disk writes. Plain script-mode — no `cd` needed because `quick_validate.py` doesn't import from the `scripts.` package.
+
+### B — `run_eval.py` (triggering score)
+
+```bash
+make triggering-<skill>  [MODEL=claude-sonnet-4-5] [NUM_WORKERS=10] [RUNS_PER_QUERY=3]
+# → cd <repo>/skills/skill-creator && python3 -m scripts.run_eval \
+#       --eval-set   <repo>/misc/evals/<skill>/triggering.json \
+#       --skill-path <repo>/skills/<skill> \
+#       --num-workers 10 --runs-per-query 3 --model <MODEL>
+```
+
+Output: full results JSON on stdout (redirect to save). Writes nothing to disk itself; creates/deletes ephemeral files under `<repo>/.claude/commands/` during each query.
+
+### C — `improve_description.py` (propose a description rewrite)
+
+Not exposed as a standalone Make target — it's driven by `run_loop`. To invoke manually:
+
+```bash
+cd <repo>/skills/skill-creator
+python3 -m scripts.improve_description \
+  --eval-results <run_eval.json> \
+  --skill-path   <repo>/skills/<skill> \
+  --model        claude-sonnet-4-5
+```
+
+Output: `{"description": "...", "history": [...]}` on stdout.
+
+### D — `run_loop.py` (iterative description optimizer)
+
+```bash
+make optimize-<skill>  [MODEL=…] [MAX_ITER=5] [NUM_WORKERS=10] [RUNS_PER_QUERY=3]
+# → cd <repo>/skills/skill-creator && python3 -m scripts.run_loop \
+#       --eval-set   <repo>/misc/evals/<skill>/triggering.json \
+#       --skill-path <repo>/skills/<skill> \
+#       --model <MODEL> --max-iterations 5 --num-workers 10 --runs-per-query 3 \
+#       --results-dir <repo>/misc/evals/<skill>/workspace \
+#       --report none
+```
+
+Output: final JSON on stdout plus `<workspace>/<TIMESTAMP>/{results.json,report.html,logs/improve_iter_*.json}`. The Makefile passes `--report none` to suppress the auto-opened browser.
+
+### E — `aggregate_benchmark.py` (aggregate grading.json stats across runs)
+
+```bash
+make benchmark-<skill> BENCHMARK_DIR=<path-containing-eval-*/…/grading.json>
+# → cd <repo>/skills/skill-creator && python3 -m scripts.aggregate_benchmark <BENCHMARK_DIR> \
+#       --skill-name <skill> --skill-path <repo>/skills/<skill>
+```
+
+Output: `<BENCHMARK_DIR>/benchmark.json` + `benchmark.md`. Supports both `<dir>/eval-*` and `<dir>/runs/eval-*` layouts (see `skills/skill-creator/scripts/aggregate_benchmark.py`).
+
+`BENCHMARK_DIR` defaults to `<skill>/workspace/` — override when the grading runs live elsewhere.
+
+### F — `generate_report.py` (HTML viz of `run_loop` results.json)
+
+```bash
+make report-<skill>  [RESULTS_JSON=<path>]
+# → cd <repo>/skills/skill-creator && python3 -m scripts.generate_report <RESULTS_JSON> \
+#       --skill-name <skill> -o <repo>/misc/evals/<skill>/workspace/report.html
+```
+
+`RESULTS_JSON` defaults to `<skill>/workspace/results.json`. Standalone HTML file; no server.
+
+### G — `package_skill.py` (zip to `<skill>.skill`)
+
+```bash
+make package-<skill>
+# → cd <repo>/skills/skill-creator && python3 -m scripts.package_skill \
+#       <repo>/skills/<skill> <repo>/misc/evals/<skill>/workspace
+```
+
+Output: `<workspace>/<skill>.skill`. Validates first (imports `quick_validate`); exit 1 on failure. Excludes `__pycache__`, `node_modules`, `*.pyc`, `.DS_Store`, and `evals/` at the skill root.
+
+### H — `agents/grader.md` (subagent grades a run)
+
+No Make target — invoked via the `Task` tool by the agent running the eval. The grader spec expects inputs `expectations[]`, `transcript_path`, `outputs_dir`. Writes `grading.json` to `<run-dir>/grading.json`. Schema: `skills/skill-creator/references/schemas.md` §grading.json.
+
+### I — `agents/comparator.md` (blind A/B compare two variants)
+
+Task invocation; spec at `skills/skill-creator/agents/comparator.md`. Inputs: `output_a_path`, `output_b_path`, `eval_prompt`, optional `expectations`. Writes `comparison-<N>.json`.
+
+### J — `agents/analyzer.md` (post-hoc analysis)
+
+Task invocation; spec at `skills/skill-creator/agents/analyzer.md`. Inputs: winner/loser skill+transcript paths, `comparison_result_path`, `output_path`. Writes `analysis.json` to the specified `output_path`.
+
+### K — `eval-viewer/generate_review.py --static`
+
+```bash
+make review-<skill> WORKSPACE=<dir-from-a-prior-optimize-run>
+# → python3 <repo>/skills/skill-creator/eval-viewer/generate_review.py <WORKSPACE> \
+#       --skill-name <skill> --static <repo>/misc/evals/<skill>/workspace/review.html
+```
+
+Writes a self-contained HTML file. No server, no `webbrowser.open()`.
+
+## Score interpretation cheat sheet
+
+- **Triggering (B/D)**: reported as `passed/total` in `run_eval` output; `run_loop` also reports a train/holdout split (default holdout = 0.4) and per-iteration deltas.
+- **Task evals (H → E)**: `aggregate_benchmark` reports mean ± stddev of pass-rate across runs, plus per-expectation hit rate. `benchmark.md` renders a summary table.
+
+## Workspace hygiene
+
+`misc/evals/.gitignore` excludes `*/workspace/` and `*.html`. Don't commit run artefacts — regenerate them when you need them.
+
+## Useful upstream references
+
+- `skills/skill-creator/SKILL.md` §"Running and evaluating test cases" and §"Description Optimization".
+- `skills/skill-creator/references/schemas.md` — authoritative schemas for `evals.json`, `grading.json`, `benchmark.json`, `comparison.json`, `analysis.json`.
+- `skills/skill-creator/scripts/run_eval.py`, `run_loop.py`, `aggregate_benchmark.py`, `package_skill.py`, `generate_report.py` — canonical source for CLI args.

--- a/misc/evals/_template/README.md
+++ b/misc/evals/_template/README.md
@@ -1,0 +1,27 @@
+# Evals — <REPLACE>
+
+## What these evals target
+
+<REPLACE: 1-3 sentence scope description — which slice of the skill's declared scope these inputs exercise, and what `triggering.json` vs `evals.json` each check.>
+
+## Neighbor-skill disambiguation
+
+<REPLACE: table or bullet-list mapping each negative prompt in `triggering.json` to the sibling skill it targets, plus the key discriminator that keeps this skill from firing on it. Example shape:
+
+- **`sibling-skill-a`** (one-line scope) — negatives N, M ("short quoted near-miss phrase").
+- **`sibling-skill-b`** (one-line scope) — negative K ("short quoted near-miss phrase").
+
+Close with a sentence naming the discriminator that separates this skill from its neighbors.>
+
+## Live-MCP caveat
+
+<REPLACE: note whether the `evals.json` tasks need a live cluster / MCP server, or whether the prompts carry enough context to be answered from fixtures alone. State explicitly whether running these evals requires MCP availability.>
+
+## How to run
+
+From `misc/evals/`:
+- `make validate-<REPLACE>` — frontmatter + 64/1024-char limits
+- `make triggering-<REPLACE>` — triggering accuracy score
+- `make benchmark-<REPLACE>` — aggregate task-eval stats
+
+See `misc/evals/README.md` for the full capability catalogue (A–K).

--- a/misc/evals/_template/evals.json
+++ b/misc/evals/_template/evals.json
@@ -1,0 +1,14 @@
+{
+  "skill_name": "<REPLACE>",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "<REPLACE: realistic task prompt>",
+      "expected_output": "<REPLACE: what a correct response looks like>",
+      "expectations": [
+        "<REPLACE: grader-checkable assertion> — TODO: human review"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/misc/evals/_template/triggering.json
+++ b/misc/evals/_template/triggering.json
@@ -1,0 +1,4 @@
+[
+  { "query": "<REPLACE: positive prompt that should trigger this skill>", "should_trigger": true },
+  { "query": "<REPLACE: near-miss negative prompt that should NOT trigger this skill>", "should_trigger": false }
+]

--- a/misc/evals/eks-best-practices/README.md
+++ b/misc/evals/eks-best-practices/README.md
@@ -1,0 +1,24 @@
+# `eks-best-practices` evals
+
+## What these evals target
+
+These inputs exercise the `eks-best-practices` skill's declared scope: EKS architecture, design, and configuration judgement calls — compute strategy (Karpenter / MNG / Fargate / Auto Mode), multi-tenant isolation, VPC/IP planning, ingress, IAM (Pod Identity / IRSA), reliability primitives (PDBs, probes, topology spread), upgrade strategy *choice* (in-place vs blue-green), cost levers, and "is this reasonable?" sanity reviews. `triggering.json` checks that the skill fires on realistic architecture prompts and stays quiet for neighbour-skill and non-EKS prompts; `evals.json` checks the quality of two representative advisory answers.
+
+## Neighbour-skill disambiguation
+
+The 8 negative prompts in `triggering.json` (entries 9–16, 0-indexed 8–15) are deliberate near-misses targeting sibling skills:
+
+- **`eks-recon`** (discovery / "what's currently running" / pre-upgrade inventory) — negatives 9, 10, 11 ("what version am I running", "inventory what's in my EKS cluster", "snapshot of everything running").
+- **`eks-upgrader`** (actually executing an upgrade, step-by-step procedures, debugging a specific add-on upgrade failure) — negatives 12, 13 ("exact steps to upgrade control plane 1.29 → 1.30", "Karpenter v0.37 → 1.0 webhook error").
+- **`eks-mcp-server`** (installing / wiring up the MCP server itself) — negative 14 ("install the EKS MCP server and wire it up to Claude Code").
+- **Generic / non-EKS** (no architectural judgement about EKS) — negatives 15, 16 (pure Kubernetes concepts: Deployment vs StatefulSet; non-EKS managed-K8s: AKS vs GKE).
+
+The key discriminators for `eks-best-practices`: the prompt asks for a *decision*, *recommendation*, *tradeoff*, or *sanity check* about an EKS design surface — not a discovery scan, not an executable upgrade runbook, and not MCP tooling setup.
+
+## Live-MCP caveat
+
+`evals.json` prompts are intentionally advisory and scenario-described — both evals give the model enough context in the prompt text that it can produce a quality answer without reaching into a live EKS cluster via MCP tools. Running these evals does **not** require a live cluster or the EKS MCP server to be configured. Triggering evals (`triggering.json`) are matched against the skill's `description` frontmatter only and are never affected by MCP availability.
+
+## How to run
+
+See `/workspace/sample-apex-skills/misc/evals/README.md` for the full workflow, and the top-level `Makefile` targets (`make trigger-eks-best-practices`, `make eval-eks-best-practices`) for the exact invocations.

--- a/misc/evals/eks-best-practices/evals.json
+++ b/misc/evals/eks-best-practices/evals.json
@@ -1,0 +1,31 @@
+{
+  "skill_name": "eks-best-practices",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We run ~40 microservices across 3 product teams on EC2 today and we're moving to EKS. Traffic is spiky, teams want autonomy, and we expect the service count to double in 12 months. Should we run one shared EKS cluster or split per team, and what compute model (Karpenter, MNG, Fargate, Auto Mode) should we default to? Explain the tradeoffs.",
+      "expected_output": "A recommendation that favors a shared multi-tenant cluster with per-team namespace isolation (RBAC, NetworkPolicy, ResourceQuota) unless a concrete isolation driver argues otherwise, and recommends Karpenter (or EKS Auto Mode for minimal ops) as the default data plane given the spiky, varied workload mix. Should cover tradeoffs and call out system components on a stable MNG.",
+      "expectations": [
+        "The output recommends a shared multi-tenant EKS cluster as the default over per-team clusters for this scale, with per-team namespace isolation (at least two of: RBAC, NetworkPolicy, ResourceQuota) called out explicitly. TODO: human review",
+        "The output recommends Karpenter (or EKS Auto Mode) as the default compute model over pure MNG or Fargate, citing at least one concrete reason such as consolidation, instance flexibility, or faster scale-up for spiky traffic. TODO: human review",
+        "The output recommends running system/platform components (e.g. CoreDNS, Karpenter controller, ingress controller) on a stable managed node group or Fargate rather than on Karpenter-managed workload nodes. TODO: human review",
+        "The output names at least one concrete trigger that would justify splitting into multiple clusters (e.g. strict compliance/data-residency boundary, blast-radius isolation for a critical workload, or drastically different upgrade cadences). TODO: human review",
+        "The output mentions a path for tenant autonomy that is not cluster-per-team (e.g. namespace-as-a-service, GitOps per-team app-of-apps, or platform abstractions) so teams can move fast on a shared cluster. TODO: human review"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Review this EKS setup for production readiness. We have a single managed node group of 2 m5.large on-demand nodes in one AZ, no Pod Disruption Budgets defined, no ingress controller installed yet (we're hitting pods via NodePort), and application IAM permissions are attached directly to the node IAM role. What should we fix, in priority order?",
+      "expected_output": "A prioritized review flagging the single-AZ node group as the top reliability risk, missing PDBs as a disruption/upgrade hazard, NodePort as an ingress anti-pattern (recommend AWS Load Balancer Controller with ALB/NLB or Gateway API), and node-role IAM as a security anti-pattern (recommend Pod Identity or IRSA). Should suggest multi-AZ spread and topology spread constraints.",
+      "expectations": [
+        "The output identifies the single-AZ / two-node configuration as a high-priority reliability issue and recommends spreading nodes across at least 3 AZs (or 2 at minimum) with topology spread constraints or equivalent. TODO: human review",
+        "The output recommends adding Pod Disruption Budgets for production workloads with more than one replica, with at least one concrete example target (e.g. minAvailable 50% for stateless, maxUnavailable 1 for stateful quorum). TODO: human review",
+        "The output flags NodePort as inappropriate for production ingress and recommends the AWS Load Balancer Controller with ALB or NLB (or Gateway API) as the replacement. TODO: human review",
+        "The output flags attaching application IAM permissions to the node role as a security anti-pattern and recommends migrating to EKS Pod Identity (preferred) or IRSA per workload. TODO: human review",
+        "The output presents the fixes in a prioritized order (e.g. reliability first, then security, then ingress) rather than as an unordered list. TODO: human review"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/misc/evals/eks-best-practices/triggering.json
+++ b/misc/evals/eks-best-practices/triggering.json
@@ -1,0 +1,19 @@
+[
+  {"query": "We're standing up a new EKS cluster for a growing platform team. Should we default to Karpenter, managed node groups, or EKS Auto Mode for the data plane?", "should_trigger": true},
+  {"query": "Three product teams want to share one EKS cluster. What's the right approach for tenant isolation across namespaces, node pools, and network policies?", "should_trigger": true},
+  {"query": "Our VPC is running short on IPs and we expect 50+ pods per node. How should we plan subnets and VPC CNI mode for a new EKS cluster?", "should_trigger": true},
+  {"query": "For a new EKS workload that needs AWS permissions, should we use IRSA or EKS Pod Identity? Any reason to still pick IRSA for new stuff?", "should_trigger": true},
+  {"query": "We're about to roll out our first production services on EKS. What PDBs, probes, and topology spread settings should we put in place for reliability?", "should_trigger": true},
+  {"query": "We have a critical production EKS cluster and an upgrade coming up. Should we do in-place or blue-green? How do we decide?", "should_trigger": true},
+  {"query": "EKS bill is creeping up. What are the highest-leverage cost levers — Graviton, Spot, Karpenter consolidation — and in what order?", "should_trigger": true},
+  {"query": "Here's our node group setup: 2 m5.large on-demand nodes in one AZ, no PDBs, no ingress controller yet. Is this reasonable for prod?", "should_trigger": true},
+
+  {"query": "What version of Kubernetes is my EKS cluster currently running, and which add-ons are installed?", "should_trigger": false},
+  {"query": "Can you inventory what's in my EKS cluster right now — node groups, Karpenter, ingress, CI/CD tooling — before I plan an upgrade?", "should_trigger": false},
+  {"query": "I need a snapshot of everything running in the cluster: workloads, namespaces, IAM associations. Discovery only, no recommendations yet.", "should_trigger": false},
+  {"query": "Walk me through the exact steps to upgrade my EKS control plane from 1.29 to 1.30 in place, including the aws CLI commands.", "should_trigger": false},
+  {"query": "My Karpenter upgrade from v0.37 to 1.0 is failing with a webhook error during the CRD migration. How do I fix it?", "should_trigger": false},
+  {"query": "How do I install the EKS MCP server and wire it up to Claude Code so I can query live clusters?", "should_trigger": false},
+  {"query": "What's the difference between a Kubernetes Deployment and a StatefulSet, and when would I use each?", "should_trigger": false},
+  {"query": "We're evaluating AKS vs GKE for a new workload. Which managed Kubernetes service has better node autoscaling out of the box?", "should_trigger": false}
+]

--- a/misc/evals/eks-mcp-server/README.md
+++ b/misc/evals/eks-mcp-server/README.md
@@ -1,0 +1,20 @@
+# eks-mcp-server evals
+
+## What these evals target
+
+These artifacts exercise the `eks-mcp-server` skill, which is **meta**: it is about installing, configuring, and troubleshooting the EKS MCP Server itself (the bridge that lets an AI assistant reach a live EKS cluster). `triggering.json` checks that Claude activates this skill for setup / config / auth-failure prompts and stays away from requests that merely **use** the MCP tools to do cluster work. `evals.json` checks that, once activated, Claude produces correct setup and IAM-troubleshooting guidance. Explicit contrast: this skill is **not** about using MCP tools to inspect, upgrade, or architect a cluster — those tasks belong to `eks-recon`, `eks-upgrader`, and `eks-best-practices` respectively.
+
+## Neighbour-skill disambiguation
+
+- **eks-recon (most important edge — the recon-boundary):** "inventory my cluster", "what version am I running", "list my node groups", "check IMDSv2" all *use* the MCP tools and route to `eks-recon`. Only "configure the MCP server so Claude can see my cluster" (or "tools aren't appearing", "AccessDenied on eks-mcp:InvokeMcp", "where does mcp.json go") routes here. This boundary is the highest overmapping risk and negative cases 1–4 in `triggering.json` enforce it.
+- **eks-upgrader:** Actually performing an EKS version upgrade or an add-on upgrade (Karpenter, Istio, CoreDNS) is upgrader territory. The MCP server is a *tool used during* the upgrade, not the subject. Negatives 5–6 enforce this.
+- **eks-best-practices:** Architecture and design decisions ("should we use Karpenter or Auto Mode", multi-tenant platform design) are best-practices territory. Negative 7 enforces this.
+- **Generic MCP / unrelated:** "How do I build my own MCP server in Python" is about MCP-the-protocol, not the EKS MCP Server — it should not trigger this skill. Negative 8 enforces this.
+
+## Live-MCP caveat
+
+The two eval prompts in `evals.json` are about **talking about** the EKS MCP Server — explaining how to install it and diagnosing IAM errors when calling it. Answering them requires no live MCP tools and no real EKS cluster; the model should respond from the skill's reference docs. Triggering evals are pure classification and are never affected by MCP availability either.
+
+## How to run
+
+See `misc/evals/README.md` for the full harness description and the Makefile targets (`make eval-triggering SKILL=eks-mcp-server`, `make eval-tasks SKILL=eks-mcp-server`).

--- a/misc/evals/eks-mcp-server/evals.json
+++ b/misc/evals/eks-mcp-server/evals.json
@@ -1,0 +1,30 @@
+{
+  "skill_name": "eks-mcp-server",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Walk me through installing the self-hosted EKS MCP Server for Claude Code on my laptop. I'm on macOS, my AWS profile is `dev-admin`, and I only want read access for now — no write or sensitive-data tools. Where does the config file go and what exactly should it contain?",
+      "expected_output": "A step-by-step setup that covers prerequisites (Python 3.10+, uv/uvx), the Claude Code config file path (.mcp.json project-scope or ~/.claude/mcp.json user-scope), a concrete mcpServers JSON block invoking uvx awslabs.eks-mcp-server@latest with AWS_PROFILE=dev-admin, explicit omission of --allow-write and --allow-sensitive-data-access for read-only mode, and the restart-then-verify step.",
+      "expectations": [
+        "The output states the Claude Code MCP config lives at `.mcp.json` (project scope) or `~/.claude/mcp.json` (user scope). TODO: human review",
+        "The output provides a concrete JSON block under `mcpServers.awslabs.eks-mcp-server` that invokes `uvx` with `awslabs.eks-mcp-server@latest` and sets `AWS_PROFILE` to `dev-admin`. TODO: human review",
+        "The output explicitly omits `--allow-write` and `--allow-sensitive-data-access` from the args array (or equivalently tells the user to leave them out) to satisfy the read-only requirement. TODO: human review",
+        "The output mentions prerequisites: Python 3.10+ and the `uv`/`uvx` package manager (installable via the astral.sh/uv script). TODO: human review",
+        "The output tells the user to restart Claude Code after editing the config and verify by asking to list EKS clusters or available MCP tools. TODO: human review"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "I set up the AWS-hosted EKS MCP Server (mcp-proxy-for-aws) in my Amazon Q CLI config, but every tool call fails with `AccessDenied: User is not authorized to perform eks-mcp:InvokeMcp`. The tools show up in the list but none of them work. What's wrong and how do I fix it?",
+      "expected_output": "A diagnosis that this is an IAM permissions problem on the caller principal, not an MCP config bug — the AWS-hosted proxy requires specific eks-mcp:* actions (InvokeMcp for discovery, CallReadOnlyTool for reads, CallPrivilegedTool for writes). The fix is to attach the AmazonEKSMCPReadOnlyAccess managed policy (or a custom policy granting those actions) to the IAM user/role and retry.",
+      "expectations": [
+        "The output identifies the root cause as missing IAM permissions on the caller principal for the `eks-mcp:*` action family, not a client-config bug. TODO: human review",
+        "The output names the `AmazonEKSMCPReadOnlyAccess` AWS managed policy as the standard read-only fix and/or lists the required actions `eks-mcp:InvokeMcp`, `eks-mcp:CallReadOnlyTool`, and `eks-mcp:CallPrivilegedTool`. TODO: human review",
+        "The output gives a concrete remediation step such as `aws iam attach-user-policy` (or attach-role-policy) using the `AmazonEKSMCPReadOnlyAccess` policy ARN. TODO: human review",
+        "The output notes that `CallPrivilegedTool` is only required if the user needs write operations, so read-only access is sufficient to unblock tool calls. TODO: human review"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/misc/evals/eks-mcp-server/triggering.json
+++ b/misc/evals/eks-mcp-server/triggering.json
@@ -1,0 +1,19 @@
+[
+  {"query": "I want to connect Claude Code to my EKS clusters. Should I use the self-hosted EKS MCP Server or the AWS-hosted one?", "should_trigger": true},
+  {"query": "Walk me through installing the awslabs eks-mcp-server locally with uvx and an AWS profile.", "should_trigger": true},
+  {"query": "What IAM policy do I need to attach to run the self-hosted EKS MCP Server in IAM mode?", "should_trigger": true},
+  {"query": "I added the eks-mcp config to my mcp.json but when I restart Claude Code no EKS tools show up. What's wrong?", "should_trigger": true},
+  {"query": "Where does the mcp.json file live for Amazon Q CLI vs Claude Code vs Cursor? I want the EKS MCP server available in all of them.", "should_trigger": true},
+  {"query": "My EKS MCP Server keeps failing with an AccessDenied on eks-mcp:InvokeMcp. How do I fix this?", "should_trigger": true},
+  {"query": "Should I put the EKS MCP server config in project-scope .mcp.json or user-scope ~/.claude/mcp.json?", "should_trigger": true},
+  {"query": "How do I configure the self-hosted EKS MCP Server in kubeconfig mode so I don't need AWS IAM credentials?", "should_trigger": true},
+
+  {"query": "List all the node groups and Karpenter NodePools in my prod-use1 cluster and tell me what instance families they use.", "should_trigger": false},
+  {"query": "What version is my EKS cluster on and which add-ons are installed?", "should_trigger": false},
+  {"query": "Do a full inventory of my EKS cluster — compute, networking, add-ons, observability — I need context before an upgrade.", "should_trigger": false},
+  {"query": "Check whether my clusters are using IMDSv2 and report any nodes still on v1.", "should_trigger": false},
+  {"query": "Upgrade my EKS cluster from 1.29 to 1.30 — walk me through the in-place procedure.", "should_trigger": false},
+  {"query": "My Karpenter 0.37 install needs to move to 1.x before the EKS 1.31 upgrade. How do I do that?", "should_trigger": false},
+  {"query": "We're building a new multi-tenant EKS platform. Should we use Karpenter, managed node groups, or Auto Mode for the tenant workloads?", "should_trigger": false},
+  {"query": "How do I write my own MCP server in Python using the official SDK? I want to expose an internal API as tools.", "should_trigger": false}
+]

--- a/misc/evals/eks-recon/README.md
+++ b/misc/evals/eks-recon/README.md
@@ -1,0 +1,27 @@
+# `eks-recon` evals
+
+## What these evals target
+
+These artifacts exercise the `eks-recon` skill, whose job is read-only discovery of an existing EKS cluster: current version, compute strategy (Karpenter / MNG / Auto Mode / Fargate), IaC tooling, CI/CD pipelines, add-on inventory, networking, security posture, and observability. `triggering.json` checks that the skill fires on realistic recon phrasings and does NOT fire on near-miss requests that belong to its sibling skills. `evals.json` sketches two end-to-end recon tasks (upgrade-prep context and a team handoff) that a good recon response must cover.
+
+## Neighbour-skill disambiguation
+
+- **`eks-best-practices`** — owns architectural / design judgement calls ("should we use X or Y", tenant isolation, ingress placement). Negatives at items 9–11 (`should_trigger: false`) are phrased as design questions and must route there, not to recon.
+- **`eks-upgrader`** — owns executing upgrades and component-specific upgrade procedures (in-place, blue-green, Karpenter bumps). Negatives at items 12–14 ask for step-by-step upgrade runbooks and belong to the upgrader, not recon. Note: item 2 in the positives ("about to upgrade, give me context first") IS recon because it asks for pre-upgrade discovery rather than upgrade execution.
+- **`eks-mcp-server`** — owns setup/configuration of the EKS MCP server itself. Item 15 asks how to install the MCP server locally, which is a meta-tooling question, not a cluster recon request.
+
+Item 16 is a pure Kubernetes-internals question with no EKS hook — a sanity negative.
+
+## Live-MCP caveat
+
+The two prompts in `evals.json` describe realistic recon tasks against named clusters (`payments-prod`, `data-platform-staging`). Running them end-to-end expects EKS MCP tooling (or AWS CLI + kubectl fallback) pointed at real clusters, and `files: []` is intentional — no static fixtures have been authored yet. Running the grader against a live model without MCP access will produce shallow answers; a follow-up pass should either stage fixture YAML under `files/` or flag these as MCP-required in the eval harness.
+
+The `triggering.json` evals (run via `run_eval` / `run_loop`) are unaffected — they test description-fit only and never invoke EKS tooling.
+
+## How to run
+
+See `misc/evals/README.md` for the full invocation surface. From `misc/evals/` the relevant Makefile targets are:
+
+```bash
+make validate-eks-recon triggering-eks-recon optimize-eks-recon
+```

--- a/misc/evals/eks-recon/evals.json
+++ b/misc/evals/eks-recon/evals.json
@@ -1,0 +1,30 @@
+{
+  "skill_name": "eks-recon",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I'm about to upgrade cluster `payments-prod` in us-east-1 from 1.29 to 1.30. Before I start, run full reconnaissance on that cluster and give me a complete picture — current version, compute strategy, add-on inventory, and anything else that would matter for an upgrade.",
+      "expected_output": "A structured reconnaissance report for cluster payments-prod covering cluster-basics (name, region, version, platform version), compute strategy, EKS-managed add-ons with versions, and IaC tool — with upgrade-relevant observations surfaced.",
+      "expectations": [
+        "The output reports the current cluster version and platform version for payments-prod. TODO: human review",
+        "The output identifies whether Karpenter, managed node groups, Auto Mode, or Fargate is the primary compute strategy. TODO: human review",
+        "The output lists EKS-managed add-ons with their installed versions (e.g. vpc-cni, coredns, kube-proxy). TODO: human review",
+        "The output identifies the IaC tool managing the cluster (Terraform, CloudFormation, CDK, eksctl, or unknown with reasoning). TODO: human review",
+        "The output calls out at least one upgrade-relevant finding (e.g. add-on version compatibility, Karpenter version, deprecated API usage). TODO: human review"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "A new platform engineer is taking over cluster `data-platform-staging` in us-west-2 next week. Document the compute layout, IaC setup, and CI/CD pipelines so I can hand it off cleanly.",
+      "expected_output": "A handoff-oriented report for data-platform-staging that focuses on compute (nodepools / node groups / Fargate profiles), IaC provenance, and CI/CD — both workspace pipelines (GitHub Actions, GitLab CI, Jenkins) and GitOps (ArgoCD, Flux).",
+      "expectations": [
+        "The output describes the compute topology of data-platform-staging (node groups, Karpenter nodepools, or Fargate profiles as applicable). TODO: human review",
+        "The output identifies the IaC tool and, where possible, evidence (workspace files, stack names, module references). TODO: human review",
+        "The output reports on workspace CI pipelines (GitHub Actions / GitLab CI / Jenkins) with detection evidence. TODO: human review",
+        "The output reports on GitOps tooling (ArgoCD or Flux) including namespace and rough application / kustomization counts when available. TODO: human review"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/misc/evals/eks-recon/triggering.json
+++ b/misc/evals/eks-recon/triggering.json
@@ -1,0 +1,22 @@
+[
+  {"query": "What version is my EKS cluster prod-use1 running right now?", "should_trigger": true},
+  {"query": "I'm about to upgrade cluster foo from 1.29 to 1.30 — can you pull together everything you know about it first so I have context?", "should_trigger": true},
+  {"query": "Take a look at my EKS cluster `payments-prod` in us-east-1 and tell me what's going on in there.", "should_trigger": true},
+  {"query": "Am I using Karpenter or managed node groups on the platform cluster?", "should_trigger": true},
+  {"query": "How is cluster bar-staging managed? Is it Terraform, CDK, eksctl, something else?", "should_trigger": true},
+  {"query": "Give me an inventory of every EKS add-on and Helm release installed on cluster apex-prod.", "should_trigger": true},
+  {"query": "Document the networking and security posture of our dev cluster for the new platform engineer starting Monday.", "should_trigger": true},
+  {"query": "Before I touch anything, walk me through what's deployed in the cluster and how CI/CD gets things there.", "should_trigger": true},
+
+  {"query": "We're designing a new EKS cluster from scratch — should we go with Karpenter or Auto Mode for the compute layer?", "should_trigger": false},
+  {"query": "What's the recommended way to do tenant isolation on a shared EKS platform — separate node pools, namespaces, network policies?", "should_trigger": false},
+  {"query": "Is it a better practice to run my ingress controller on Fargate or on Karpenter-managed nodes?", "should_trigger": false},
+
+  {"query": "Execute the in-place upgrade of cluster prod-use1 from 1.29 to 1.30 and walk me through each step.", "should_trigger": false},
+  {"query": "Give me the exact procedure to upgrade Karpenter from 0.37 to 1.0 on an EKS cluster.", "should_trigger": false},
+  {"query": "I need the blue-green upgrade runbook for moving a production EKS cluster two minor versions forward.", "should_trigger": false},
+
+  {"query": "How do I install and configure the EKS MCP server locally so Claude can reach my clusters?", "should_trigger": false},
+
+  {"query": "Explain how Kubernetes StatefulSet rolling updates work at the controller level.", "should_trigger": false}
+]

--- a/misc/evals/eks-upgrader/README.md
+++ b/misc/evals/eks-upgrader/README.md
@@ -1,0 +1,20 @@
+# eks-upgrader evals
+
+## What these evals target
+
+These evals exercise the `eks-upgrader` skill's declared scope: **executing** EKS version upgrades and producing **component-specific procedures** for Karpenter, Istio, CoreDNS, kube-proxy, VPC CNI, ingress controllers, and cluster-autoscaler — plus the in-place and blue-green procedural playbooks, add-on compatibility matrices, version end-of-support handling, and debugging of a stuck upgrade. `triggering.json` covers the decision "should this skill fire?" with near-miss negatives drawn from the three sibling skills; `evals.json` covers "when it fires, does it produce a real, sequenced, component-aware upgrade plan?". Strategy *choice* ("in-place vs blue-green, which should we pick?") is deliberately routed to `eks-best-practices` and appears only as negatives here.
+
+## Neighbour-skill disambiguation
+
+- **eks-recon** (discovery / "what do we have?"): negatives 9–11 in `triggering.json` — inherited-cluster inventory, environment discovery pass, pre-planning "tell me what's deployed". **This is the single most important boundary for `eks-upgrader`**: many users plan upgrades by first asking what they're running, and the skill must *not* fire on discovery intent. The rule: if the user hasn't yet committed to an upgrade action or compatibility question, it's recon.
+- **eks-best-practices** (strategy / architecture): negatives 12–14 — in-place-vs-blue-green decision, 2x-cost worth-it question, platform redesign where upgrades are a theme but not the task. **This is the second most important boundary**: `eks-upgrader` owns the *procedure* for a chosen strategy; `eks-best-practices` owns the *choice between* strategies and upgrade-friendly architecture. The rule: if the user is still deciding, it's best-practices; if they've decided and want steps, it's upgrader.
+- **eks-mcp-server** (tooling setup): negative 15 — configuring the MCP server itself so the assistant can talk to a live cluster. Not an upgrade task.
+- **Unrelated / non-EKS**: negative 16 — vanilla self-managed Kubernetes upgrade on bare metal. EKS-specific procedure is the skill's remit; generic k8s upgrades aren't.
+
+## Live-MCP caveat
+
+`eks-upgrader`'s eval prompts are intentionally advisory and documentary — both task-eval prompts are answerable from the skill's references without touching a real cluster, and no live MCP tools are required to grade them. In principle a production upgrade *would* involve live cluster inspection (Cluster Insights, deprecated-API audit-log queries, add-on versions), but we keep the eval prompts MCP-free so results are reproducible across environments that lack MCP access. Triggering evals are pure classification and are never affected by MCP availability.
+
+## How to run
+
+See `/workspace/sample-apex-skills/misc/evals/README.md` for the eval harness and the relevant `Makefile` targets (`make triggering` and `make evals`, typically scoped by skill name).

--- a/misc/evals/eks-upgrader/evals.json
+++ b/misc/evals/eks-upgrader/evals.json
@@ -1,0 +1,30 @@
+{
+  "skill_name": "eks-upgrader",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Walk me through upgrading a production EKS cluster from 1.29 to 1.30. We use Karpenter 0.37 for compute and have Istio 1.20 installed via Helm. Give me a concrete procedure, not generic advice.",
+      "expected_output": "A sequenced in-place upgrade plan covering pre-flight checks (Cluster Insights, subnet IPs, deprecated APIs), control-plane upgrade, add-on compatibility (CoreDNS, kube-proxy, VPC CNI) pinned to 1.30, Karpenter controller + CRD upgrade via the karpenter-crd chart, Istio canary/revision-tag upgrade, and data-plane (Karpenter-managed) node rotation — with explicit mention of non-prod-first and irreversibility of the control-plane step.",
+      "expectations": [
+        "The output enumerates pre-flight checks including Cluster Insights, subnet IP capacity, and a deprecated-API scan (Pluto, kubent, or apiserver_requested_deprecated_apis metric) before touching the control plane. TODO: human review",
+        "The output specifies the correct upgrade order: control plane -> core add-ons (CoreDNS, kube-proxy, VPC CNI) -> Karpenter and Istio -> data-plane node rotation, and notes the control-plane upgrade is irreversible. TODO: human review",
+        "The output addresses Karpenter CRDs specifically — stating the bundled Helm chart does not auto-upgrade CRDs and that the independent karpenter-crd chart must be applied alongside the controller. TODO: human review",
+        "The output gives an Istio-specific upgrade approach (canary/in-place via revision tags, sidecar rollout) rather than a generic 'helm upgrade' one-liner. TODO: human review",
+        "The output recommends non-prod first and includes at least one rollback or validation checkpoint (e.g. verifying node health, PDB behaviour, or add-on readiness) between steps. TODO: human review"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "We're on Karpenter 0.37 and need to upgrade to Karpenter 1.x. What breaks, and what's the migration procedure?",
+      "expected_output": "A Karpenter 0.37 -> 1.x migration plan citing the official migration guide, identifying concrete API/CRD/behaviour changes, describing CRD upgrade via the karpenter-crd chart, and noting disruption-budget and drift-replacement considerations plus how Karpenter's own hosting (Fargate vs MNG) affects the upgrade.",
+      "expectations": [
+        "The output references the Karpenter 1.x migration guide or identifies at least 2 concrete behaviour or API changes between 0.37 and 1.x (e.g. NodePool/NodeClaim API stability, removed v1beta1 fields, disruption controls). TODO: human review",
+        "The output explicitly calls out that Karpenter CRDs must be upgraded alongside the controller using the independent karpenter-crd Helm chart, not the bundled one. TODO: human review",
+        "The output warns about percentage-based disruption budgets blocking node replacement (e.g. 10% of 1 node = 0) and suggests how to handle it. TODO: human review",
+        "The output distinguishes Karpenter-on-Fargate vs Karpenter-on-MNG hosting and gives the correct refresh step for each (kubectl rollout restart vs node-group rotation). TODO: human review"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/misc/evals/eks-upgrader/triggering.json
+++ b/misc/evals/eks-upgrader/triggering.json
@@ -1,0 +1,19 @@
+[
+  {"query": "Walk me through upgrading my EKS cluster from 1.29 to 1.30. What's the procedure?", "should_trigger": true},
+  {"query": "We're on Karpenter 0.37 and I need to move to Karpenter 1.x before our next EKS upgrade. What are the breaking changes and how do I do the migration?", "should_trigger": true},
+  {"query": "Is CoreDNS 1.11.3 compatible with EKS 1.31? And what about kube-proxy and the VPC CNI add-on versions I should target?", "should_trigger": true},
+  {"query": "Give me the step-by-step blue-green cluster migration procedure for EKS. We need to move workloads from a 1.27 cluster to a fresh 1.31 one.", "should_trigger": true},
+  {"query": "My EKS control plane upgrade from 1.28 to 1.29 is stuck in UPDATING for 45 minutes. How do I debug this?", "should_trigger": true},
+  {"query": "We still have workloads using PodDisruptionBudget policy/v1beta1 and flowcontrol v1beta2. What EKS version removes those and how do I assess the blast radius before upgrading?", "should_trigger": true},
+  {"query": "Our Istio control plane is on 1.20 installed via Helm. We want to upgrade EKS to 1.31 — what's the recommended Istio upgrade sequence, including revision tags and sidecar rollout?", "should_trigger": true},
+  {"query": "EKS 1.27 goes into extended support next month. Walk me through the upgrade path to get to a supported version, including cluster-autoscaler and ingress-nginx compatibility along the way.", "should_trigger": true},
+
+  {"query": "What version of EKS am I running and which add-ons do we have installed? I just inherited this cluster.", "should_trigger": false},
+  {"query": "Can you do a discovery pass on our EKS environment — compute strategy, IaC tool, CI/CD setup — so we know what we're working with?", "should_trigger": false},
+  {"query": "Before we plan anything, tell me what's deployed in the cluster: node groups, Karpenter NodePools, ingress controllers, observability stack.", "should_trigger": false},
+  {"query": "We're debating in-place vs blue-green for our EKS upgrade strategy. Given we're a regulated fintech with tight rollback requirements, which approach should we choose?", "should_trigger": false},
+  {"query": "Is blue-green cluster migration worth the 2x cost for us? We run mostly stateless services on Karpenter.", "should_trigger": false},
+  {"query": "We're redesigning our EKS platform for multi-tenancy and upgrades come up a lot — what's the right architecture to make upgrades less painful long-term?", "should_trigger": false},
+  {"query": "How do I install and configure the EKS MCP server so my AI assistant can actually talk to my cluster?", "should_trigger": false},
+  {"query": "What's the upgrade procedure for a self-managed vanilla Kubernetes cluster running on bare metal from 1.28 to 1.30?", "should_trigger": false}
+]

--- a/skills/README.md
+++ b/skills/README.md
@@ -200,4 +200,8 @@ This simple format has some key advantages:
 * [Read authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) for writing effective skills.
 * [Use the reference library](https://github.com/agentskills/agentskills/tree/main/skills-ref) to validate skills and generate prompt XML.
 
+### Evaluating skills
+
+Every in-repo skill has a matching evaluation entry under [`misc/evals/`](../misc/evals/) — a `triggering.json` for trigger-accuracy tests and an `evals.json` for end-to-end task-usefulness tests, both runnable via the tooling in [`skills/skill-creator/`](./skill-creator/). See [`misc/evals/README.md`](../misc/evals/README.md) for the capability catalogue and how to run each eval type.
+
 ---


### PR DESCRIPTION
## Summary

Scaffolds `misc/evals/` — a per-skill evaluation home that drives `skills/skill-creator/`'s existing eval machinery for the four in-scope EKS skills:

- `eks-recon`
- `eks-best-practices`
- `eks-upgrader`
- `eks-mcp-server`

No custom harness; the only new code is the top-level `Makefile` that encodes the exact invocation patterns for `skill-creator`'s scripts (cwd + module-mode + absolute paths).

Per-skill artefacts (×4 skills):
- `triggering.json` — 16 prompts (8 positive, 8 near-miss negative targeting sibling-skill boundaries) for `run_eval` / `run_loop`.
- `evals.json` — 2 realistic task prompts each with specific assertions tagged `TODO: human review` for hand-tuning during M2.8.
- `files/` — empty; populate as fixtures are needed.
- `README.md` — what the evals target, neighbour-skill disambiguation mapping, and live-MCP caveats.

Top-level:
- `README.md` — documents all 11 capabilities (A–K) with exact invocation and output, working-directory quirk (`scripts/` is a package → module-mode required), live-vs-deterministic split, MCP-dependent caveats, score interpretation.
- `Makefile` — static-pattern rules for `validate-<skill>`, `triggering-<skill>`, `optimize-<skill>`, `benchmark-<skill>`, `report-<skill>`, `package-<skill>`, `review-<skill>` plus `validate-all` / `triggering-all` meta-targets.
- `.gitignore` — excludes `workspace/` and `*.html` so eval run artefacts never land in git.

This is infrastructure for M2.8 (per-skill evaluation + fixes). It ships independently of any skill-content changes.

## Test plan

- [x] `make validate-all` exits 0 for all 4 skills
- [x] `make -n <target>-<skill>` expands to well-formed commands for every per-skill target
- [x] Each `triggering.json` is exactly 16 prompts with an 8/8 positive/negative split
- [x] Each `evals.json` parses against `skills/skill-creator/references/schemas.md` §evals.json with unique `id`s
- [x] Every assertion in every `evals.json` ends with `TODO: human review` (grep count matches total assertion count)
- [ ] First live `triggering-<skill>` run from a separate environment (scheduled for M2.8)