### PR TITLE
docs: query EKS API for version support instead of computing from rel…

### DIFF
--- a/skills/eks-upgrader/SKILL.md
+++ b/skills/eks-upgrader/SKILL.md
@@ -144,13 +144,25 @@ If any Cluster Insight returns `"status": ERROR`, resolve it before proceeding.
 
 ## Version Support Lifecycle
 
-| Phase | Duration | Cost |
-|-------|----------|------|
-| **Standard support** | 14 months from release | Standard pricing |
-| **Extended support** | +12 months | Additional per-hour fee |
-| **End of support** | N/A | Auto-upgrade to next supported version |
+EKS versions transition through three phases:
 
-You can [disable extended support](https://docs.aws.amazon.com/eks/latest/userguide/disable-extended-support.html) so auto-upgrade happens at end of standard support instead.
+| Phase | Cost | Auto-upgrade? |
+|-------|------|----------------|
+| **Standard support** | Standard cluster pricing | No |
+| **Extended support** | Additional per-hour surcharge (~6x standard cluster fee) | No |
+| **End of extended support** | N/A | Yes -- AWS auto-upgrades at a time it chooses |
+
+**Always get exact dates from the EKS API -- do not compute them from release dates.**
+
+```bash
+aws eks describe-cluster-versions --region <region> \
+  --query 'clusterVersions[*].[clusterVersion,status,endOfStandardSupportDate,endOfExtendedSupportDate]' \
+  --output table
+```
+
+Typical durations are ~14 months standard and ~12 months extended, but AWS has historically adjusted these -- the API is the only trustworthy source. Use it every time.
+
+You can [disable extended support](https://docs.aws.amazon.com/eks/latest/userguide/disable-extended-support.html) so auto-upgrade happens at end of standard support instead of end of extended support.
 
 Upgrade every 3-4 months to stay within standard support. Budget one upgrade cycle per quarter. Review upcoming K8s releases early to identify breaking changes before they arrive.
 

--- a/steering/workflows/upgrade.md
+++ b/steering/workflows/upgrade.md
@@ -71,7 +71,7 @@ MUST gather ALL before proceeding to Phase 2:
 [ ] 6. Upgrade strategy: in-place (default) or blue-green
 [ ] 7. Environment: production / staging / development
 [ ] 8. Non-prod upgraded first? If no -> recommend it
-[ ] 9. Version validation (see below)
+[ ] 9. Version support status (run aws eks describe-cluster-versions -- see Version Support Awareness section; do NOT compute from release dates)
 ```
 
 ### IaC Detection (Item 5)
@@ -431,12 +431,24 @@ When upgrading across multiple minor versions (e.g., 1.29 -> 1.32):
 
 ## Version Support Awareness
 
-| Phase | Duration | Cost Impact |
-|-------|----------|-------------|
-| Standard support | 14 months | Standard pricing |
-| Extended support | +12 months | Additional per-hour fee |
-| End of support | Auto-upgrade by AWS | N/A |
+**Do not guess support status from "X months from release" math -- always query the API.**
 
-If on extended support, flag the extra cost. If near end of support, warn about auto-upgrade.
+```bash
+aws eks describe-cluster-versions --region <region> \
+  --query 'clusterVersions[*].[clusterVersion,status,endOfStandardSupportDate,endOfExtendedSupportDate]' \
+  --output table
+```
 
-For full details, see [eks-upgrader SKILL.md -- Version Support Lifecycle](../../skills/eks-upgrader/SKILL.md#version-support-lifecycle). You can [disable extended support](https://docs.aws.amazon.com/eks/latest/userguide/disable-extended-support.html) so auto-upgrade happens at end of standard support.
+For each upgrade, during Phase 1 Context, check:
+
+1. Current cluster version -- is it in `STANDARD_SUPPORT` or `EXTENDED_SUPPORT`?
+2. Target version -- is it in standard support today, or already in extended?
+3. How much standard-support runway does the target buy (difference between target's `endOfStandardSupportDate` and today)?
+
+If the cluster is on `EXTENDED_SUPPORT`, the user is paying the extended-support surcharge (roughly **$0.50/hr** per cluster on top of the standard $0.10/hr, us-east-1 pricing -- verify current pricing if quoting dollar figures). Quantify the monthly impact when presenting the upgrade case.
+
+If the target is also in `EXTENDED_SUPPORT`, **say so explicitly** -- upgrading to it does NOT stop the surcharge. Recommend a version in `STANDARD_SUPPORT` to fully exit extended support.
+
+If `endOfExtendedSupportDate` is within the next 60 days, warn the user about auto-upgrade risk. Option to [disable extended support](https://docs.aws.amazon.com/eks/latest/userguide/disable-extended-support.html) so auto-upgrade happens at end of standard support instead.
+
+For the general lifecycle model (standard -> extended -> auto-upgrade), see [eks-upgrader SKILL.md -- Version Support Lifecycle](../../skills/eks-upgrader/SKILL.md#version-support-lifecycle).


### PR DESCRIPTION
## Summary
  - Replace the abstract 14-month standard / 12-month extended duration tables in `steering/workflows/upgrade.md` and `skills/eks-upgrader/SKILL.md` with an instruction to query `aws eks describe-cluster-versions` for authoritative per-version dates.
  - Bind this check to Phase 1 of the upgrade workflow (Required Context item 9) so every upgrade run validates support status against the API before planning.
  - Emphasize that upgrading from an extended-support version to *another* extended-support version does NOT stop the extended-support surcharge — a common misreading when the abstract table is the only reference.

  ## Motivation
  During an upgrade workflow run, the agent reasoned about 1.31 support status using "14 months from release" math and stated the cluster would be in standard support after upgrade. The actual `endOfStandardSupportDate` for 1.31 is 2025-11-26 — already passed, so 1.31 is currently in EXTENDED_SUPPORT. The
  math-from-release approach produced a confidently-wrong answer. The API is the only trustworthy source; the steering files now direct the agent there explicitly.

  ## Test plan
  - [ ] Verify the updated command runs against any EKS region and returns `status`, `endOfStandardSupportDate`, `endOfExtendedSupportDate` for all versions
  - [ ] Review Phase 1 checklist reads naturally with the new item 9
  - [ ] Confirm `skills/eks-upgrader/SKILL.md` Version Support Lifecycle section anchor still resolves from `steering/workflows/upgrade.md`