### PR TITLE
docs(eks-best-practices): query EKS API for version support, not release-date math

### DIFF
--- a/skills/eks-best-practices/references/cluster-upgrades.md
+++ b/skills/eks-best-practices/references/cluster-upgrades.md
@@ -532,19 +532,27 @@ For nodes deployed outside the EKS managed service, use your provisioning tool:
 
 ### EKS Version Lifecycle
 
-| Phase | Duration | Patching | Cost |
-|-------|----------|----------|------|
-| **Standard support** | 14 months | Security + bug fixes | Standard pricing |
-| **Extended support** | +12 months | Critical security only | Additional per-hour fee |
-| **End of support** | N/A | Auto-upgrade to oldest supported | N/A |
+| Phase | Patching | Cost | Auto-upgrade? |
+|-------|----------|------|----------------|
+| **Standard support** | Security + bug fixes | Standard pricing | No |
+| **Extended support** | Critical security only | Additional per-hour surcharge | No |
+| **End of extended support** | None | N/A | Yes — AWS auto-upgrades at a time it chooses |
 
-You can [disable extended support](https://docs.aws.amazon.com/eks/latest/userguide/disable-extended-support.html) — in which case, auto-upgrade happens at end of standard support.
+**Always get exact dates from the EKS API — do not compute them from release dates.** Standard and extended support windows have historically shifted; the API is the only trustworthy source.
+
+```bash
+aws eks describe-cluster-versions --region <region> \
+  --query 'clusterVersions[*].[clusterVersion,status,endOfStandardSupportDate,endOfExtendedSupportDate]' \
+  --output table
+```
+
+You can [disable extended support](https://docs.aws.amazon.com/eks/latest/userguide/disable-extended-support.html) so auto-upgrade happens at end of standard support instead.
 
 ### Planning Timeline
 
-- **Month 0:** New K8s version available on EKS (~3 releases per year)
-- **Month 14:** Standard support ends
-- **Month 26:** Extended support ends
+- **New K8s minor on EKS:** ~3 releases per year
+- **End of standard support:** query the API per cluster version
+- **End of extended support:** query the API per cluster version
 - **After:** EKS auto-upgrades your cluster (may disrupt workloads)
 
 **Recommendation:** Upgrade every 3-4 months to stay within standard support. Budget one upgrade cycle per quarter. Look beyond the next version — review upcoming K8s releases to identify major changes early (e.g., Dockershim removal was announced well before 1.25).


### PR DESCRIPTION
## Summary

Mirrors PR #35 (which fixed `skills/eks-upgrader/SKILL.md` and `steering/workflows/upgrade.md`) into `skills/eks-best-practices/references/cluster-upgrades.md`, which carried the same hard-coded 14-month / 12-month / Month 14 / Month 26 heuristic.

After #35 merged, `eks-best-practices` was contradicting `eks-upgrader` on the same topic. This brings them into agreement: the EKS API (`aws eks describe-cluster-versions`) is the single source of truth for support-window dates.

## Changes

- Replace the 14-month / 12-month duration table with a phase/cost/auto-upgrade table that doesn't claim absolute durations.
- Add the `aws eks describe-cluster-versions` command (same one PR #35 introduced).
- Replace the "Month 14 / Month 26" planning timeline with a "query the API per cluster version" instruction.
- Keep the `disable-extended-support` link and the upgrade-cadence recommendation.

## Test plan

- [ ] Rendered file reads cleanly and no broken links
- [ ] Wording stays consistent with `skills/eks-upgrader/SKILL.md` Version Support Lifecycle section (post-#35)