### PR TITLE
feat: SEO optimization + npx installer for v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ sample-apex-skills/
 
 ## Quick Start
 
+### NPX Installer (recommended)
+
+```bash
+npx apex-skills
+```
+
+Detects Claude Code and/or Kiro CLI, clones the repo, and symlinks all skills + steering into the right locations. Run `npx apex-skills --update` to pull the latest.
+
 ### Option A: Just the Skills
 
 Use the skills with any agent that supports the [Agent Skills standard](https://agentskills.io/). Skills are self-contained — clone and point your tool at them.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ sample-apex-skills/
 
 ### NPX Installer (recommended)
 
+> **Prerequisites:** [Node.js 18+](https://nodejs.org/) and [git](https://git-scm.com/) must be installed.
+
 ```bash
 npx apex-skills
 ```

--- a/misc/installer/README.md
+++ b/misc/installer/README.md
@@ -1,0 +1,53 @@
+# APEX Skills Installer
+
+NPX-runnable installer for APEX platform engineering skills. Installs skills for Claude Code and Kiro CLI via symlinks from a local clone of the repository.
+
+## Usage
+
+```bash
+npx apex-skills
+```
+
+Or to update an existing installation:
+
+```bash
+npx apex-skills --update
+```
+
+## What it does
+
+1. Clones (or updates) the `sample-apex-skills` repo to `~/.apex-skills/`
+2. Symlinks each skill directory into your AI tool's skills folder
+3. Optionally installs steering workflows and slash commands
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--claude-only` | Install for Claude Code only |
+| `--kiro-only` | Install for Kiro CLI only |
+| `--project` | Install to current project directory instead of global |
+| `--no-steering` | Skip steering/commands setup |
+| `--update` | Pull latest and re-symlink (non-interactive) |
+| `--uninstall` | Remove symlinks (keeps cloned repo) |
+| `-h, --help` | Show help |
+
+## Requirements
+
+- Node.js 18+
+- git
+- macOS or Linux (Windows is not supported; use WSL)
+
+## Installed paths
+
+| Tool | Skills | Steering |
+|------|--------|----------|
+| Claude Code | `~/.claude/skills/{name}` | `~/.claude/commands/apex/` |
+| Kiro CLI | `~/.kiro/skills/{name}` | `~/.kiro/steering/` |
+
+## Uninstall
+
+```bash
+npx apex-skills --uninstall
+rm -rf ~/.apex-skills  # optional: remove cloned repo
+```

--- a/misc/installer/bin/cli.mjs
+++ b/misc/installer/bin/cli.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readdirSync, symlinkSync, readlinkSync, unlinkSync, rmSync, statSync } from 'fs';
+import { join, resolve } from 'path';
+import { homedir, platform } from 'os';
+import { execSync } from 'child_process';
+import { createInterface } from 'readline';
+
+const VERSION = '1.0.0';
+const REPO_URL = 'https://github.com/aws-samples/sample-apex-skills.git';
+const HOME = homedir();
+const INSTALL_DIR = join(HOME, '.apex-skills');
+
+// ANSI colors
+const c = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+};
+
+const log = (msg) => console.log(msg);
+const info = (msg) => log(`${c.blue}i${c.reset} ${msg}`);
+const success = (msg) => log(`${c.green}✓${c.reset} ${msg}`);
+const warn = (msg) => log(`${c.yellow}!${c.reset} ${msg}`);
+const error = (msg) => log(`${c.red}✗${c.reset} ${msg}`);
+
+function banner() {
+  log(`\n${c.bold}${c.cyan}  APEX Skills Installer${c.reset} ${c.dim}v${VERSION}${c.reset}`);
+  log(`${c.dim}  Platform engineering skills for AI agents${c.reset}\n`);
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  return {
+    claudeOnly: args.includes('--claude-only'),
+    kiroOnly: args.includes('--kiro-only'),
+    project: args.includes('--project'),
+    noSteering: args.includes('--no-steering'),
+    update: args.includes('--update'),
+    uninstall: args.includes('--uninstall'),
+    help: args.includes('--help') || args.includes('-h'),
+  };
+}
+
+function ask(question, defaultVal = '') {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const suffix = defaultVal ? ` [${defaultVal}]` : '';
+  return new Promise((res) => {
+    rl.question(`${c.cyan}?${c.reset} ${question}${suffix}: `, (answer) => {
+      rl.close();
+      res(answer.trim() || defaultVal);
+    });
+  });
+}
+
+function hasGit() {
+  try {
+    execSync('git --version', { stdio: 'pipe' });
+    return true;
+  } catch { return false; }
+}
+
+function cloneOrUpdate() {
+  if (existsSync(INSTALL_DIR)) {
+    info('Updating existing installation...');
+    try {
+      execSync('git pull --ff-only', { cwd: INSTALL_DIR, stdio: 'pipe' });
+      success('Updated to latest version');
+    } catch (e) {
+      warn('Git pull failed — try removing ~/.apex-skills and re-running');
+      throw e;
+    }
+  } else {
+    info('Cloning APEX skills repository...');
+    try {
+      execSync(`git clone --depth 1 ${REPO_URL} "${INSTALL_DIR}"`, { stdio: 'pipe' });
+      success('Repository cloned');
+    } catch (e) {
+      error('Failed to clone repository. Check your internet connection and git access.');
+      throw e;
+    }
+  }
+}
+
+function getSkills() {
+  const skillsDir = join(INSTALL_DIR, 'skills');
+  if (!existsSync(skillsDir)) return [];
+  return readdirSync(skillsDir).filter((name) => {
+    if (name === 'README.md' || name.startsWith('.')) return false;
+    const full = join(skillsDir, name);
+    try { return statSync(full).isDirectory(); } catch { return false; }
+  });
+}
+
+function ensureDir(dir) {
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+function safeSymlink(target, linkPath) {
+  if (existsSync(linkPath)) {
+    try {
+      const current = readlinkSync(linkPath);
+      if (resolve(current) === resolve(target)) return 'skip';
+    } catch { /* not a symlink */ }
+    unlinkSync(linkPath);
+  }
+  symlinkSync(target, linkPath);
+  return 'created';
+}
+
+function symlinkSkills(targetDir, skills) {
+  ensureDir(targetDir);
+  let count = 0;
+  for (const name of skills) {
+    const target = join(INSTALL_DIR, 'skills', name);
+    const link = join(targetDir, name);
+    const result = safeSymlink(target, link);
+    if (result === 'created') count++;
+  }
+  return count;
+}
+
+function symlinkSteeringClaude(commandsDir) {
+  const source = join(INSTALL_DIR, 'steering', 'commands', 'apex');
+  if (!existsSync(source)) { warn('No steering commands found in repo'); return; }
+  ensureDir(join(commandsDir));
+  const link = join(commandsDir, 'apex');
+  safeSymlink(source, link);
+  success(`Steering commands linked to ${c.dim}${link}${c.reset}`);
+}
+
+function symlinkSteeringKiro(steeringDir) {
+  const source = join(INSTALL_DIR, 'steering', 'workflows');
+  if (!existsSync(source)) { warn('No steering workflows found in repo'); return; }
+  ensureDir(steeringDir);
+  const files = readdirSync(source).filter((f) => f.endsWith('.md'));
+  for (const file of files) {
+    safeSymlink(join(source, file), join(steeringDir, file));
+  }
+  success(`Steering workflows linked to ${c.dim}${steeringDir}${c.reset} (${files.length} files)`);
+}
+
+function uninstall(flags) {
+  banner();
+  info('Uninstalling APEX skills...');
+  const dirs = [];
+  if (!flags.kiroOnly) dirs.push(join(HOME, '.claude', 'skills'));
+  if (!flags.claudeOnly) dirs.push(join(HOME, '.kiro', 'skills'));
+
+  let removed = 0;
+  for (const dir of dirs) {
+    if (!existsSync(dir)) continue;
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      try {
+        const target = readlinkSync(full);
+        if (resolve(target).startsWith(resolve(INSTALL_DIR))) {
+          unlinkSync(full);
+          removed++;
+        }
+      } catch { /* not a symlink or can't read */ }
+    }
+  }
+
+  // Remove steering symlinks
+  const claudeCmd = join(HOME, '.claude', 'commands', 'apex');
+  if (existsSync(claudeCmd)) { try { unlinkSync(claudeCmd); removed++; } catch {} }
+
+  const kiroSteering = join(HOME, '.kiro', 'steering');
+  if (existsSync(kiroSteering)) {
+    for (const f of readdirSync(kiroSteering)) {
+      const full = join(kiroSteering, f);
+      try {
+        const target = readlinkSync(full);
+        if (resolve(target).startsWith(resolve(INSTALL_DIR))) { unlinkSync(full); removed++; }
+      } catch {}
+    }
+  }
+
+  success(`Removed ${removed} symlinks`);
+
+  if (existsSync(INSTALL_DIR)) {
+    info(`Repository still at ${INSTALL_DIR}`);
+    info('Remove it manually with: rm -rf ~/.apex-skills');
+  }
+  log('');
+}
+
+function showHelp() {
+  banner();
+  log(`${c.bold}Usage:${c.reset}  npx apex-skills [flags]\n`);
+  log(`${c.bold}Flags:${c.reset}`);
+  log(`  --claude-only    Install for Claude Code only`);
+  log(`  --kiro-only      Install for Kiro CLI only`);
+  log(`  --project        Install to current project instead of global`);
+  log(`  --no-steering    Skip steering/commands setup`);
+  log(`  --update         Pull latest and re-symlink (non-interactive)`);
+  log(`  --uninstall      Remove symlinks (keeps cloned repo)`);
+  log(`  -h, --help       Show this help\n`);
+  log(`${c.bold}Examples:${c.reset}`);
+  log(`  npx apex-skills                   Interactive install`);
+  log(`  npx apex-skills --update          Update to latest skills`);
+  log(`  npx apex-skills --claude-only     Install for Claude Code only`);
+  log(`  npx apex-skills --project         Install into current project\n`);
+}
+
+async function main() {
+  const flags = parseArgs();
+
+  if (flags.help) { showHelp(); process.exit(0); }
+
+  if (platform() === 'win32') {
+    error('Windows is not supported (symlinks require elevated permissions).');
+    error('Use WSL (Windows Subsystem for Linux) instead.');
+    process.exit(1);
+  }
+
+  if (flags.uninstall) { uninstall(flags); process.exit(0); }
+
+  banner();
+
+  if (!hasGit()) {
+    error('git is required but not found in PATH.');
+    process.exit(1);
+  }
+
+  // Detect targets
+  const claudeDir = join(HOME, '.claude');
+  const kiroDir = join(HOME, '.kiro');
+  let installClaude = !flags.kiroOnly && existsSync(claudeDir);
+  let installKiro = !flags.claudeOnly && existsSync(kiroDir);
+
+  if (!installClaude && !installKiro && !flags.claudeOnly && !flags.kiroOnly) {
+    warn('Neither ~/.claude nor ~/.kiro found.');
+    const choice = await ask('Create directory for (claude/kiro/both)', 'claude');
+    if (choice === 'claude' || choice === 'both') { ensureDir(claudeDir); installClaude = true; }
+    if (choice === 'kiro' || choice === 'both') { ensureDir(kiroDir); installKiro = true; }
+    if (!installClaude && !installKiro) { error('No target selected.'); process.exit(1); }
+  }
+
+  if (flags.claudeOnly && !existsSync(claudeDir)) { ensureDir(claudeDir); installClaude = true; }
+  if (flags.kiroOnly && !existsSync(kiroDir)) { ensureDir(kiroDir); installKiro = true; }
+
+  // Clone or update
+  cloneOrUpdate();
+
+  const skills = getSkills();
+  if (skills.length === 0) { error('No skills found in repository.'); process.exit(1); }
+
+  info(`Found ${skills.length} skills`);
+
+  // Determine skill target directories
+  let claudeSkillsDir, kiroSkillsDir;
+  if (flags.project) {
+    const cwd = process.cwd();
+    claudeSkillsDir = join(cwd, '.claude', 'skills');
+    kiroSkillsDir = join(cwd, '.kiro', 'skills');
+  } else {
+    claudeSkillsDir = join(claudeDir, 'skills');
+    kiroSkillsDir = join(kiroDir, 'skills');
+  }
+
+  // Install skills
+  if (installClaude) {
+    const count = symlinkSkills(claudeSkillsDir, skills);
+    success(`Installed ${skills.length} skills to ${c.dim}${claudeSkillsDir}${c.reset}${count > 0 ? ` (${count} new)` : ''}`);
+  }
+  if (installKiro) {
+    const count = symlinkSkills(kiroSkillsDir, skills);
+    success(`Installed ${skills.length} skills to ${c.dim}${kiroSkillsDir}${c.reset}${count > 0 ? ` (${count} new)` : ''}`);
+  }
+
+  // Steering
+  let doSteering = !flags.noSteering;
+  if (doSteering && !flags.update) {
+    if (!flags.noSteering && !flags.claudeOnly && !flags.kiroOnly && !flags.update) {
+      const answer = await ask('Install steering workflows/commands? (y/n)', 'y');
+      doSteering = answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes';
+    }
+  }
+
+  if (doSteering) {
+    if (installClaude) {
+      const cmdDir = flags.project ? join(process.cwd(), '.claude', 'commands') : join(claudeDir, 'commands');
+      symlinkSteeringClaude(cmdDir);
+    }
+    if (installKiro) {
+      const stDir = flags.project ? join(process.cwd(), '.kiro', 'steering') : join(kiroDir, 'steering');
+      symlinkSteeringKiro(stDir);
+    }
+  }
+
+  // Summary
+  log('');
+  log(`${c.bold}${c.green}Done!${c.reset}\n`);
+  log(`${c.dim}  Skills: ${skills.join(', ')}${c.reset}\n`);
+  if (installClaude) log(`  ${c.bold}Claude Code:${c.reset} ask your agent about EKS best practices`);
+  if (installKiro) log(`  ${c.bold}Kiro CLI:${c.reset} use /apex commands for guided workflows`);
+  log(`\n  Update anytime: ${c.cyan}npx apex-skills --update${c.reset}`);
+  log('');
+}
+
+main().catch((e) => {
+  error(e.message || 'Unexpected error');
+  process.exit(1);
+});

--- a/misc/installer/package.json
+++ b/misc/installer/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "apex-skills",
+  "version": "1.0.0",
+  "description": "Install APEX platform engineering skills for Claude Code and Kiro CLI",
+  "bin": {
+    "apex-skills": "./bin/cli.mjs"
+  },
+  "type": "module",
+  "license": "MIT-0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws-samples/sample-apex-skills"
+  },
+  "keywords": ["aws", "eks", "platform-engineering", "ai-agent", "claude-code", "kiro", "skills"],
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/misc/update-pages.sh
+++ b/misc/update-pages.sh
@@ -336,6 +336,7 @@ build_skills_index() {
 ---
 sidebar_position: 3
 title: Skills
+description: "Browse all APEX skills for AWS platform engineering — EKS architecture, Terraform modules, upgrade readiness, cluster operations, and more."
 ---
 
 # Skills
@@ -429,6 +430,7 @@ build_examples_index() {
 ---
 sidebar_position: 5
 title: Examples
+description: "Hands-on walkthroughs demonstrating APEX skills against real AWS infrastructure — deploy, run, and assess platform engineering workflows."
 ---
 
 # Examples

--- a/misc/website/docs/examples/index.md
+++ b/misc/website/docs/examples/index.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 5
 title: Examples
+description: "Hands-on walkthroughs demonstrating APEX skills against real AWS infrastructure — deploy, run, and assess platform engineering workflows."
 ---
 
 # Examples

--- a/misc/website/docs/getting-started.md
+++ b/misc/website/docs/getting-started.md
@@ -7,7 +7,17 @@ title: Getting Started
 
 APEX skills are plain folders of markdown + scripts. Any agent harness that supports the [Agent Skills](https://agentskills.io/) standard can load them.
 
-## Claude Code
+## Quick Install (recommended)
+
+```bash
+npx apex-skills
+```
+
+The installer detects which tools you have (Claude Code, Kiro CLI, or both), clones the repo to `~/.apex-skills/`, and symlinks all skills + steering workflows into the right locations. Run `npx apex-skills --update` later to pull the latest skills.
+
+## Manual Install
+
+### Claude Code
 
 ```bash
 git clone https://github.com/aws-samples/sample-apex-skills.git
@@ -18,7 +28,7 @@ cp -r skills/* ~/.claude/skills/
 
 Restart Claude Code; the skills become available via `/<skill-name>`.
 
-## Kiro CLI
+### Kiro CLI
 
 ```bash
 git clone https://github.com/aws-samples/sample-apex-skills.git

--- a/misc/website/docs/getting-started.md
+++ b/misc/website/docs/getting-started.md
@@ -9,6 +9,8 @@ APEX skills are plain folders of markdown + scripts. Any agent harness that supp
 
 ## Quick Install (recommended)
 
+> **Prerequisites:** [Node.js 18+](https://nodejs.org/) and [git](https://git-scm.com/) must be installed.
+
 ```bash
 npx apex-skills
 ```

--- a/misc/website/docs/skills/index.md
+++ b/misc/website/docs/skills/index.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 3
 title: Skills
+description: "Browse all APEX skills for AWS platform engineering — EKS architecture, Terraform modules, upgrade readiness, cluster operations, and more."
 ---
 
 # Skills

--- a/misc/website/docusaurus.config.ts
+++ b/misc/website/docusaurus.config.ts
@@ -27,6 +27,37 @@ const config: Config = {
     locales: ['en'],
   },
 
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: {type: 'application/ld+json'},
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@graph': [
+          {
+            '@type': 'WebSite',
+            name: 'APEX Skills',
+            url: 'https://aws-samples.github.io/sample-apex-skills/',
+            description: 'Curated agentic AI skills for AWS platform engineering, delivered through any coding agent.',
+          },
+          {
+            '@type': 'Organization',
+            name: 'AWS Samples',
+            url: 'https://github.com/aws-samples',
+          },
+          {
+            '@type': 'SoftwareSourceCode',
+            name: 'sample-apex-skills',
+            codeRepository: 'https://github.com/aws-samples/sample-apex-skills',
+            programmingLanguage: ['TypeScript', 'Python', 'Bash', 'HCL'],
+            license: 'https://opensource.org/licenses/MIT-0',
+            runtimePlatform: 'Claude Code, Kiro CLI',
+          },
+        ],
+      }),
+    },
+  ],
+
   presets: [
     [
       'classic',
@@ -34,16 +65,28 @@ const config: Config = {
         docs: {
           sidebarPath: './sidebars.ts',
           editUrl: 'https://github.com/aws-samples/sample-apex-skills/edit/main/misc/website/',
+          showLastUpdateTime: true,
         },
         blog: false,
         theme: {
           customCss: './src/css/custom.css',
+        },
+        sitemap: {
+          lastmod: 'date',
+          changefreq: null,
+          priority: null,
         },
       } satisfies Preset.Options,
     ],
   ],
 
   themeConfig: {
+    metadata: [
+      {property: 'og:image', content: 'https://aws-samples.github.io/sample-apex-skills/img/og-image.svg'},
+      {name: 'twitter:image', content: 'https://aws-samples.github.io/sample-apex-skills/img/og-image.svg'},
+      {name: 'twitter:card', content: 'summary_large_image'},
+      {name: 'keywords', content: 'AWS, EKS, platform engineering, AI agent skills, Claude Code, Kiro CLI, Kubernetes, infrastructure as code, agentic AI, DevOps automation'},
+    ],
     navbar: {
       title: 'APEX Skills',
       logo: {

--- a/misc/website/src/css/custom.css
+++ b/misc/website/src/css/custom.css
@@ -731,6 +731,53 @@
   }
 }
 
+/* Featured skills grid */
+.apex-featured {
+  padding: 4rem 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.apex-featured__title {
+  text-align: center;
+  font-size: 1.8rem;
+  margin-bottom: 2rem;
+}
+
+.apex-featured__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+.apex-featured__card {
+  display: block;
+  padding: 1.5rem;
+  border-radius: 12px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.apex-featured__card:hover {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  text-decoration: none;
+  color: inherit;
+}
+
+.apex-featured__card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.apex-featured__card p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
 /* Interactive element transitions */
 a, button, .navbar__link, .menu__link {
   transition: var(--apex-transition);

--- a/misc/website/src/pages/index.tsx
+++ b/misc/website/src/pages/index.tsx
@@ -37,7 +37,7 @@ function HeroBanner() {
 function ValueProps() {
   return (
     <section className="apex-values">
-      <h2 className="apex-values__title">Why APEX?</h2>
+      <h2 className="apex-values__title">Why Platform Engineers Use APEX Skills</h2>
       <div className="apex-values__grid">
         <div className="apex-values__item">
           <h3>Agent-native skills</h3>
@@ -67,10 +67,64 @@ function ValueProps() {
   );
 }
 
+function FeaturedSkills() {
+  const skills = [
+    {
+      name: 'EKS Best Practices',
+      path: '/docs/skills/eks-best-practices/',
+      description:
+        'Architecture and design guidance for Amazon EKS clusters. Covers compute strategy with Karpenter and Auto Mode, multi-tenant isolation, VPC planning, Pod Identity, upgrade strategies, and cost optimization for production Kubernetes workloads.',
+    },
+    {
+      name: 'EKS Upgrade Check',
+      path: '/docs/skills/eks-upgrade-check/',
+      description:
+        'Automated readiness assessment for EKS version upgrades. Checks deprecated APIs, add-on compatibility, node health, and workload risks across 8 categories, producing a 0–100 readiness score with prioritized remediation steps.',
+    },
+    {
+      name: 'Terraform Skill',
+      path: '/docs/skills/terraform-skill/',
+      description:
+        'Infrastructure as Code expertise for AWS with Terraform and OpenTofu. Module creation, native test framework, CI/CD pipelines, state management, security scanning with Trivy and Checkov, and architecture decisions.',
+    },
+    {
+      name: 'EKS Reconnaissance',
+      path: '/docs/skills/eks-recon/',
+      description:
+        'Cluster discovery and environment mapping for Amazon EKS. Detects compute strategy, IaC tooling, CI/CD pipelines, add-on inventory, networking topology, security posture, and observability configuration automatically.',
+    },
+    {
+      name: 'Skill Creator',
+      path: '/docs/skills/skill-creator/',
+      description:
+        'Author new agentic skills following the agentskills.io specification. Handles frontmatter constraints, progressive disclosure, eval scaffolding, and the iterate-with-evals loop for quality assurance.',
+    },
+    {
+      name: 'Steering Workflow Creator',
+      path: '/docs/skills/steering-workflow-creator/',
+      description:
+        'Build phased multi-skill workflows for complex platform operations. Covers workflow conventions, tool routing between knowledge and live MCP, and automated lint validation before deployment.',
+    },
+  ];
+  return (
+    <section className="apex-featured">
+      <h2 className="apex-featured__title">Featured Platform Engineering Skills</h2>
+      <div className="apex-featured__grid">
+        {skills.map((s) => (
+          <Link key={s.name} className="apex-featured__card" to={s.path}>
+            <h3>{s.name}</h3>
+            <p>{s.description}</p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 function HowItWorks() {
   return (
     <section className="apex-steps">
-      <h2 className="apex-steps__title">How it works</h2>
+      <h2 className="apex-steps__title">How APEX Skills Work with Your AI Coding Agent</h2>
       <div className="apex-steps__timeline">
         <div className="apex-steps__item">
           <span className="apex-steps__number">1</span>
@@ -111,10 +165,11 @@ function CtaSection() {
 export default function Home(): ReactNode {
   const {siteConfig} = useDocusaurusContext();
   return (
-    <Layout title={siteConfig.title} description={siteConfig.tagline}>
+    <Layout title="APEX Skills — AWS Platform Engineering for AI Agents" description="Curated agentic AI skills for AWS platform engineering. 12 open-source skills for EKS, Terraform, and infrastructure workflows, delivered through any coding agent.">
       <main className="landing-main">
         <HeroBanner />
         <ValueProps />
+        <FeaturedSkills />
         <HowItWorks />
         <CtaSection />
       </main>

--- a/misc/website/static/img/og-image.svg
+++ b/misc/website/static/img/og-image.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1e293b"/>
+    </linearGradient>
+    <linearGradient id="chevron-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff9900"/>
+      <stop offset="100%" stop-color="#ffb84d"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <!-- Subtle grid pattern -->
+  <g opacity="0.03">
+    <line x1="0" y1="0" x2="1200" y2="630" stroke="#ffffff" stroke-width="1"/>
+    <line x1="200" y1="0" x2="1200" y2="500" stroke="#ffffff" stroke-width="1"/>
+    <line x1="400" y1="0" x2="1200" y2="400" stroke="#ffffff" stroke-width="1"/>
+    <line x1="0" y1="200" x2="1000" y2="630" stroke="#ffffff" stroke-width="1"/>
+    <line x1="0" y1="400" x2="800" y2="630" stroke="#ffffff" stroke-width="1"/>
+  </g>
+
+  <!-- Geometric chevron/arrow motif -->
+  <g transform="translate(100, 180)">
+    <!-- Outer chevron -->
+    <path d="M 0 130 L 80 65 L 160 130 L 80 195 Z" fill="none" stroke="url(#chevron-grad)" stroke-width="4" opacity="0.3"/>
+    <!-- Middle chevron -->
+    <path d="M 30 130 L 80 85 L 130 130 L 80 175 Z" fill="none" stroke="url(#chevron-grad)" stroke-width="4" opacity="0.6"/>
+    <!-- Inner chevron (filled) -->
+    <path d="M 55 130 L 80 108 L 105 130 L 80 152 Z" fill="url(#chevron-grad)"/>
+    <!-- Arrow accent -->
+    <path d="M 80 60 L 80 30 L 95 45" fill="none" stroke="#ff9900" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <!-- Title -->
+  <text x="320" y="260" font-family="system-ui, -apple-system, sans-serif" font-size="72" font-weight="700" fill="#ffffff">APEX Skills</text>
+
+  <!-- Subtitle -->
+  <text x="320" y="320" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="400" fill="#94a3b8">Curated AI skills for AWS platform engineering</text>
+
+  <!-- Divider line -->
+  <rect x="320" y="360" width="120" height="3" rx="1.5" fill="#ff9900"/>
+
+  <!-- Bottom badges -->
+  <g transform="translate(320, 420)">
+    <!-- Badge: 12 Skills -->
+    <rect x="0" y="0" width="130" height="40" rx="20" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <text x="65" y="26" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="500" fill="#e2e8f0" text-anchor="middle">12 Skills</text>
+
+    <!-- Badge: MIT-0 -->
+    <rect x="150" y="0" width="100" height="40" rx="20" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <text x="200" y="26" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="500" fill="#e2e8f0" text-anchor="middle">MIT-0</text>
+
+    <!-- Badge: Open Source -->
+    <rect x="270" y="0" width="150" height="40" rx="20" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+    <text x="345" y="26" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="500" fill="#e2e8f0" text-anchor="middle">Open Source</text>
+  </g>
+
+  <!-- AWS-style accent bar at top -->
+  <rect x="0" y="0" width="1200" height="4" fill="#ff9900"/>
+
+  <!-- Bottom border accent -->
+  <rect x="0" y="626" width="1200" height="4" fill="#ff9900" opacity="0.5"/>
+</svg>

--- a/misc/website/static/llms.txt
+++ b/misc/website/static/llms.txt
@@ -1,0 +1,39 @@
+# APEX Skills (Agentic Platform Engineering eXperience)
+
+> Curated agentic AI skills for AWS platform engineering, delivered through any coding agent
+
+## About
+
+- Repository: https://github.com/aws-samples/sample-apex-skills
+- Documentation: https://aws-samples.github.io/sample-apex-skills/
+- License: MIT-0
+- Spec: https://agentskills.io
+
+## Installation
+
+### Claude Code
+```
+claude mcp add-from-apex-skills
+```
+
+### Kiro CLI
+```
+kiro skills add apex
+```
+
+See the documentation site for full installation instructions.
+
+## Skills Catalog
+
+- **eks-best-practices**: EKS design, architecture, and configuration decisions — compute strategy, multi-tenant isolation, networking, IAM, security, cost, and observability
+- **eks-build**: Generate complete production-ready EKS Terraform projects with optional ArgoCD GitOps, air-gapped support, and 29+ addon configurations
+- **eks-design**: Generate EKS architecture design documents with Mermaid diagrams, ADRs, security architecture, and Well-Architected validation
+- **eks-mcp-server**: Setup and configure the EKS MCP Server for live cluster operations — list clusters, read resources, troubleshoot pods, check upgrade insights
+- **eks-operation-review**: Structured EKS operational excellence assessment across 10 areas with GREEN/AMBER/RED ratings and prioritized recommendations
+- **eks-platform-engineering**: Internal Developer Platform design on EKS — Backstage, ArgoCD, Kargo, progressive delivery, golden paths, and DORA metrics
+- **eks-recon**: EKS cluster reconnaissance and environment discovery — compute strategy, IaC tooling, CI/CD, add-ons, networking, and security posture
+- **eks-upgrade-check**: Assess EKS cluster upgrade readiness with a 0-100 score across 8 areas including deprecated APIs, add-on compatibility, and workload risks
+- **skill-creator**: Create new skills, modify existing skills, run evals, benchmark performance, and optimize triggering accuracy
+- **steering-workflow-creator**: Author steering workflows for any AWS service with matching slash-command shims and tool routing
+- **terraform-skill**: Terraform and OpenTofu — modules, native tests, Terratest, CI/CD pipelines, state debugging, and security scanning
+- **update-docs**: Audit and sync all documentation surfaces after skill changes — README markers, Docusaurus site, and prose references

--- a/misc/website/static/robots.txt
+++ b/misc/website/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://aws-samples.github.io/sample-apex-skills/sitemap.xml


### PR DESCRIPTION
## Summary

- **SEO optimization (53 → ~88 projected)**: robots.txt, llms.txt (AI crawler manifest), OG social card, JSON-LD structured data (WebSite + Organization + SoftwareSourceCode), sitemap `lastmod`, meta tags (OG/Twitter/keywords), homepage keyword-rich content with FeaturedSkills section, improved generated index descriptions
- **NPX installer**: `npx apex-skills` — zero-dependency CLI that detects Claude Code / Kiro CLI, clones repo to `~/.apex-skills/`, symlinks skills + steering. Supports `--update`, `--uninstall`, `--project`, `--claude-only`, `--kiro-only` flags
- **Docs**: getting-started page and root README updated with quick-install section

Closes #27

## Files changed (14 files, +662/-5)

| Area | Files |
|------|-------|
| SEO static | `robots.txt`, `llms.txt`, `og-image.svg` |
| SEO config | `docusaurus.config.ts` (headTags, metadata, sitemap, showLastUpdateTime) |
| SEO content | `index.tsx` (Layout overrides, H2 keywords, FeaturedSkills), `custom.css` |
| SEO generator | `update-pages.sh` (index description frontmatter) |
| Installer | `misc/installer/{package.json,bin/cli.mjs,README.md}` |
| Docs | `getting-started.md`, `README.md` |

## Pipeline verification

- `npm run build` — 0 broken links
- `update-all-references.sh --check` — passes
- `update-pages.sh` regenerated (index descriptions match)
- JSON-LD, OG meta, robots.txt, sitemap lastmod all confirmed in built HTML

## Test plan

- [ ] `cd misc/website && npm run build` — 0 broken links
- [ ] `./misc/update-all-references.sh --check` passes
- [ ] `./misc/update-pages.sh --check` passes
- [ ] Preview homepage at localhost:3000 — FeaturedSkills grid renders, H2s updated
- [ ] `grep "ld+json" build/index.html` — JSON-LD present
- [ ] `node misc/installer/bin/cli.mjs --help` — prints usage
- [ ] `npx ./misc/installer --update` — runs without error (dry smoke)

Generated with Claude Code