### PR TITLE
chore(evals): phase 3.99 — small fixes before PLAN.md removal

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -14,7 +14,11 @@ on:
   pull_request:
     paths:
       - "skills/**"
-      - "misc/evals/**"
+      - "steering/**"
+      - "examples/**"
+      - "misc/**"
+      - "README.md"
+      - "CONTRIBUTING.md"
       - ".github/workflows/evals.yml"
   push:
     branches:
@@ -52,3 +56,11 @@ jobs:
         run: pip install pyyaml
       - name: Hygiene pre-flight (no model, no cluster)
         run: make -C misc/evals hygiene
+
+  docs-sync:
+    name: docs auto-gen blocks are in sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Regenerate and fail on diff
+        run: ./misc/update-all-references.sh --check

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -42,6 +42,29 @@ jobs:
         run: pip install pyyaml
       - name: Check every skill has a misc/evals/ entry
         run: make -C misc/evals check-evals-coverage
+      - name: How to fix (shown on failure)
+        if: failure()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## Evals coverage failed
+
+          A skill under `skills/` has no matching `misc/evals/<name>/` directory.
+
+          **Fix — recommended (walks the full onboarding workflow):**
+          ```
+          /apex:new-skill
+          ```
+
+          **Fix — manual:**
+          ```bash
+          cd misc/evals
+          make init-evals SKILL=<name> [SIBLINGS="a,b,c"]
+          # edit triggering.json, evals.json, README.md
+          make init-evals-finalize SKILL=<name>
+          ```
+
+          Full details: [`misc/evals/README.md` → Adding evals for a new skill](../blob/${{ github.head_ref || github.ref_name }}/misc/evals/README.md#adding-evals-for-a-new-skill).
+          EOF
 
   hygiene:
     name: evals hygiene
@@ -56,6 +79,26 @@ jobs:
         run: pip install pyyaml
       - name: Hygiene pre-flight (no model, no cluster)
         run: make -C misc/evals hygiene
+      - name: How to fix (shown on failure)
+        if: failure()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## Evals hygiene failed
+
+          At least one `misc/evals/<skill>/` entry failed the pre-flight checks (frontmatter, positives/negatives count, SIBLING_MAP attribution, `evals.json` prompt/expectation count, …). The specific warnings are in the job log above.
+
+          **Fix — single skill:**
+          ```bash
+          make -C misc/evals init-evals-finalize SKILL=<name>
+          ```
+
+          **Fix — every skill (same checks CI runs):**
+          ```bash
+          make -C misc/evals hygiene
+          ```
+
+          The structure the checks enforce is documented in [`misc/evals/README.md` → Adding evals for a new skill](../blob/${{ github.head_ref || github.ref_name }}/misc/evals/README.md#adding-evals-for-a-new-skill).
+          EOF
 
   docs-sync:
     name: docs auto-gen blocks are in sync
@@ -64,3 +107,20 @@ jobs:
       - uses: actions/checkout@v4
       - name: Regenerate and fail on diff
         run: ./misc/update-all-references.sh --check
+      - name: How to fix (shown on failure)
+        if: failure()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## Docs auto-gen blocks are stale
+
+          One of the marker-delimited catalogues in `README.md` or `skills/README.md` (Skills Reference, Steering Reference, Examples Reference) diverged from the source of truth (`skills/*/SKILL.md`, `steering/**/*.md`, or `examples/**/README.md` frontmatter). The exact diff is in the job log above.
+
+          **Fix:**
+          ```bash
+          ./misc/update-all-references.sh
+          git add README.md skills/README.md
+          git commit -m "docs: regenerate reference tables"
+          ```
+
+          Full details: [`CONTRIBUTING.md` → Keeping docs in sync](../blob/${{ github.head_ref || github.ref_name }}/CONTRIBUTING.md#keeping-docs-in-sync-auto-generated-catalogues).
+          EOF

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ PLAN*
 eks-best-practices-workspace
 
 # Eval artefacts (misc/evals/) — per-run ephemera. history/ is intentionally
-# tracked so regression detection has shared signal (see misc/evals/PLAN.md §1.2).
+# tracked so regression detection has shared signal across contributors.
 misc/evals/*/workspace/
 misc/evals/**/*.html
 misc/evals/.secrets/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,11 +65,7 @@ skills/{skill-name}/
 
 ### Current Skills
 
-| Skill | What It Covers |
-|-------|---------------|
-| `eks-best-practices` | EKS architecture decisions, compute, networking, security, reliability, autoscaling, upgrades, cost, observability, ArgoCD, container registry, EKS Capabilities |
-| `terraform-skill` | Terraform modules, testing (native + Terratest), CI/CD, security scanning |
-| `skill-creator` | Meta-skill: how to create and package new skills |
+See the auto-generated [Skills Reference](README.md#skills-reference) in `README.md` — regenerated from each `skills/<name>/SKILL.md` frontmatter by `misc/update-skills-references.sh` (and enforced by CI via `misc/update-all-references.sh`), so it can't fall out of sync with the repo.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -313,6 +313,26 @@ Each item is something `/apex:new-skill` will have produced by the end of Phase 
 7. Run `misc/update-steering-references.sh` to update the README
 8. Test with a real scenario and document results in `examples/`
 
+## Keeping docs in sync (auto-generated catalogues)
+
+Three catalogues in the repo are **auto-generated** from each entry's frontmatter and must not be edited by hand:
+
+| Block | Rendered in | Source of truth | Regenerator |
+|---|---|---|---|
+| Skills Reference | `README.md`, `skills/README.md` | `skills/<name>/SKILL.md` frontmatter | `misc/update-skills-references.sh` |
+| Steering Reference | `README.md` | `steering/**/*.md` frontmatter | `misc/update-steering-references.sh` |
+| Examples Reference | `README.md` | `examples/**/README.md` frontmatter | `misc/update-examples-references.sh` |
+
+Each block is delimited by HTML markers like `<!-- SKILLS_REFERENCE_START -->` / `<!-- SKILLS_REFERENCE_END -->`. The regenerator owns everything between the markers; anything outside them is free.
+
+**One-shot refresh** (run this whenever you add a skill, workflow, or example, or change a frontmatter field):
+
+```bash
+./misc/update-all-references.sh
+```
+
+**CI enforcement.** The `docs-sync` job in `.github/workflows/evals.yml` runs `./misc/update-all-references.sh --check` on every PR. If the rendered blocks diverge from frontmatter, the job fails and prints the exact diff. The fix is always the same: run the command above locally, commit the result.
+
 ## Creating a New Example
 
 1. Create `examples/<scenario>/<variant>/`

--- a/misc/evals/Makefile
+++ b/misc/evals/Makefile
@@ -41,7 +41,6 @@ else
 endif
 
 NUM_WORKERS    ?= 10
-MAX_ITER       ?= 5
 RUNS_PER_QUERY ?= 3
 
 # Per-skill default locations (override with WORKSPACE=… / BENCHMARK_DIR=…)
@@ -52,7 +51,6 @@ evals_json      = $(EVALS_ROOT)/$(1)/evals.json
 
 VALIDATE_T   := $(addprefix validate-,$(SKILLS))
 TRIGGERING_T := $(addprefix triggering-,$(SKILLS))
-OPTIMIZE_T   := $(addprefix optimize-,$(SKILLS))
 BENCHMARK_T  := $(addprefix benchmark-,$(SKILLS))
 REPORT_T     := $(addprefix report-,$(SKILLS))
 PACKAGE_T    := $(addprefix package-,$(SKILLS))
@@ -73,14 +71,13 @@ AWS_REGION        ?= us-west-2
 .PHONY: help list-skills validate-all triggering-all task-all score-full \
         init-evals init-evals-finalize check-evals-coverage hygiene \
         score score-dry \
-        $(VALIDATE_T) $(TRIGGERING_T) $(OPTIMIZE_T) \
+        $(VALIDATE_T) $(TRIGGERING_T) \
         $(BENCHMARK_T) $(REPORT_T) $(PACKAGE_T) $(REVIEW_T) $(TASK_T)
 
 help:
 	@echo "Per-skill targets (SKILL in: $(SKILLS)):"
 	@echo "  validate-<skill>    A  quick_validate.py          (deterministic)"
 	@echo "  triggering-<skill>  B  run_triggering.py            (LIVE — needs claude -p)"
-	@echo "  optimize-<skill>    D  run_loop.py                 (LIVE)"
 	@echo "  benchmark-<skill>   E  aggregate_benchmark.py      (deterministic)"
 	@echo "  report-<skill>      F  generate_report.py          (deterministic)"
 	@echo "  package-<skill>     G  package_skill.py            (deterministic)"
@@ -99,7 +96,7 @@ help:
 	@echo "  check-evals-coverage                          verify every skills/*/ has a misc/evals/*/ entry"
 	@echo "  hygiene                                       pre-flight every misc/evals/*/ (no model calls)"
 	@echo ""
-	@echo "Overrides: PROVIDER (bedrock|anthropic), MODEL, NUM_WORKERS, MAX_ITER, RUNS_PER_QUERY,"
+	@echo "Overrides: PROVIDER (bedrock|anthropic), MODEL, NUM_WORKERS, RUNS_PER_QUERY,"
 	@echo "           RUNS_PER_PROMPT, INCLUDE_LIVE_ONLY, KUBECONFIG_RO, AWS_POLICY_RO, WORKSPACE, BENCHMARK_DIR"
 	@echo "Defaults : PROVIDER=$(PROVIDER) MODEL=$(MODEL) RUNS_PER_QUERY=$(RUNS_PER_QUERY) NUM_WORKERS=$(NUM_WORKERS)"
 	@echo "           RUNS_PER_PROMPT=$(RUNS_PER_PROMPT) INCLUDE_LIVE_ONLY=$(INCLUDE_LIVE_ONLY)"
@@ -131,20 +128,13 @@ $(TRIGGERING_T): triggering-%:
 
 triggering-all: $(TRIGGERING_T)
 
-# ---------- D  run_loop (LIVE; iterative description optimizer) ---------------
-$(OPTIMIZE_T): optimize-%:
-	@test -f $(call triggering_json,$*) || \
-	  { echo "missing: $(call triggering_json,$*)"; exit 1; }
-	mkdir -p $(call workspace_dir,$*)
-	cd $(SC_DIR) && python3 -m scripts.run_loop \
-	  --eval-set   $(call triggering_json,$*) \
-	  --skill-path $(REPO_ROOT)/skills/$* \
-	  --model $(MODEL) \
-	  --max-iterations $(MAX_ITER) \
-	  --num-workers $(NUM_WORKERS) \
-	  --runs-per-query $(RUNS_PER_QUERY) \
-	  --results-dir $(call workspace_dir,$*) \
-	  --report none
+# ---------- D  run_loop — not wired (PLAN §1.5) -------------------------------
+# skill-creator/scripts/run_loop.py drives its inner eval via the upstream
+# detector that run_triggering.py replaced; invoking it here would feed noise
+# into the optimizer. The optimize-% target has been removed on purpose. If
+# description optimization becomes load-bearing, build a local replacement
+# under misc/evals/scripts/ that reuses stage_skill_sandbox + the Skill
+# tool_use parser from run_triggering.py.
 
 # ---------- E  aggregate_benchmark (deterministic) ----------------------------
 # Expects BENCHMARK_DIR to contain eval-*/<config>/run-*/grading.json.
@@ -157,8 +147,10 @@ $(BENCHMARK_T): benchmark-%:
 	    --skill-name $* \
 	    --skill-path $(REPO_ROOT)/skills/$*
 
-# ---------- F  generate_report (deterministic; reads run_loop results JSON) ---
-# Expects RESULTS_JSON=<path to run_loop results.json>.
+# ---------- F  generate_report — orphaned (reads run_loop results JSON) -------
+# F depends on D's output layout; with D unwired, this target has no fresh
+# input. Kept for symmetry with the upstream catalogue but not used in CI
+# or the scorecard flow.
 $(REPORT_T): report-%:
 	@: $${RESULTS_JSON:=$(call workspace_dir,$*)/results.json} ; \
 	  test -f "$$RESULTS_JSON" || \
@@ -174,12 +166,12 @@ $(PACKAGE_T): package-%:
 	cd $(SC_DIR) && python3 -m scripts.package_skill $(REPO_ROOT)/skills/$* $(EVALS_ROOT)/$*/workspace
 
 # ---------- K  eval-viewer/generate_review --static (deterministic) -----------
-# Expects WORKSPACE to be a directory created by run_loop / run_eval.
+# Expects WORKSPACE to be a directory created by run_loop (orphaned — see D).
 $(REVIEW_T): review-%:
 	@: $${WORKSPACE:=$(call workspace_dir,$*)} ; \
 	  test -d "$$WORKSPACE" || \
 	    { echo "workspace not found: $$WORKSPACE"; \
-	      echo "pass WORKSPACE=<dir> from a prior optimize-$* run"; exit 1; } ; \
+	      echo "pass WORKSPACE=<dir> (no current producer; see Makefile D note)"; exit 1; } ; \
 	  python3 $(SC_DIR)/eval-viewer/generate_review.py "$$WORKSPACE" \
 	    --skill-name $* \
 	    --static $(call workspace_dir,$*)/review.html

--- a/misc/evals/README.md
+++ b/misc/evals/README.md
@@ -420,7 +420,7 @@ Full `make task-all` at `RUNS_PER_PROMPT=1` is ~60–90 minutes and ~30 model ca
 
 ## Model & provider configuration
 
-Live targets (`triggering-*`, `optimize-*`, `score`, `score-dry`) shell out to `claude -p`. Both how it reaches a model (provider) and which model it asks for (model ID) are Makefile variables you can override per-invocation:
+Live targets (`triggering-*`, `task-*`, `score`, `score-dry`, `score-full`) shell out to `claude -p`. Both how it reaches a model (provider) and which model it asks for (model ID) are Makefile variables you can override per-invocation:
 
 | Variable | Default | Values | Notes |
 |---|---|---|---|
@@ -568,9 +568,9 @@ Two exceptions:
 | Capability | Needs live model? |
 |---|---|
 | A `quick_validate` | deterministic |
-| B `run_eval` | **live** (`claude -p`) |
-| C `improve_description` | **live** |
-| D `run_loop` | **live** |
+| B `run_triggering` | **live** (`claude -p`) |
+| C `improve_description` | **live** (not wired — see D) |
+| D `run_loop` | **not wired** — upstream detector mismatch (PLAN §1.5) |
 | E `aggregate_benchmark` | deterministic |
 | F `generate_report` | deterministic |
 | G `package_skill` | deterministic |
@@ -600,17 +600,17 @@ make validate-<skill>
 
 Output: one-line verdict on stdout. Exit 0 valid / 1 invalid. No disk writes. Plain script-mode — no `cd` needed because `quick_validate.py` doesn't import from the `scripts.` package.
 
-### B — `run_eval.py` (triggering score)
+### B — `run_triggering.py` (triggering score)
 
 ```bash
-make triggering-<skill>  [MODEL=claude-sonnet-4-5] [NUM_WORKERS=10] [RUNS_PER_QUERY=3]
-# → cd <repo>/skills/skill-creator && python3 -m scripts.run_eval \
+make triggering-<skill>  [MODEL=…] [NUM_WORKERS=10] [RUNS_PER_QUERY=3]
+# → python3 <repo>/misc/evals/scripts/run_triggering.py \
 #       --eval-set   <repo>/misc/evals/<skill>/triggering.json \
 #       --skill-path <repo>/skills/<skill> \
 #       --num-workers 10 --runs-per-query 3 --model <MODEL>
 ```
 
-Output: full results JSON on stdout (redirect to save). Writes nothing to disk itself; creates/deletes ephemeral files under `<repo>/.claude/commands/` during each query.
+Output: full results JSON on stdout (redirect to save). `make triggering-<skill>` is the dev-time target — it prints and exits; nothing is persisted under `workspace/`. Per-run artefacts (`{raw,triggering,metrics}.json` under `<skill>/workspace/runs/<UTC>/`) are written by `run_all_evals.py` / `make score`, which is the orchestration entry point. Each query stages a throwaway sandbox (`mktemp` project dir + `.claude/skills/<name>` symlink + clean `HOME`) and removes it after the subprocess exits; the repo's real `.claude/` is never touched.
 
 ### C — `improve_description.py` (propose a description rewrite)
 
@@ -626,19 +626,9 @@ python3 -m scripts.improve_description \
 
 Output: `{"description": "...", "history": [...]}` on stdout.
 
-### D — `run_loop.py` (iterative description optimizer)
+### D — `run_loop.py` (iterative description optimizer) — **not wired**
 
-```bash
-make optimize-<skill>  [MODEL=…] [MAX_ITER=5] [NUM_WORKERS=10] [RUNS_PER_QUERY=3]
-# → cd <repo>/skills/skill-creator && python3 -m scripts.run_loop \
-#       --eval-set   <repo>/misc/evals/<skill>/triggering.json \
-#       --skill-path <repo>/skills/<skill> \
-#       --model <MODEL> --max-iterations 5 --num-workers 10 --runs-per-query 3 \
-#       --results-dir <repo>/misc/evals/<skill>/workspace \
-#       --report none
-```
-
-Output: final JSON on stdout plus `<workspace>/<TIMESTAMP>/{results.json,report.html,logs/improve_iter_*.json}`. The Makefile passes `--report none` to suppress the auto-opened browser.
+No Makefile target. `skill-creator/scripts/run_loop.py` drives its inner eval via the upstream detector that `run_triggering.py` replaced (PLAN §1.5); running it against the repo's current skills would produce noise, so the `optimize-<skill>` target has been removed. If description optimization becomes load-bearing, build a local equivalent under `misc/evals/scripts/` that shells through `run_triggering.py` — hand-edits have been sufficient through Phase 3.
 
 ### E — `aggregate_benchmark.py` (aggregate grading.json stats across runs)
 
@@ -652,7 +642,9 @@ Output: `<BENCHMARK_DIR>/benchmark.json` + `benchmark.md`. Supports both `<dir>/
 
 `BENCHMARK_DIR` defaults to `<skill>/workspace/` — override when the grading runs live elsewhere.
 
-### F — `generate_report.py` (HTML viz of `run_loop` results.json)
+### F — `generate_report.py` (HTML viz of `run_loop` results.json) — orphaned
+
+Reads `run_loop`'s output layout. With D unwired this target has no fresh input; kept for completeness.
 
 ```bash
 make report-<skill>  [RESULTS_JSON=<path>]
@@ -696,7 +688,7 @@ Writes a self-contained HTML file. No server, no `webbrowser.open()`.
 
 ## Score interpretation cheat sheet
 
-- **Triggering (B/D)**: reported as `passed/total` in `run_eval` output; `run_loop` also reports a train/holdout split (default holdout = 0.4) and per-iteration deltas.
+- **Triggering (B)**: reported as `passed/total` in `run_triggering` output; the scorecard in this README adds stratified TPR/TNR, flake counts, threshold sweep, and per-sibling leakage.
 - **Task evals (H → E)**: `aggregate_benchmark` reports mean ± stddev of pass-rate across runs, plus per-expectation hit rate. `benchmark.md` renders a summary table.
 
 ## Workspace hygiene

--- a/misc/evals/eks-best-practices/README.md
+++ b/misc/evals/eks-best-practices/README.md
@@ -23,4 +23,4 @@ The key discriminators for `eks-best-practices`: the prompt asks for a *decision
 
 ## How to run
 
-See `/workspace/sample-apex-skills/misc/evals/README.md` for the full workflow. Per-skill Makefile targets: `make triggering-eks-best-practices` (triggering accuracy), `make optimize-eks-best-practices` (iterative description optimizer), `make benchmark-eks-best-practices BENCHMARK_DIR=…` (aggregate `grading.json` files into `benchmark.md`).
+See `misc/evals/README.md` for the full workflow. Per-skill Makefile targets: `make triggering-eks-best-practices` (triggering accuracy), `make benchmark-eks-best-practices BENCHMARK_DIR=…` (aggregate `grading.json` files into `benchmark.md`).

--- a/misc/evals/eks-mcp-server/README.md
+++ b/misc/evals/eks-mcp-server/README.md
@@ -19,4 +19,4 @@ The two eval prompts in `evals.json` are about **talking about** the EKS MCP Ser
 
 ## How to run
 
-See `misc/evals/README.md` for the full harness description. Per-skill Makefile targets: `make triggering-eks-mcp-server` (triggering accuracy), `make optimize-eks-mcp-server` (iterative description optimizer), `make benchmark-eks-mcp-server BENCHMARK_DIR=…` (aggregate `grading.json` files into `benchmark.md`).
+See `misc/evals/README.md` for the full harness description. Per-skill Makefile targets: `make triggering-eks-mcp-server` (triggering accuracy), `make benchmark-eks-mcp-server BENCHMARK_DIR=…` (aggregate `grading.json` files into `benchmark.md`).

--- a/misc/evals/eks-recon/README.md
+++ b/misc/evals/eks-recon/README.md
@@ -24,5 +24,5 @@ The `triggering.json` evals (run via `run_triggering.py`) are unaffected — the
 See `misc/evals/README.md` for the full invocation surface. From `misc/evals/` the relevant Makefile targets are:
 
 ```bash
-make validate-eks-recon triggering-eks-recon optimize-eks-recon
+make validate-eks-recon triggering-eks-recon
 ```

--- a/misc/evals/eks-upgrader/README.md
+++ b/misc/evals/eks-upgrader/README.md
@@ -7,10 +7,10 @@ These evals exercise the `eks-upgrader` skill's declared scope: **executing** EK
 ## Neighbour-skill disambiguation
 
 <!-- SIBLING_MAP_START -->
-- **eks-recon** (discovery / "what do we have?"): negatives 9–11 in `triggering.json` — inherited-cluster inventory, environment discovery pass, pre-planning "tell me what's deployed". **This is the single most important boundary for `eks-upgrader`**: many users plan upgrades by first asking what they're running, and the skill must *not* fire on discovery intent. The rule: if the user hasn't yet committed to an upgrade action or compatibility question, it's recon.
-- **eks-best-practices** (strategy / architecture): negatives 12–14 — in-place-vs-blue-green decision, 2x-cost worth-it question, platform redesign where upgrades are a theme but not the task. **This is the second most important boundary**: `eks-upgrader` owns the *procedure* for a chosen strategy; `eks-best-practices` owns the *choice between* strategies and upgrade-friendly architecture. The rule: if the user is still deciding, it's best-practices; if they've decided and want steps, it's upgrader.
-- **eks-mcp-server** (tooling setup): negative 15 — configuring the MCP server itself so the assistant can talk to a live cluster. Not an upgrade task.
-- **Unrelated / non-EKS**: negative 16 — vanilla self-managed Kubernetes upgrade on bare metal. EKS-specific procedure is the skill's remit; generic k8s upgrades aren't.
+- **`eks-recon`** (discovery / "what do we have?") — negatives 9, 10, 11 ("what version am I running", "discovery pass on our EKS environment", "tell me what's deployed"). **The single most important boundary for `eks-upgrader`**: many users plan upgrades by first asking what they're running, and the skill must *not* fire on discovery intent. The rule: if the user hasn't yet committed to an upgrade action or compatibility question, it's recon.
+- **`eks-best-practices`** (strategy / architecture) — negatives 12, 13, 14 ("in-place vs blue-green, which should we choose", "is blue-green worth the 2x cost", "redesigning our EKS platform for multi-tenancy"). **The second most important boundary**: `eks-upgrader` owns the *procedure* for a chosen strategy; `eks-best-practices` owns the *choice between* strategies and upgrade-friendly architecture. The rule: if the user is still deciding, it's best-practices; if they've decided and want steps, it's upgrader.
+- **`eks-mcp-server`** (tooling setup) — negative 15 ("install and configure the EKS MCP server so my AI assistant can talk to my cluster"). Not an upgrade task.
+- **Unrelated / non-EKS** — negative 16 ("upgrade procedure for self-managed vanilla Kubernetes on bare metal"). EKS-specific procedure is the skill's remit; generic k8s upgrades aren't.
 <!-- SIBLING_MAP_END -->
 
 ## Live-MCP caveat
@@ -19,4 +19,4 @@ These evals exercise the `eks-upgrader` skill's declared scope: **executing** EK
 
 ## How to run
 
-See `/workspace/sample-apex-skills/misc/evals/README.md` for the eval harness. Per-skill Makefile targets: `make triggering-eks-upgrader` (triggering accuracy), `make optimize-eks-upgrader` (iterative description optimizer), `make benchmark-eks-upgrader BENCHMARK_DIR=…` (aggregate `grading.json` files into `benchmark.md`).
+See `misc/evals/README.md` for the eval harness. Per-skill Makefile targets: `make triggering-eks-upgrader` (triggering accuracy), `make benchmark-eks-upgrader BENCHMARK_DIR=…` (aggregate `grading.json` files into `benchmark.md`).

--- a/misc/evals/scripts/run_triggering.py
+++ b/misc/evals/scripts/run_triggering.py
@@ -137,7 +137,11 @@ def _match_skill_in_input(raw_json: str, skill_name: str) -> bool:
     and unique across the staged sandbox (only one skill is visible to the
     subprocess at all).
     """
-    return f'"skill":"{skill_name}"' in raw_json.replace(" ", "")
+    compact = raw_json.replace(" ", "")
+    return (
+        f'"skill":"{skill_name}"' in compact
+        or f'"name":"{skill_name}"' in compact
+    )
 
 
 def parse_stream_for_trigger(
@@ -291,7 +295,12 @@ def _handle_line(
                 continue
             if c.get("name") != "Skill":
                 continue
-            if (c.get("input") or {}).get("skill") == skill_name:
+            # Accept either `input.skill` or `input.name` — current Claude Code
+            # emits `skill`, but the field has moved before and a rename would
+            # silently zero TPR on this fallback path. The delta path above
+            # substring-matches the raw JSON and is unaffected.
+            inp = c.get("input") or {}
+            if inp.get("skill") == skill_name or inp.get("name") == skill_name:
                 out["triggered"] = True
                 return None
         return pending_block

--- a/misc/update-all-references.sh
+++ b/misc/update-all-references.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# update-all-references.sh
+#
+# Thin orchestrator: runs every auto-gen script that rebuilds marker-delimited
+# blocks in the repo's docs (Skills/Steering/Examples reference tables in
+# README.md + skills/README.md). One entry point so contributors and CI don't
+# have to remember which script owns which block.
+#
+# Usage:
+#   ./misc/update-all-references.sh              # regenerate in place
+#   ./misc/update-all-references.sh --check      # fail if any block is stale
+#   ./misc/update-all-references.sh --dry-run    # preview; forwards to each script
+#
+# --check is what the `docs-sync` CI job runs: regenerate, then `git diff
+# --exit-code` on the docs paths. Non-zero exit means someone edited a
+# marker block by hand or added a skill/workflow/example without running
+# the scripts — fix is `./misc/update-all-references.sh && git add … && commit`.
+
+set -euo pipefail
+
+MODE="run"
+if [[ "${1:-}" == "--check" ]]; then
+  MODE="check"
+elif [[ "${1:-}" == "--dry-run" ]]; then
+  MODE="dry-run"
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+SCRIPTS=(
+  "misc/update-skills-references.sh"
+  "misc/update-steering-references.sh"
+  "misc/update-examples-references.sh"
+)
+
+# Files any script above may touch — the blast radius of --check.
+TOUCHED_PATHS=(
+  "README.md"
+  "skills/README.md"
+)
+
+run_script() {
+  local script="$1"
+  case "$MODE" in
+    dry-run) bash "$script" --dry-run ;;
+    *)       bash "$script" ;;
+  esac
+}
+
+for s in "${SCRIPTS[@]}"; do
+  echo "▸ $s"
+  run_script "$s"
+done
+
+if [[ "$MODE" == "check" ]]; then
+  if ! git diff --quiet -- "${TOUCHED_PATHS[@]}"; then
+    echo ""
+    echo "ERROR: auto-generated blocks are stale. Diff:"
+    git --no-pager diff -- "${TOUCHED_PATHS[@]}"
+    echo ""
+    echo "Fix: run ./misc/update-all-references.sh locally, commit the result."
+    exit 1
+  fi
+  echo "✓ docs are in sync with skills/, steering/, examples/"
+fi

--- a/steering/eks.md
+++ b/steering/eks.md
@@ -70,41 +70,9 @@ When routing between workflows, carry forward any known context. This is critica
 
 ## Skills Reference
 
-All workflows use these skills:
+These EKS workflows draw on the skills in the repo-level [Skills Reference](../README.md#skills-reference) — primarily `eks-best-practices` (architecture, compute, networking, security, reliability, observability), `eks-upgrader` (in-place and blue-green upgrade procedures, add-on upgrade guides), `eks-mcp-server` (live-cluster MCP setup), and `terraform-skill` (IaC patterns). The authoritative table is auto-generated from each skill's frontmatter; enumerate here only intent, not the skill set.
 
-| Skill | What It Provides |
-|-------|-----------------|
-| **eks-best-practices** | Decision frameworks, compute selection, networking, security, reliability, autoscaling, cost, observability, ArgoCD patterns, container registry |
-| **eks-upgrader** | Upgrade procedures (in-place, blue-green), pre-flight checks, add-on upgrade guides (Karpenter, Istio), rollback, troubleshooting |
-| **eks-mcp-server** | Setup guide for EKS MCP Server (AWS-hosted or self-hosted) — enables live cluster operations via MCP tools |
-| **terraform-skill** | Terraform modules, testing, CI/CD, security scanning |
-
-### Key Reference Files (Loaded on Demand)
-
-| Reference | Used By |
-|-----------|---------|
-| **eks-upgrader** | |
-| [in-place-upgrade.md](../skills/eks-upgrader/references/in-place-upgrade.md) | Upgrade workflow |
-| [blue-green-upgrade.md](../skills/eks-upgrader/references/blue-green-upgrade.md) | Upgrade workflow |
-| [karpenter.md (upgrader)](../skills/eks-upgrader/references/karpenter.md) | Upgrade workflow (Karpenter upgrade procedures) |
-| [istio.md](../skills/eks-upgrader/references/istio.md) | Upgrade workflow (Istio upgrade procedures) |
-| **eks-best-practices** | |
-| [security.md](../skills/eks-best-practices/references/security.md) | Design workflow (security domain) |
-| [security-runtime-network.md](../skills/eks-best-practices/references/security-runtime-network.md) | Design workflow (security domain) |
-| [security-supply-chain.md](../skills/eks-best-practices/references/security-supply-chain.md) | Design workflow (security domain) |
-| [networking.md](../skills/eks-best-practices/references/networking.md) | Design workflow (networking domain) |
-| [networking-ingress-dns.md](../skills/eks-best-practices/references/networking-ingress-dns.md) | Design workflow (networking domain) |
-| [reliability-core.md](../skills/eks-best-practices/references/reliability-core.md) | Design workflow, Upgrade workflow |
-| [reliability-advanced.md](../skills/eks-best-practices/references/reliability-advanced.md) | Design workflow, Upgrade workflow |
-| [terraform-examples.md](../skills/eks-best-practices/references/terraform-examples.md) | Design workflow, Upgrade workflow (Terraform path) |
-| [autoscaling.md](../skills/eks-best-practices/references/autoscaling.md) | Design workflow |
-| [karpenter.md (best-practices)](../skills/eks-best-practices/references/karpenter.md) | Design workflow (Karpenter operational config) |
-| [eks-auto-mode.md](../skills/eks-best-practices/references/eks-auto-mode.md) | Design workflow |
-| [cost-optimization.md](../skills/eks-best-practices/references/cost-optimization.md) | Design workflow |
-| [scalability.md](../skills/eks-best-practices/references/scalability.md) | Design workflow |
-| [observability.md](../skills/eks-best-practices/references/observability.md) | Design workflow |
-| [argocd-patterns.md](../skills/eks-best-practices/references/argocd-patterns.md) | Design workflow |
-| [container-registry.md](../skills/eks-best-practices/references/container-registry.md) | Design workflow |
+Each skill's progressive-disclosure block in its `SKILL.md` lists the individual reference files under `skills/<skill>/references/` and when each is loaded — do not mirror that list here.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes out the `misc/evals/` project. Three commits on `chore/evals-phase-3.99` targeting `fix/review-findings` (PR #20's long-running branch):

1. **`7720ec5`** — Phase 3.99 small fixes: eks-upgrader SIBLING_MAP canonical shape, workspace/ format doc, `optimize-%` target removed (upstream `run_loop` detector is incompatible with `run_triggering` per PLAN §1.5), `run_triggering.py` fallback detector widened to accept `input.skill` OR `input.name`.
2. **`09de122`** — Rot-proofing pass: hand-maintained skill catalogues in `CONTRIBUTING.md` and `steering/eks.md` replaced with pointers to auto-generated tables or count-agnostic prose. New `misc/update-all-references.sh` orchestrator + `docs-sync` CI job enforce that `<!-- *_REFERENCE_START/END -->` marker blocks stay in sync with `skills/`, `steering/`, and `examples/` frontmatter.
3. **`2f9013b`** — PLAN.md removed; commit body is the project's gravestone (lists every issue opened + every bullet dropped during Phase 4 triage).

## Issues opened as part of this triage

- **#29** — rewritten as the combined eval-improvement issue covering three axes: human review pass on AI-generated prompts/expectations, multi-turn / integration eval harness, local description optimizer (replacement for the unwired `optimize-%` path).
- **#33** — `steering-workflow-creator` overlaps with `/apex:new-skill` meta-workflow (item 10 leaks at trigger rate 1.0).

## Test plan

- [x] `make hygiene` passes on all 5 skills
- [x] `python3 scripts/run_all_evals.py --dry-run --skip-triggering` re-renders the scorecard without parser warnings
- [x] `./misc/update-all-references.sh --check` green on a clean tree; exits 1 when docs are artificially staled
- [x] Python + Makefile syntax clean after `optimize-%` / `MAX_ITER` / `OPTIMIZE_T` removal
- [x] PLAN.md gone from the working tree (was .gitignored from day one, now also absent from disk)

After this merges into `fix/review-findings`, PR #20 is clear to merge into `main`.