### PR TITLE
chore(regen): strip YAML quotes + enumerate any skill subdirectory

### DIFF
--- a/misc/update-examples-references.sh
+++ b/misc/update-examples-references.sh
@@ -33,6 +33,8 @@ parse_frontmatter() {
     /^---$/ { block++; next }
     block == 1 && $0 ~ "^" key ":" {
       sub("^" key ":[ ]*", "")
+      sub("^\"", ""); sub("\"$", "")
+      sub("^'\''", ""); sub("'\''$", "")
       print
       exit
     }

--- a/misc/update-skills-references.sh
+++ b/misc/update-skills-references.sh
@@ -34,6 +34,8 @@ parse_frontmatter() {
     /^---$/ { block++; next }
     block == 1 && $0 ~ "^" key ":" {
       sub("^" key ":[ ]*", "")
+      sub("^\"", ""); sub("\"$", "")
+      sub("^'\''", ""); sub("'\''$", "")
       print
       exit
     }

--- a/misc/update-skills-references.sh
+++ b/misc/update-skills-references.sh
@@ -208,6 +208,50 @@ build_skills_detail() {
         done
       fi
     fi
+
+    # --- Other subdirectories (e.g. data/, tools/, agents/, eval-viewer/) ---
+    # The Anthropic skill spec allows any subdirectory under a skill root.
+    # Surface anything not already handled above so vendored or richer-layout
+    # skills are not invisible in the catalog.
+    local other_dirs=()
+    while IFS= read -r -d '' d; do
+      local d_name
+      d_name="$(basename "$d")"
+      case "$d_name" in
+        references|scripts|assets) continue ;;
+      esac
+      other_dirs+=("$d")
+    done < <(find "$skill_dir" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+
+    for other_dir in "${other_dirs[@]}"; do
+      local other_name
+      other_name="$(basename "$other_dir")"
+      local other_files=()
+      while IFS= read -r -d '' f; do
+        other_files+=("$f")
+      done < <(find "$other_dir" -maxdepth 1 \( -type f -o -type d \) ! -path "$other_dir" -print0 | sort -z)
+
+      if [[ ${#other_files[@]} -gt 0 ]]; then
+        local other_heading
+        other_heading="$(humanize_filename "$other_name")"
+        echo ""
+        echo "**$other_heading:**"
+        echo ""
+        echo "| File | Description |"
+        echo "|------|-------------|"
+        for other_file in "${other_files[@]}"; do
+          local other_basename
+          other_basename="$(basename "$other_file")"
+          local other_label
+          other_label="$(humanize_filename "$other_basename")"
+          if [[ -d "$other_file" ]]; then
+            echo "| [$other_basename/](./$folder_name/$other_name/$other_basename/) | $other_label |"
+          else
+            echo "| [$other_basename](./$folder_name/$other_name/$other_basename) | $other_label |"
+          fi
+        done
+      fi
+    done
   done
 }
 

--- a/misc/update-steering-references.sh
+++ b/misc/update-steering-references.sh
@@ -32,6 +32,8 @@ parse_frontmatter() {
     /^---$/ { block++; next }
     block == 1 && $0 ~ "^" key ":" {
       sub("^" key ":[ ]*", "")
+      sub("^\"", ""); sub("\"$", "")
+      sub("^'\''", ""); sub("'\''$", "")
       print
       exit
     }

--- a/skills/README.md
+++ b/skills/README.md
@@ -81,6 +81,20 @@ EKS cluster reconnaissance and environment discovery. Detects compute strategy (
 | [storage.md](./eks-recon/references/storage.md) | Storage |
 | [workloads.md](./eks-recon/references/workloads.md) | Workloads |
 
+**Agents:**
+
+| File | Description |
+|------|-------------|
+| [addons-recon.md](./eks-recon/agents/addons-recon.md) | Addons recon |
+| [cicd-recon.md](./eks-recon/agents/cicd-recon.md) | Cicd recon |
+| [compute-recon.md](./eks-recon/agents/compute-recon.md) | Compute recon |
+| [iac-recon.md](./eks-recon/agents/iac-recon.md) | Iac recon |
+| [networking-recon.md](./eks-recon/agents/networking-recon.md) | Networking recon |
+| [observability-recon.md](./eks-recon/agents/observability-recon.md) | Observability recon |
+| [security-recon.md](./eks-recon/agents/security-recon.md) | Security recon |
+| [storage-recon.md](./eks-recon/agents/storage-recon.md) | Storage recon |
+| [workloads-recon.md](./eks-recon/agents/workloads-recon.md) | Workloads recon |
+
 ---
 
 ### [skill-creator](./skill-creator/)
@@ -112,6 +126,21 @@ Create new skills, modify and improve existing skills, and measure skill perform
 | Asset | Description |
 |-------|-------------|
 | [eval_review.html](./skill-creator/assets/eval_review.html) | Eval_review |
+
+**Agents:**
+
+| File | Description |
+|------|-------------|
+| [analyzer.md](./skill-creator/agents/analyzer.md) | Analyzer |
+| [comparator.md](./skill-creator/agents/comparator.md) | Comparator |
+| [grader.md](./skill-creator/agents/grader.md) | Grader |
+
+**Eval viewer:**
+
+| File | Description |
+|------|-------------|
+| [generate_review.py](./skill-creator/eval-viewer/generate_review.py) | Generate_review |
+| [viewer.html](./skill-creator/eval-viewer/viewer.html) | Viewer |
 
 ---
 


### PR DESCRIPTION
## Summary

Two related fixes to the auto-catalog generators in `misc/update-*-references.sh`:

1. **Strip surrounding YAML quotes from frontmatter values.** The shared `parse_frontmatter` helper extracted everything after `key:` verbatim, so descriptions written as quoted YAML scalars (e.g. `description: "..."`) leaked their quotes into catalog rows.
2. **List any subdirectory under a skill, not just the legacy triple.** The Anthropic skill spec (https://agentskills.io/specification) allows arbitrary subdirectories beyond `references/`/`scripts/`/`assets/`. Skills that ship `data/`, `tools/`, `agents/`, etc. were silently invisible in `skills/README.md`.

## Why now

PR #36 vendors `eks-upgrade-check` whose `SKILL.md` uses quoted YAML and ships `steering/`, `data/`, `tools/`. Without these fixes the catalog row renders with literal quotes around the description and none of the subfolders surface. Fix the generators rather than fight valid skill layouts.

## What changes in catalog output

- Quoted descriptions render cleanly (no churn for any current skill — they all use unquoted YAML today).
- Three previously-invisible existing folders are now surfaced: `eks-recon/agents/`, `skill-creator/agents/`, `skill-creator/eval-viewer/`. These additions are the only catalog churn introduced.

## Test plan

- [x] Regression-tested `parse_frontmatter` against quoted, unquoted, and single-quoted descriptions — all render cleanly.
- [x] `bash misc/update-all-references.sh` produces the expected additive diff (the three folders above) and zero unexpected churn.
- [ ] After merge: PR #36 rebases and the `eks-upgrade-check` row in `skills/README.md` shows quote-free description plus subtables for `data/`, `tools/`, and (post-rename) `references/`.