### PR TITLE
feat(installer): add --branch and --version flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,22 +43,18 @@ sample-apex-skills/
 npx apex-skills
 ```
 
-Detects Claude Code and/or Kiro CLI, clones the repo, and symlinks all skills + steering into the right locations. Run `npx apex-skills --update` to pull the latest.
-
-### Option A: Just the Skills
-
-Use the skills with any agent that supports the [Agent Skills standard](https://agentskills.io/). Skills are self-contained — clone and point your tool at them.
+Detects Claude Code and/or Kiro CLI, clones the repo to `~/.apex-skills/`, and symlinks all skills + steering into the right locations.
 
 ```bash
-git clone https://github.com/aws-samples/sample-apex-skills.git
-cd sample-apex-skills
+npx apex-skills --update              # Pull latest skills
+npx apex-skills --version v1.0.0      # Pin to a specific release
+npx apex-skills --branch feat/new-eks # Install from a branch
+npx apex-skills --help                # See all options
 ```
 
-Each skill lives in `skills/{skill-name}/` with a `SKILL.md` (frontmatter + instructions) and optional `references/`, `scripts/`, and `assets/` directories. See [skills/README.md](skills/README.md) for details.
+### Manual Install
 
-### Option B: Skills + Steering (Guided Experience)
-
-For a structured engagement experience — where the agent follows a questionnaire, enforces checkpoints, and validates output quality — add the steering files.
+If you prefer not to use npx, clone the repo and copy skills directly.
 
 #### Claude Code
 
@@ -66,24 +62,16 @@ For a structured engagement experience — where the agent follows a questionnai
 git clone https://github.com/aws-samples/sample-apex-skills.git
 cd sample-apex-skills
 
-# One-time setup — symlink skills, steering + commands into .claude/
-mkdir -p .claude/skills .claude/commands
-for skill in skills/*/; do ln -sfn "../../$skill" ".claude/skills/$(basename $skill)"; done
-ln -sfn ../../steering/commands/apex .claude/commands/apex
-ln -sfn ../steering .claude/steering
-
-# Make steering available at a fixed absolute path for slash commands
+mkdir -p ~/.claude/skills ~/.claude/commands
+cp -r skills/* ~/.claude/skills/
+ln -sfn "$(pwd)/steering/commands/apex" ~/.claude/commands/apex
 ln -sfn "$(pwd)/steering" ~/.claude/apex-steering
 ```
 
-> Claude Code walks up to the git root to find `.claude/`, so commands work from **any subdirectory** in the repo. The `~/.claude/apex-steering` symlink gives slash commands an absolute path to load steering files instantly.
-
-**Usage:**
-1. Start a Claude Code session from anywhere in the repo
-2. Use slash commands:
-   - `/apex:eks` — hub that auto-routes based on your request
-   - `/apex:eks-design` — *"Help me design an EKS cluster"*
-   - `/apex:eks-upgrade-check` — *"Is my cluster ready to upgrade to 1.32?"*
+**Usage:** Start a Claude Code session and use slash commands:
+- `/apex:eks` — hub that auto-routes based on your request
+- `/apex:eks-design` — *"Help me design an EKS cluster"*
+- `/apex:eks-upgrade-check` — *"Is my cluster ready to upgrade to 1.32?"*
 
 #### Kiro CLI
 
@@ -91,26 +79,14 @@ ln -sfn "$(pwd)/steering" ~/.claude/apex-steering
 git clone https://github.com/aws-samples/sample-apex-skills.git
 cd sample-apex-skills
 
