### PR TITLE
fix(ci): vendor-update skips all skills on manual dispatch

### DIFF
--- a/.github/workflows/vendor-update.yml
+++ b/.github/workflows/vendor-update.yml
@@ -13,6 +13,7 @@ on:
       skill:
         description: 'Sync a specific skill (blank = all)'
         required: false
+        default: all
         type: choice
         options:
           - all
@@ -54,6 +55,7 @@ jobs:
         if: >-
           github.event_name == 'workflow_dispatch' &&
           inputs.skill != 'all' &&
+          inputs.skill != '' &&
           inputs.skill != matrix.skill.name
         run: echo "Skipping ${{ matrix.skill.name }} (not selected)" && exit 0
 
@@ -61,6 +63,7 @@ jobs:
         if: >-
           github.event_name != 'workflow_dispatch' ||
           inputs.skill == 'all' ||
+          inputs.skill == '' ||
           inputs.skill == matrix.skill.name
 
       - name: Check upstream for new commits
@@ -68,6 +71,7 @@ jobs:
         if: >-
           github.event_name != 'workflow_dispatch' ||
           inputs.skill == 'all' ||
+          inputs.skill == '' ||
           inputs.skill == matrix.skill.name
         run: |
           # Get upstream HEAD


### PR DESCRIPTION
## Summary

- Adds `default: all` to the `skill` input so CLI dispatch without `-f skill=...` works
- Adds `inputs.skill == ''` fallback in skip/run conditions for safety

## What happened

`gh workflow run vendor-update.yml` (no `-f skill=all`) sent empty string for `inputs.skill`. The skip condition `inputs.skill != 'all'` evaluated true → all 4 jobs skipped immediately.

## Test plan

- [ ] Merge → workflow triggers on push (path match on `vendor-update.yml`)
- [ ] Confirm all 4 skills are checked (not skipped)
- [ ] Confirm PRs opened for terraform-skill + eks-upgrade-check