-# Skills — symlink into .kiro/skills/
-mkdir -p .kiro/skills
-for skill in skills/*/; do
-  name=$(basename "$skill")
-  ln -sfn "../../skills/$name" ".kiro/skills/$name"
-done
-
-# Steering — copy for Kiro IDE slash commands
-mkdir -p .kiro/steering
-cp steering/eks.md .kiro/steering/eks.md
+mkdir -p ~/.kiro/skills ~/.kiro/steering
+cp -r skills/* ~/.kiro/skills/
+cp steering/workflows/*.md ~/.kiro/steering/
 ```
 
-**Usage:**
-```bash
-kiro-cli chat
-# Then in the session:
-/model claude-opus-4.5
-/context add steering/eks.md
-# Ask: "Help me design an EKS cluster"
-```
+#### Other Agent Harnesses
+
+Skills follow the [Agent Skills standard](https://agentskills.io/). Each skill lives in `skills/{skill-name}/` with a `SKILL.md` and optional `references/`, `scripts/`, and `assets/` directories. Clone and point your tool at them — see [skills/README.md](skills/README.md) for the layout.
 
 <!-- SKILLS_REFERENCE_START -->
 ## Skills Reference

--- a/misc/installer/README.md
+++ b/misc/installer/README.md
@@ -29,6 +29,8 @@ npx apex-skills --update
 | `--project` | Install to current project directory instead of global |
 | `--no-steering` | Skip steering/commands setup |
 | `--update` | Pull latest and re-symlink (non-interactive) |
+| `--version <tag>` | Pin to a specific release (e.g. `v1.0.0`) |
+| `--branch <name>` | Use a specific branch instead of main |
 | `--uninstall` | Remove symlinks (keeps cloned repo) |
 | `-h, --help` | Show help |
 

--- a/misc/installer/bin/cli.mjs
+++ b/misc/installer/bin/cli.mjs
@@ -5,7 +5,7 @@ import { homedir, platform } from 'os';
 import { execSync } from 'child_process';
 import { createInterface } from 'readline';
 
-const VERSION = '1.0.0';
+const VERSION = '1.1.0';
 const REPO_URL = 'https://github.com/aws-samples/sample-apex-skills.git';
 const HOME = homedir();
 const INSTALL_DIR = join(HOME, '.apex-skills');

--- a/misc/installer/bin/cli.mjs
+++ b/misc/installer/bin/cli.mjs
@@ -35,6 +35,10 @@ function banner() {
 
 function parseArgs() {
   const args = process.argv.slice(2);
+  const getVal = (flag) => {
+    const i = args.indexOf(flag);
+    return i !== -1 && i + 1 < args.length ? args[i + 1] : null;
+  };
   return {
     claudeOnly: args.includes('--claude-only'),
     kiroOnly: args.includes('--kiro-only'),
@@ -43,6 +47,8 @@ function parseArgs() {
     update: args.includes('--update'),
     uninstall: args.includes('--uninstall'),
     help: args.includes('--help') || args.includes('-h'),
+    branch: getVal('--branch'),
+    version: getVal('--version') || getVal('-v'),
   };
 }
 
@@ -64,21 +70,36 @@ function hasGit() {
   } catch { return false; }
 }
 
-function cloneOrUpdate() {
+function cloneOrUpdate(flags) {
+  const ref = flags.version || flags.branch;
   if (existsSync(INSTALL_DIR)) {
-    info('Updating existing installation...');
-    try {
-      execSync('git pull --ff-only', { cwd: INSTALL_DIR, stdio: 'pipe' });
-      success('Updated to latest version');
-    } catch (e) {
-      warn('Git pull failed — try removing ~/.apex-skills and re-running');
-      throw e;
+    if (ref) {
+      info(`Switching to ${flags.version ? `version ${ref}` : `branch ${ref}`}...`);
+      try {
+        execSync('git fetch --tags --force', { cwd: INSTALL_DIR, stdio: 'pipe' });
+        execSync(`git checkout ${ref}`, { cwd: INSTALL_DIR, stdio: 'pipe' });
+        if (flags.branch) execSync('git pull --ff-only', { cwd: INSTALL_DIR, stdio: 'pipe' });
+        success(`Now on ${ref}`);
+      } catch (e) {
+        error(`Failed to checkout ${ref}. Run: git -C ~/.apex-skills tag -l`);
+        throw e;
+      }
+    } else {
+      info('Updating existing installation...');
+      try {
+        execSync('git pull --ff-only', { cwd: INSTALL_DIR, stdio: 'pipe' });
+        success('Updated to latest version');
+      } catch (e) {
+        warn('Git pull failed — try removing ~/.apex-skills and re-running');
+        throw e;
+      }
     }
   } else {
     info('Cloning APEX skills repository...');
+    const branchFlag = ref ? ` --branch ${ref}` : '';
     try {
-      execSync(`git clone --depth 1 ${REPO_URL} "${INSTALL_DIR}"`, { stdio: 'pipe' });
-      success('Repository cloned');
+      execSync(`git clone --depth 1${branchFlag} ${REPO_URL} "${INSTALL_DIR}"`, { stdio: 'pipe' });
+      success(`Repository cloned${ref ? ` (${ref})` : ''}`);
     } catch (e) {
       error('Failed to clone repository. Check your internet connection and git access.');
       throw e;
@@ -194,24 +215,33 @@ function showHelp() {
   banner();
   log(`${c.bold}Usage:${c.reset}  npx apex-skills [flags]\n`);
   log(`${c.bold}Flags:${c.reset}`);
-  log(`  --claude-only    Install for Claude Code only`);
-  log(`  --kiro-only      Install for Kiro CLI only`);
-  log(`  --project        Install to current project instead of global`);
-  log(`  --no-steering    Skip steering/commands setup`);
-  log(`  --update         Pull latest and re-symlink (non-interactive)`);
-  log(`  --uninstall      Remove symlinks (keeps cloned repo)`);
-  log(`  -h, --help       Show this help\n`);
+  log(`  --claude-only        Install for Claude Code only`);
+  log(`  --kiro-only          Install for Kiro CLI only`);
+  log(`  --project            Install to current project instead of global`);
+  log(`  --no-steering        Skip steering/commands setup`);
+  log(`  --update             Pull latest and re-symlink (non-interactive)`);
+  log(`  --version <tag>      Pin to a specific release (e.g. v1.0.0)`);
+  log(`  --branch <name>      Use a specific branch instead of main`);
+  log(`  --uninstall          Remove symlinks (keeps cloned repo)`);
+  log(`  -h, --help           Show this help\n`);
   log(`${c.bold}Examples:${c.reset}`);
-  log(`  npx apex-skills                   Interactive install`);
-  log(`  npx apex-skills --update          Update to latest skills`);
-  log(`  npx apex-skills --claude-only     Install for Claude Code only`);
-  log(`  npx apex-skills --project         Install into current project\n`);
+  log(`  npx apex-skills                        Interactive install`);
+  log(`  npx apex-skills --update               Update to latest skills`);
+  log(`  npx apex-skills --version v1.0.0       Pin to release v1.0.0`);
+  log(`  npx apex-skills --branch feat/new-eks  Install from a branch`);
+  log(`  npx apex-skills --claude-only          Install for Claude Code only`);
+  log(`  npx apex-skills --project              Install into current project\n`);
 }
 
 async function main() {
   const flags = parseArgs();
 
   if (flags.help) { showHelp(); process.exit(0); }
+
+  if (flags.branch && flags.version) {
+    error('Cannot use --branch and --version together. Pick one.');
+    process.exit(1);
+  }
 
   if (platform() === 'win32') {
     error('Windows is not supported (symlinks require elevated permissions).');
@@ -246,7 +276,7 @@ async function main() {
   if (flags.kiroOnly && !existsSync(kiroDir)) { ensureDir(kiroDir); installKiro = true; }
 
   // Clone or update
-  cloneOrUpdate();
+  cloneOrUpdate(flags);
 
   const skills = getSkills();
   if (skills.length === 0) { error('No skills found in repository.'); process.exit(1); }

--- a/misc/installer/package.json
+++ b/misc/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-skills",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Install APEX platform engineering skills for Claude Code and Kiro CLI",
   "bin": {
     "apex-skills": "./bin/cli.mjs"

--- a/misc/website/docs/getting-started.md
+++ b/misc/website/docs/getting-started.md
@@ -7,7 +7,7 @@ title: Getting Started
 
 APEX skills are plain folders of markdown + scripts. Any agent harness that supports the [Agent Skills](https://agentskills.io/) standard can load them.
 
-## Quick Install (recommended)
+## NPX Installer (recommended)
 
 > **Prerequisites:** [Node.js 18+](https://nodejs.org/) and [git](https://git-scm.com/) must be installed.
 
@@ -15,29 +15,47 @@ APEX skills are plain folders of markdown + scripts. Any agent harness that supp
 npx apex-skills
 ```
 
-The installer detects which tools you have (Claude Code, Kiro CLI, or both), clones the repo to `~/.apex-skills/`, and symlinks all skills + steering workflows into the right locations. Run `npx apex-skills --update` later to pull the latest skills.
+The installer detects which tools you have (Claude Code, Kiro CLI, or both), clones the repo to `~/.apex-skills/`, and symlinks all skills + steering workflows into the right locations.
+
+```bash
+npx apex-skills --update              # Pull latest skills
+npx apex-skills --version v1.0.0      # Pin to a specific release
+npx apex-skills --branch feat/new-eks # Install from a branch
+npx apex-skills --help                # See all options
+```
 
 ## Manual Install
+
+If you prefer not to use npx, clone the repo and copy skills directly.
 
 ### Claude Code
 
 ```bash
 git clone https://github.com/aws-samples/sample-apex-skills.git
 cd sample-apex-skills
-mkdir -p ~/.claude/skills
+
+mkdir -p ~/.claude/skills ~/.claude/commands
 cp -r skills/* ~/.claude/skills/
+ln -sfn "$(pwd)/steering/commands/apex" ~/.claude/commands/apex
+ln -sfn "$(pwd)/steering" ~/.claude/apex-steering
 ```
 
-Restart Claude Code; the skills become available via `/<skill-name>`.
+Restart Claude Code; skills become available via `/<skill-name>` and steering via `/apex:*`.
 
 ### Kiro CLI
 
 ```bash
 git clone https://github.com/aws-samples/sample-apex-skills.git
 cd sample-apex-skills
-mkdir -p ~/.kiro/skills
+
+mkdir -p ~/.kiro/skills ~/.kiro/steering
 cp -r skills/* ~/.kiro/skills/
+cp steering/workflows/*.md ~/.kiro/steering/
 ```
+
+### Other Agent Harnesses
+
+Skills follow the [Agent Skills](https://agentskills.io/) standard. Clone and point your tool at `skills/{skill-name}/` — each contains a `SKILL.md` and optional `references/` directory.
 
 ## Verify
 

--- a/misc/website/src/pages/index.tsx
+++ b/misc/website/src/pages/index.tsx
@@ -140,8 +140,8 @@ function HowItWorks() {
       <div className="apex-steps__timeline">
         <div className="apex-steps__item">
           <span className="apex-steps__number">1</span>
-          <h3>Add the skill</h3>
-          <p>skills:<br />&nbsp;&nbsp;- /path/to/sample-apex-skills/skills/eks-recon</p>
+          <h3>Install</h3>
+          <p>npx apex-skills</p>
         </div>
         <div className="apex-steps__item">
           <span className="apex-steps__number">2</span>


### PR DESCRIPTION
## Summary

- Adds `--version <tag>` flag to pin to a specific release (e.g. `npx apex-skills --version v1.0.0`)
- Adds `--branch <name>` flag to install from a specific branch (e.g. `npx apex-skills --branch feat/new-eks`)
- Mutually exclusive — errors cleanly if both specified
- Works for both fresh installs (passes `--branch` to `git clone`) and existing installs (fetches + checkouts)

## Usage

```bash
# Pin to a release
npx apex-skills --version v1.0.0

# Track a feature branch
npx apex-skills --branch feat/new-eks

# Update to latest (existing behavior unchanged)
npx apex-skills --update
```

## Test plan

- [ ] Fresh install with `--version v1.0.0` → clones at that tag
- [ ] Existing install + `--version v1.0.0` → fetches and checks out tag
- [ ] Fresh install with `--branch main` → clones main
- [ ] `--branch` + `--version` together → error message
- [ ] No flags → existing behavior unchanged (clone default branch)
- [ ] `--help` → shows new flags