### PR TITLE
fix(vendor-update): run update-pages.sh in vendor sync workflow

### DIFF
--- a/.github/workflows/vendor-update.yml
+++ b/.github/workflows/vendor-update.yml
@@ -114,6 +114,9 @@ jobs:
           if [ -x misc/update-all-references.sh ]; then
             ./misc/update-all-references.sh || true
           fi
+          if [ -x misc/update-pages.sh ]; then
+            ./misc/update-pages.sh || true
+          fi
 
       - name: Check for actual diff
         id: diff

--- a/misc/website/docs/skills/eks-upgrade-check/references/deprecated-apis.md
+++ b/misc/website/docs/skills/eks-upgrade-check/references/deprecated-apis.md
@@ -31,7 +31,8 @@ Use the EKS Insights API with category `UPGRADE_READINESS` — this is the most 
 
 ### Step 2: Scan Live Resources
 
-For each resource type below, list resources and check their `apiVersion` field against the deprecation table.
+Run **two scans in parallel** for each resource type. Both are required because
+they catch different failure modes.
 
 **Resource types to scan:**
 - Deployments, DaemonSets, StatefulSets, ReplicaSets
@@ -43,6 +44,53 @@ For each resource type below, list resources and check their `apiVersion` field 
 - CustomResourceDefinitions
 - ValidatingWebhookConfigurations, MutatingWebhookConfigurations
 - FlowSchemas, PriorityLevelConfigurations
+
+#### Step 2a: Object `apiVersion` scan
+
+For each resource type, list resources and check the live `apiVersion` field
+against the deprecation table in Step 3.
+
+#### Step 2b: `managedFields` apiVersion scan
+
+For each resource, inspect every entry in `metadata.managedFields[]` and check
+its `apiVersion` against the deprecation table in Step 3. The API server may
+auto-convert resources to the storage version, so Step 2a alone misses
+manifests originally applied under a deprecated apiVersion. `managedFields`
+preserves the apiVersion used by every writer (kubectl, controllers, Argo CD,
+Flux, Helm), so this scan covers all configuration sources.
+
+```bash
+kubectl get <kind> --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}{"/"}{.metadata.name}{"\t"}{range .metadata.managedFields[*]}{.manager}{"="}{.apiVersion}{","}{end}{"\n"}{end}'
+```
+
+Output is `namespace/name<TAB>manager1=apiVersion1,manager2=apiVersion2,...`.
+The `manager` portion identifies which writer used each apiVersion (e.g.,
+`kubectl-client-side-apply`, `argocd-application-controller`, controller
+names) — this points to where the source manifest needs to be updated.
+
+**Anti-pattern — do not pre-filter with naïve substring greps.**
+
+```bash
+# WRONG — `v1` is a prefix of `v1beta3`, so `grep -v` strips both lines.
+... | grep -v "flowcontrol.apiserver.k8s.io/v1"
+```
+
+A single resource often has multiple `manager=apiVersion` entries on the
+same line (e.g., a controller writing `v1` plus the user writing `v1beta3`).
+Filter-then-decide pipelines drop the line entirely as soon as any benign
+apiVersion matches. Walk the full output line by line and check each
+`manager=apiVersion` pair against the deprecation table in Step 3 instead.
+
+**Anti-pattern — do not substitute `-o yaml` or `-o json`.**
+
+```bash
+# WRONG — kubectl 1.21+ hides managedFields from -o yaml / -o json by default,
+# so this scan returns false negatives.
+kubectl get <kind> -A -o yaml | grep apiVersion
+```
+
+Use the `-o jsonpath` form above. It accesses `managedFields` directly and
+is not affected by the default-hide behavior.
 
 ### Step 3: Check for Removed APIs by Target Version
 
@@ -61,18 +109,26 @@ For each resource type below, list resources and check their `apiVersion` field 
 
 ### Step 4: Classify Findings
 
-For each deprecated API found:
+For each deprecated API found, record the **source** (`object` from Step 2a /
+`managedFields` from Step 2b) and severity:
+
 - **Removed in target version** → HIGH severity, action required
 - **Deprecated but still available in target** → LOW severity, plan migration
 - **Removed in future version** → INFO, awareness only
+
+If a single resource is flagged by both Step 2a and Step 2b, report it once
+with `source: object+managedFields`. Counting at the API-path level (not the
+resource level) is canonical — see `references/report-generation.md` Category 2.
 
 ## Output Format
 
 For each finding, report:
 - API version and kind
 - Resource name and namespace
+- **Source** (`object` / `managedFields` / `object+managedFields`)
 - Whether it's removed in the target version or just deprecated
-- Specific migration command (e.g., update apiVersion field)
+- Specific migration command (e.g., update apiVersion field, re-apply manifests
+  with the new apiVersion)
 
 ## Score Impact
 

--- a/misc/website/docs/skills/eks-upgrade-check/references/report-generation.md
+++ b/misc/website/docs/skills/eks-upgrade-check/references/report-generation.md
@@ -43,6 +43,10 @@ breaking_changes_deduction = min(breaking_changes_deduction, 25)
 # COUNTING UNIT: each distinct API path (e.g., flowschemas and prioritylevelconfigurations
 # are 2 separate API paths even though they share the same API group).
 # Count API paths, NOT individual resources using that path.
+#
+# An API path is "found in cluster" if surfaced by EITHER Step 2a (live object
+# apiVersion) OR Step 2b (any entry in metadata.managedFields[].apiVersion) in
+# references/deprecated-apis.md. A path is counted ONCE regardless of step.
 deprecated_apis_deduction = 0
 for each deprecated_api_path found in cluster:
     if removed_in_target_version:    deprecated_apis_deduction += 5

--- a/misc/website/docs/skills/index.md
+++ b/misc/website/docs/skills/index.md
@@ -50,7 +50,7 @@ Author a new steering workflow for any AWS service and pair it with a matching s
 
 ## [terraform-skill](./terraform-skill/)
 
-Use when working with Terraform or OpenTofu - creating modules, writing tests (native test framework, Terratest), setting up CI/CD pipelines, reviewing configurations, choosing between testing approaches, debugging state issues, implementing security scanning (trivy, checkov), or making infrastructure-as-code architecture decisions
+Use when writing, reviewing, or debugging Terraform/OpenTofu modules, tests, CI, scans, or state ops - diagnoses failure mode (identity churn, secrets, blast radius, CI drift, state corruption) with version-aware guards.
 
 ## [update-docs](./update-docs/)
 

--- a/misc/website/docs/skills/terraform-skill/index.md
+++ b/misc/website/docs/skills/terraform-skill/index.md
@@ -1,6 +1,6 @@
 ---
 title: "terraform-skill"
-description: "Use when working with Terraform or OpenTofu - creating modules, writing tests (native test framework, Terratest), setting up CI/CD pipelines, reviewing configurations, choosing between testing approaches, debugging state issues, implementing security scanning (trivy, checkov), or making infrastructure-as-code architecture decisions"
+description: "Use when writing, reviewing, or debugging Terraform/OpenTofu modules, tests, CI, scans, or state ops - diagnoses failure mode (identity churn, secrets, blast radius, CI drift, state corruption) with version-aware guards."
 custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/skills/terraform-skill/SKILL.md
 format: md
 ---
@@ -17,508 +17,297 @@ This skill is maintained by **Anton Babenko ([terraform-best-practices.com](http
 
 # Terraform Skill for Claude
 
-Comprehensive Terraform and OpenTofu guidance covering testing, modules, CI/CD, and production patterns. Based on terraform-best-practices.com and enterprise experience.
+Diagnose-first guidance for Terraform and OpenTofu. Core file is a workflow; depth lives in references loaded on demand.
+
+## Response Contract
+
+Every Terraform/OpenTofu response must include:
+
+1. **Assumptions & version floor** — runtime (`terraform` or `tofu`), exact version, providers, state backend, execution path (local/CI/Cloud/Atlantis), environment criticality. State assumptions explicitly if the user did not provide them.
+2. **Risk category addressed** — one or more of: identity churn, secret exposure, blast radius, CI drift, compliance gaps, state corruption, provider upgrade risk, testing blind spots.
+3. **Chosen remediation & tradeoffs** — what was chosen, what was traded off, why.
+4. **Validation plan** — exact commands (`fmt -check`, `validate`, `plan -out`, policy check) tailored to runtime and risk tier.
+5. **Rollback notes** — for any destructive or state-mutating change: how to undo, what evidence to keep.
+
+Never recommend direct production apply without a reviewed plan artifact and approval.
+
+## Workflow
+
+1. **Capture execution context** — runtime+version, provider(s), backend, execution path, environment criticality.
+2. **Diagnose failure mode(s)** using the routing table below. If intent spans categories, load both references.
+3. **Load only the matching reference file(s)** — do not preload depth the task does not need.
+4. **Propose fix with risk controls** — why this addresses the mode, what could still go wrong, guardrails (tests/approvals/rollback).
+5. **Generate artifacts** — HCL, migration blocks (`moved`, `import`), CI changes, policy rules.
+6. **Validate before finalizing** — run validation commands tailored to risk tier.
+7. **Emit the Response Contract** at the end.
+
+## Diagnose Before You Generate
+
+| Failure category | Symptoms | Primary references |
+|------------------|----------|--------------------|
+| **Identity churn** | Resource addresses shift after refactor, `count` index churn, missing `moved` blocks | [Code Patterns: count vs for_each](references/code-patterns#count-vs-for_each-deep-dive), [Code Patterns: moved blocks](references/code-patterns#moved-blocks-terraform-11), [Code Patterns: LLM mistakes](references/code-patterns#llm-mistake-checklist--code-patterns) |
+| **Secret exposure** | Secrets in defaults, state, logs, CI artifacts | [Security & Compliance](references/security-compliance), [Code Patterns: write-only](references/code-patterns#write-only-arguments-terraform-111), [State Management](references/state-management) |
+| **Blast radius** | Oversized stacks, shared prod/non-prod state, unsafe applies | [State Management](references/state-management), [Module Patterns](references/module-patterns) |
+| **CI drift** | Local plan ≠ CI plan, apply without reviewed artifact, unpinned versions | [CI/CD Workflows](references/ci-cd-workflows), [Code Patterns: versions](references/code-patterns#version-management) |
+| **Compliance gaps** | Missing policy stage, no approval model, no evidence retention | [Security & Compliance](references/security-compliance), [CI/CD Workflows](references/ci-cd-workflows) |
+| **Testing blind spots** | Plan-only validation of computed values, set-type indexing, mock/real confusion | [Testing Frameworks](references/testing-frameworks) |
+| **State corruption / recovery** | Stuck lock, backend migration, drift reconciliation | [State Management](references/state-management) |
+| **Provider upgrade risk** | Breaking-change provider bump, unpinned modules | [Code Patterns: versions](references/code-patterns#version-management), [Module Patterns](references/module-patterns) |
+| **Provider lifecycle** | Removing a provider with resources still in state, orphaned resources, `removed` block usage | [State Management: Provider Removal](references/state-management#provider-removal) |
+| **Bootstrap / orchestration misuse** | `null_resource` + `local-exec` for bootstrap, `remote-exec` for setup scripts, provisioner stdout leaking secrets in CI logs | [Code Patterns: Provisioners as Last Resort](references/code-patterns#provisioners-as-last-resort) |
+| **Navigation / safe-rename blind spots** | Cannot locate symbol defs/refs semantically, value-symbol rename done as blind text replace, grep-only refactor missing refs, hallucinated `rg` shim | [Code Intelligence](references/code-intelligence-lsp#terraform-ls-capability-matrix) |
+| **Cross-cloud / provider mapping** | "What's the Azure/GCP equivalent of X", picking a backend/auth model per cloud | [State Management: Cross-cloud equivalents](references/state-management#cross-cloud-equivalents) |
 
 ## When to Use This Skill
 
-**Activate this skill when:**
-- Creating new Terraform or OpenTofu configurations or modules
-- Setting up testing infrastructure for IaC code
-- Deciding between testing approaches (validate, plan, frameworks)
-- Structuring multi-environment deployments
-- Implementing CI/CD for infrastructure-as-code
-- Reviewing or refactoring existing Terraform/OpenTofu projects
-- Choosing between module patterns or state management approaches
+**Activate when:** creating or reviewing Terraform/OpenTofu configurations or modules, setting up or debugging tests, structuring multi-environment deployments, implementing IaC CI/CD, choosing module patterns or state organization, configuring or migrating remote state backends.
 
-**Don't use this skill for:**
-- Basic Terraform/OpenTofu syntax questions (Claude knows this)
-- Provider-specific API reference (link to docs instead)
-- Cloud platform questions unrelated to Terraform/OpenTofu
+**Don't use for:** basic HCL syntax questions Claude already knows, provider API reference (link to docs), cloud-platform questions unrelated to Terraform/OpenTofu.
 
 ## Core Principles
 
-### 1. Code Structure Philosophy
-
-**Module Hierarchy:**
+### Module Hierarchy
 
 | Type | When to Use | Scope |
 |------|-------------|-------|
-| **Resource Module** | Single logical group of connected resources | VPC + subnets, Security group + rules |
-| **Infrastructure Module** | Collection of resource modules for a purpose | Multiple resource modules in one region/account |
+| **Resource module** | Single logical group of connected resources | VPC + subnets, SG + rules |
+| **Infrastructure module** | Collection of resource modules for a purpose | Multiple resource modules in one region/account |
 | **Composition** | Complete infrastructure | Spans multiple regions/accounts |
 
-**Hierarchy:** Resource → Resource Module → Infrastructure Module → Composition
+Flow: resource → resource module → infrastructure module → composition.
 
-**Directory Structure:**
+### Directory Layout
+
 ```
-environments/        # Environment-specific configurations
-├── prod/
-├── staging/
-└── dev/
-
-modules/            # Reusable modules
-├── networking/
-├── compute/
-└── data/
-
-examples/           # Module usage examples (also serve as tests)
-├── complete/
-└── minimal/
+environments/   # prod/ staging/ dev/  — per-env configurations
+modules/        # networking/ compute/ data/ — reusable modules
+examples/       # minimal/ complete/ — docs + integration fixtures
 ```
 
-**Key principle from terraform-best-practices.com:**
-- Separate **environments** (prod, staging) from **modules** (reusable components)
-- Use **examples/** as both documentation and integration test fixtures
-- Keep modules small and focused (single responsibility)
+Separate **environments** from **modules**. Use `examples/` as both documentation and test fixtures. Keep modules small and single-responsibility.
 
-**For detailed module architecture, see:** [Code Patterns: Module Types & Hierarchy](references/code-patterns)
+See [Module Patterns](references/module-patterns) for architecture principles, naming conventions, variable/output contracts.
 
-### 2. Naming Conventions
+### Naming Conventions (summary)
 
-**Resources:**
-```hcl
-# Good: Descriptive, contextual
-resource "aws_instance" "web_server" { }
-resource "aws_s3_bucket" "application_logs" { }
+- Descriptive resource names (`aws_instance.web_server`, not `aws_instance.main`)
+- Reserve `this` for genuine singleton resources only
+- Prefix variables with context (`vpc_cidr_block`, not `cidr`)
+- Standard files: `main.tf`, `variables.tf`, `outputs.tf`, `versions.tf`
 
-# Good: "this" for singleton resources (only one of that type)
-resource "aws_vpc" "this" { }
-resource "aws_security_group" "this" { }
+See [Module Patterns: Variable Naming](references/module-patterns) and [Code Patterns: Block Ordering](references/code-patterns#block-ordering--structure) for examples.
 
-# Avoid: Generic names for non-singletons
-resource "aws_instance" "main" { }
-resource "aws_s3_bucket" "bucket" { }
-```
+### Block Ordering (summary)
 
-**Singleton Resources:**
+Resource blocks: `count`/`for_each` first → arguments → `tags` → `depends_on` → `lifecycle`.
+Variable blocks: `description` → `type` → `default` → `validation` → `nullable` → `sensitive`.
 
-Use `"this"` when your module creates only one resource of that type:
+See [Code Patterns: Block Ordering & Structure](references/code-patterns#block-ordering--structure) for the full rules and examples.
 
-✅ DO:
-```hcl
-resource "aws_vpc" "this" {}           # Module creates one VPC
-resource "aws_security_group" "this" {}  # Module creates one SG
-```
-
-❌ DON'T use "this" for multiple resources:
-```hcl
-resource "aws_subnet" "this" {}  # If creating multiple subnets
-```
-
-Use descriptive names when creating multiple resources of the same type.
-
-**Variables:**
-```hcl
-# Prefix with context when needed
-var.vpc_cidr_block          # Not just "cidr"
-var.database_instance_class # Not just "instance_class"
-```
-
-**Files:**
-- `main.tf` - Primary resources
-- `variables.tf` - Input variables
-- `outputs.tf` - Output values
-- `versions.tf` - Provider versions
-- `data.tf` - Data sources (optional)
-
-## Testing Strategy Framework
+## Testing Strategy
 
 ### Decision Matrix: Which Testing Approach?
 
-| Your Situation | Recommended Approach | Tools | Cost |
-|----------------|---------------------|-------|------|
-| **Quick syntax check** | Static analysis | `terraform validate`, `fmt` | Free |
-| **Pre-commit validation** | Static + lint | `validate`, `tflint`, `trivy`, `checkov` | Free |
-| **Terraform 1.6+, simple logic** | Native test framework | Built-in `terraform test` | Free-Low |
-| **Pre-1.6, or Go expertise** | Integration testing | Terratest | Low-Med |
-| **Security/compliance focus** | Policy as code | OPA, Sentinel | Free |
-| **Cost-sensitive workflow** | Mock providers (1.7+) | Native tests + mocking | Free |
-| **Multi-cloud, complex** | Full integration | Terratest + real infra | Med-High |
+| Situation | Approach | Tools | Cost |
+|-----------|----------|-------|------|
+| Quick syntax check | Static analysis | `validate`, `fmt` | Free |
+| Pre-commit validation | Static + lint | `validate`, `tflint`, `trivy`, `checkov` | Free |
+| Terraform 1.6+, simple logic | Native test framework | `terraform test` | Free-Low |
+| Pre-1.6, or Go expertise | Integration testing | Terratest | Low-Med |
+| Security/compliance focus | Policy as code | OPA, Sentinel | Free |
+| Cost-sensitive workflow | Mock providers (1.7+) | Native tests + mocks | Free |
+| Multi-cloud, complex | Full integration | Terratest + real infra | Med-High |
 
-### Testing Pyramid for Infrastructure
+### Native Test Rules (1.6+)
 
-```
-        /\
-       /  \          End-to-End Tests (Expensive)
-      /____\         - Full environment deployment
-     /      \        - Production-like setup
-    /________\
-   /          \      Integration Tests (Moderate)
-  /____________\     - Module testing in isolation
- /              \    - Real resources in test account
-/________________\   Static Analysis (Cheap)
-                     - validate, fmt, lint
-                     - Security scanning
-```
+Before writing test code: validate resource schemas via Terraform MCP so assertions target real attributes.
 
-### Native Test Best Practices (1.6+)
+- `command = plan` — fast, for input-derived values only
+- `command = apply` — required for **computed values** (ARNs, generated names) and **set-type nested blocks**
+- Set-type blocks cannot be indexed with `[0]` — use `for` expressions or materialize via `command = apply`
+- Common set types: S3 encryption rules, lifecycle transitions, IAM policy statements
 
-**Before generating test code:**
+See [Testing Frameworks](references/testing-frameworks) for static-analysis pipelines, native-test patterns, Terratest integration, mock providers, and the full LLM-mistake checklist.
 
-1. **Validate schemas with Terraform MCP:**
-   ```
-   Search provider docs → Get resource schema → Identify block types
-   ```
-
-2. **Choose correct command mode:**
-   - `command = plan` - Fast, for input validation
-   - `command = apply` - Required for computed values and set-type blocks
-
-3. **Handle set-type blocks correctly:**
-   - Cannot index with `[0]`
-   - Use `for` expressions to iterate
-   - Or use `command = apply` to materialize
-
-**Common patterns:**
-- S3 encryption rules: **set** (use for expressions)
-- Lifecycle transitions: **set** (use for expressions)
-- IAM policy statements: **set** (use for expressions)
-
-**For detailed testing guides, see:**
-- **[Testing Frameworks Guide](references/testing-frameworks)** - Deep dive into static analysis, native tests, and Terratest
-- **[Quick Reference](references/quick-reference#testing-approach-selection)** - Decision flowchart and command cheat sheet
-
-## Code Structure Standards
-
-### Resource Block Ordering
-
-**Strict ordering for consistency:**
-1. `count` or `for_each` FIRST (blank line after)
-2. Other arguments
-3. `tags` as last real argument
-4. `depends_on` after tags (if needed)
-5. `lifecycle` at the very end (if needed)
-
-```hcl
-# ✅ GOOD - Correct ordering
-resource "aws_nat_gateway" "this" {
-  count = var.create_nat_gateway ? 1 : 0
-
-  allocation_id = aws_eip.this[0].id
-  subnet_id     = aws_subnet.public[0].id
-
-  tags = {
-    Name = "${var.name}-nat"
-  }
-
-  depends_on = [aws_internet_gateway.this]
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-```
-
-### Variable Block Ordering
-
-1. `description` (ALWAYS required)
-2. `type`
-3. `default`
-4. `validation`
-5. `nullable` (when setting to false)
-
-```hcl
-variable "environment" {
-  description = "Environment name for resource tagging"
-  type        = string
-  default     = "dev"
-
-  validation {
-    condition     = contains(["dev", "staging", "prod"], var.environment)
-    error_message = "Environment must be one of: dev, staging, prod."
-  }
-
-  nullable = false
-}
-```
-
-**For complete structure guidelines, see:** [Code Patterns: Block Ordering & Structure](references/code-patterns#block-ordering--structure)
-
-## Count vs For_Each: When to Use Each
-
-### Quick Decision Guide
+## Count vs For_Each — Quick Rule
 
 | Scenario | Use | Why |
 |----------|-----|-----|
-| Boolean condition (create or don't) | `count = condition ? 1 : 0` | Simple on/off toggle |
-| Simple numeric replication | `count = 3` | Fixed number of identical resources |
-| Items may be reordered/removed | `for_each = toset(list)` | Stable resource addresses |
-| Reference by key | `for_each = map` | Named access to resources |
-| Multiple named resources | `for_each` | Better maintainability |
+| Boolean condition (create / don't) | `count = condition ? 1 : 0` | Optional singleton toggle |
+| Items may be reordered or removed | `for_each = toset(list)` | Stable resource addresses |
+| Reference by key | `for_each = map` | Named access |
+| Multiple named resources | `for_each` | Better identity stability |
 
-### Common Patterns
-
-**Boolean conditions:**
-```hcl
-# ✅ GOOD - Boolean condition
-resource "aws_nat_gateway" "this" {
-  count = var.create_nat_gateway ? 1 : 0
-  # ...
-}
-```
-
-**Stable addressing with for_each:**
-```hcl
-# ✅ GOOD - Removing "us-east-1b" only affects that subnet
-resource "aws_subnet" "private" {
-  for_each = toset(var.availability_zones)
-
-  availability_zone = each.key
-  # ...
-}
-
-# ❌ BAD - Removing middle AZ recreates all subsequent subnets
-resource "aws_subnet" "private" {
-  count = length(var.availability_zones)
-
-  availability_zone = var.availability_zones[count.index]
-  # ...
-}
-```
-
-**For migration guides and detailed examples, see:** [Code Patterns: Count vs For_Each](references/code-patterns#count-vs-for_each-deep-dive)
+**Never** use list index as long-lived identity — removing a middle element reshuffles every address after it. For the decision matrix, safe migration playbook, `moved` block patterns, and known-at-plan failure cases, see [Code Patterns: count vs for_each](references/code-patterns#count-vs-for_each-deep-dive).
 
 ## Locals for Dependency Management
 
-**Use locals to ensure correct resource deletion order:**
+Using `try()` in a local to prefer a conditional resource's attribute over its parent is a specialized but high-value pattern — it forces correct deletion order without explicit `depends_on`. Common use: VPC + secondary CIDR associations + subnets.
 
-```hcl
-# Problem: Subnets might be deleted after CIDR blocks, causing errors
-# Solution: Use try() in locals to hint deletion order
-
-locals {
-  # References secondary CIDR first, falling back to VPC
-  # Forces Terraform to delete subnets before CIDR association
-  vpc_id = try(
-    aws_vpc_ipv4_cidr_block_association.this[0].vpc_id,
-    aws_vpc.this.id,
-    ""
-  )
-}
-
-resource "aws_vpc" "this" {
-  cidr_block = "10.0.0.0/16"
-}
-
-resource "aws_vpc_ipv4_cidr_block_association" "this" {
-  count = var.add_secondary_cidr ? 1 : 0
-
-  vpc_id     = aws_vpc.this.id
-  cidr_block = "10.1.0.0/16"
-}
-
-resource "aws_subnet" "public" {
-  vpc_id     = local.vpc_id  # Uses local, not direct reference
-  cidr_block = "10.1.0.0/24"
-}
-```
-
-**Why this matters:**
-- Prevents deletion errors when destroying infrastructure
-- Ensures correct dependency order without explicit `depends_on`
-- Particularly useful for VPC configurations with secondary CIDR blocks
-
-**For detailed examples, see:** [Code Patterns: Locals for Dependency Management](references/code-patterns#locals-for-dependency-management)
+See [Code Patterns: Locals for Dependency Management](references/code-patterns#locals-for-dependency-management) for the full pattern and worked example.
 
 ## Module Development
 
-### Standard Module Structure
+Standard layout:
 
 ```
 my-module/
-├── README.md           # Usage documentation
-├── main.tf             # Primary resources
-├── variables.tf        # Input variables with descriptions
-├── outputs.tf          # Output values
-├── versions.tf         # Provider version constraints
+├── README.md       # Usage documentation
+├── main.tf         # Primary resources
+├── variables.tf    # Typed inputs with descriptions
+├── outputs.tf      # Output values
+├── versions.tf     # required_version + required_providers
 ├── examples/
-│   ├── minimal/        # Minimal working example
-│   └── complete/       # Full-featured example
-└── tests/              # Test files
-    └── module_test.tftest.hcl  # Or .go
+│   ├── minimal/
+│   └── complete/
+└── tests/
+    └── module_test.tftest.hcl   # or Go for Terratest
 ```
 
-### Best Practices Summary
+**Variable contracts**: always `description`, always explicit `type`, use `validation` for complex constraints, use `sensitive = true` for secrets, prefer `optional()` with typed defaults (1.3+) over untyped `map(any)`.
 
-**Variables:**
-- ✅ Always include `description`
-- ✅ Use explicit `type` constraints
-- ✅ Provide sensible `default` values where appropriate
-- ✅ Add `validation` blocks for complex constraints
-- ✅ Use `sensitive = true` for secrets
+**Output contracts**: always `description`, mark sensitive outputs, expose stable subsets (not whole provider objects).
 
-**Outputs:**
-- ✅ Always include `description`
-- ✅ Mark sensitive outputs with `sensitive = true`
-- ✅ Consider returning objects for related values
-- ✅ Document what consumers should do with each output
+See [Module Patterns](references/module-patterns) for the full contract patterns, module release checklist, and LLM-mistake checklist.
 
-**For detailed module patterns, see:**
-- **[Module Patterns Guide](references/module-patterns)** - Variable best practices, output design, ✅ DO vs ❌ DON'T patterns
-- **[Quick Reference](references/quick-reference#common-patterns)** - Resource naming, variable naming, file organization
+## CI/CD
 
-## CI/CD Integration
+Pipeline stages: **validate** → **test** → **plan** → **apply** (with environment protection).
 
-### Recommended Workflow Stages
+Cost control: mock providers on PR validation, real-cloud integration only on main or scheduled, tag test resources, auto-cleanup.
 
-1. **Validate** - Format check + syntax validation + linting
-2. **Test** - Run automated tests (native or Terratest)
-3. **Plan** - Generate and review execution plan
-4. **Apply** - Execute changes (with approvals for production)
+Drift prevention: pin runtime and providers, commit `.terraform.lock.hcl`, apply the **reviewed plan artifact** from the plan stage (do not re-run `plan` inside the apply job), run policy/security stage on every path to apply.
 
-### Cost Optimization Strategy
-
-1. **Use mocking for PR validation** (free)
-2. **Run integration tests only on main branch** (controlled cost)
-3. **Implement auto-cleanup** (prevent orphaned resources)
-4. **Tag all test resources** (track spending)
-
-**For complete CI/CD templates, see:**
-- **[CI/CD Workflows Guide](references/ci-cd-workflows)** - GitHub Actions, GitLab CI, Atlantis integration, cost optimization
-- **[Quick Reference](references/quick-reference#troubleshooting-guide)** - Common CI/CD issues and solutions
+See [CI/CD Workflows](references/ci-cd-workflows) for GitHub Actions, GitLab CI, and Atlantis templates plus the LLM-mistake checklist.
 
 ## Security & Compliance
 
-### Essential Security Checks
+**Essential checks:**
 
 ```bash
-# Static security scanning
 trivy config .
 checkov -d .
 ```
 
-### Common Issues to Avoid
+**Don't:** store secrets in variables or `.tfvars`, use default VPC, skip encryption, open security groups to `0.0.0.0/0`, use inline `ingress`/`egress` blocks in `aws_security_group`.
 
-❌ **Don't:**
-- Store secrets in variables
-- Use default VPC
-- Skip encryption
-- Open security groups to 0.0.0.0/0
+**Do:** source secrets from a cloud secret manager (AWS Secrets Manager / Azure Key Vault / GCP Secret Manager) or use `write_only` arguments on 1.11+, create dedicated VPCs, enforce encryption at rest and TLS, least-privilege SGs, use separate `aws_vpc_security_group_{ingress,egress}_rule` resources (e.g. AWS provider v5+).
 
-✅ **Do:**
-- Use AWS Secrets Manager / Parameter Store
-- Create dedicated VPCs
-- Enable encryption at rest
-- Use least-privilege security groups
+Marking a variable `sensitive = true` masks display only — the value still lives in state. Use `write_only` / `*_wo` on 1.11+, or keep secret material out of Terraform entirely via runtime lookups.
 
-**For detailed security guidance, see:**
-- **[Security & Compliance Guide](references/security-compliance)** - Trivy/Checkov integration, secrets management, state file security, compliance testing
+See [Security & Compliance](references/security-compliance) for trivy/checkov pipelines, state-file hardening, compliance mappings, and the LLM-mistake checklist.
 
-## Version Management
+## State Management
 
-### Version Constraint Syntax
+**Never use local state in teams or production.** Remote backends provide automatic locking, encryption, versioning, audit logging, and safe collaboration.
+
+### Choosing a Remote Backend
+
+AWS example (Azure `azurerm` / GCP `gcs` / TF Cloud syntax: see [State Management: Choosing a Remote Backend](references/state-management#choosing-a-remote-backend)):
 
 ```hcl
-version = "5.0.0"      # Exact (avoid - inflexible)
-version = "~> 5.0"     # Recommended: 5.0.x only
-version = ">= 5.0"     # Minimum (risky - breaking changes)
-```
-
-### Strategy by Component
-
-| Component | Strategy | Example |
-|-----------|----------|---------|
-| **Terraform** | Pin minor version | `required_version = "~> 1.9"` |
-| **Providers** | Pin major version | `version = "~> 5.0"` |
-| **Modules (prod)** | Pin exact version | `version = "5.1.2"` |
-| **Modules (dev)** | Allow patch updates | `version = "~> 5.1"` |
-
-### Update Workflow
-
-```bash
-# Lock versions initially
-terraform init              # Creates .terraform.lock.hcl
-
-# Update to latest within constraints
-terraform init -upgrade     # Updates providers
-
-# Review and test
-terraform plan
-```
-
-**For detailed version management, see:** [Code Patterns: Version Management](references/code-patterns#version-management)
-
-## Modern Terraform Features (1.0+)
-
-### Feature Availability by Version
-
-| Feature | Version | Use Case |
-|---------|---------|----------|
-| `try()` function | 0.13+ | Safe fallbacks, replaces `element(concat())` |
-| `nullable = false` | 1.1+ | Prevent null values in variables |
-| `moved` blocks | 1.1+ | Refactor without destroy/recreate |
-| `optional()` with defaults | 1.3+ | Optional object attributes |
-| Native testing | 1.6+ | Built-in test framework |
-| Mock providers | 1.7+ | Cost-free unit testing |
-| Provider functions | 1.8+ | Provider-specific data transformation |
-| Cross-variable validation | 1.9+ | Validate relationships between variables |
-| Write-only arguments | 1.11+ | Secrets never stored in state |
-
-### Quick Examples
-
-```hcl
-# try() - Safe fallbacks (0.13+)
-output "sg_id" {
-  value = try(aws_security_group.this[0].id, "")
-}
-
-# optional() - Optional attributes with defaults (1.3+)
-variable "config" {
-  type = object({
-    name    = string
-    timeout = optional(number, 300)  # Default: 300
-  })
-}
-
-# Cross-variable validation (1.9+)
-variable "environment" { type = string }
-variable "backup_days" {
-  type = number
-  validation {
-    condition     = var.environment == "prod" ? var.backup_days >= 7 : true
-    error_message = "Production requires backup_days >= 7"
+terraform {
+  backend "s3" {
+    bucket        = "my-terraform-state"
+    key           = "prod/vpc/terraform.tfstate"
+    region        = "us-east-1"
+    encrypt       = true
+    use_lockfile  = true   # Native S3 locking, 1.10+
   }
 }
 ```
 
-**For complete patterns and examples, see:** [Code Patterns: Modern Terraform Features](references/code-patterns#modern-terraform-features-10)
+On Terraform < 1.10, use `dynamodb_table = "terraform-state-lock"` instead of `use_lockfile`. Azure Storage, GCS, and Terraform Cloud all offer built-in locking - see the State Management reference for syntax. For choosing among backends and their locking models, see [Choosing a Remote Backend](references/state-management#choosing-a-remote-backend).
 
-## Version-Specific Guidance
+### State Organization
 
-### Terraform 1.0-1.5
-- Use Terratest for testing
-- No native testing framework available
-- Focus on static analysis and plan validation
+| Pattern | Use When | Example Path |
+|---------|----------|--------------|
+| **Per environment** | Different teams per env | `prod/terraform.tfstate`, `staging/...` |
+| **Per component** | Independent lifecycles | `prod/vpc/`, `prod/eks/`, `prod/rds/` |
+| **Hybrid** (recommended) | Both benefits | `prod/networking/`, `prod/compute/`, `staging/networking/` |
 
-### Terraform 1.6+ / OpenTofu 1.6+
-- **New:** Native `terraform test` / `tofu test` command
-- Consider migrating from external frameworks for simple tests
-- Keep Terratest only for complex integration tests
+Split state when: different teams, different update cadences, or >500 resources. Combine when: tightly coupled resources, <100 resources, same lifecycle.
 
-### Terraform 1.7+ / OpenTofu 1.7+
-- **New:** Mock providers for unit testing
-- Reduce cost by mocking external dependencies
-- Use real integration tests for final validation
+See [State Management](references/state-management) for locking, migration, multi-team isolation, disaster recovery, and the LLM-mistake checklist.
 
-### Terraform vs OpenTofu
+## Version Management
 
-Both are fully supported by this skill. For licensing, governance, and feature comparison, see [Quick Reference: Terraform vs OpenTofu](references/quick-reference#terraform-vs-opentofu-comparison).
+| Component | Strategy | Example |
+|-----------|----------|---------|
+| Terraform runtime | Pin minor | `required_version = "~> 1.9"` |
+| Providers | Pin major | `version = "~> 5.0"` |
+| Modules (prod) | Pin exact | `version = "5.1.2"` |
+| Modules (dev) | Allow patch | `version = "~> 5.1"` |
 
-## Detailed Guides
+Commit `.terraform.lock.hcl` intentionally. Keep provider/runtime upgrades in a separate PR from functional changes. See [Code Patterns: Version Management](references/code-patterns#version-management) for constraint syntax and upgrade workflow.
 
-This skill uses **progressive disclosure** - essential information is in this main file, detailed guides are available when needed:
+## Modern Terraform Features (1.0+)
 
-📚 **Reference Files:**
-- **[Testing Frameworks](references/testing-frameworks)** - In-depth guide to static analysis, native tests, and Terratest
-- **[Module Patterns](references/module-patterns)** - Module structure, variable/output best practices, ✅ DO vs ❌ DON'T patterns
-- **[CI/CD Workflows](references/ci-cd-workflows)** - GitHub Actions, GitLab CI templates, cost optimization, automated cleanup
-- **[Security & Compliance](references/security-compliance)** - Trivy/Checkov integration, secrets management, compliance testing
-- **[Quick Reference](references/quick-reference)** - Command cheat sheets, decision flowcharts, troubleshooting guide
+| Feature | Min version | Common use |
+|---------|-------------|------------|
+| `try()` | 0.13+ | Safe fallbacks, replaces `element(concat())` |
+| `nullable = false` | 1.1+ | Prevent `null` silently overriding defaults |
+| `moved` blocks | 1.1+ | Refactor without destroy/recreate |
+| `optional()` with defaults | 1.3+ | Typed object attributes |
+| `import` blocks | 1.5+ | Declarative imports, reviewable in VCS |
+| `check` blocks | 1.5+ | Runtime assertions |
+| Native `terraform test` | 1.6+ | Built-in test framework |
+| Mock providers | 1.7+ | Cost-free unit testing |
+| `removed` blocks | 1.7+ | Declarative resource removal |
+| Provider-defined functions | 1.8+ | Provider-specific transformations (requires provider to declare functions) |
+| Cross-variable validation | 1.9+ | Reference other `var.*` in `validation` blocks |
+| `write_only` arguments | 1.11+ | Secrets never stored in state |
+| S3 native lock-file | 1.10+ | State locking without DynamoDB |
 
-**How to use:** When you need detailed information on a topic, reference the appropriate guide. Claude will load it on demand to provide comprehensive guidance.
+Before emitting a feature, verify the runtime floor. See [Code Patterns: Feature Guard Table](references/code-patterns#feature-guard-table--version-floor--common-llm-errors) for the full table with common LLM error patterns per feature.
+
+## Runtime-Specific Guidance
+
+- **Terraform 1.0-1.5 (OpenTofu starts at 1.6)**: Terratest for integration, static analysis + plan validation only (no native tests).
+- **1.6+**: native `terraform test` / `tofu test` available — migrate simple unit tests, keep Terratest for complex integration.
+- **1.7+**: mock providers cut test cost — mock for unit tests, real runs for final integration.
+- **1.10+**: S3 native lock-file (`use_lockfile`) is the correct default for new configurations — DynamoDB locking is no longer required.
+- **1.11+**: `write_only` arguments for secret handling keep credentials out of state.
+- **Terraform vs OpenTofu**: both supported. For licensing, governance, and feature delta, see [Quick Reference: Terraform vs OpenTofu](references/quick-reference#terraform-vs-opentofu-comparison).
+
+## Code Intelligence (terraform-ls)
+
+Semantic navigation for HCL. terraform-ls is optional; without it every row below degrades to a disclosed `rg` + Read fallback.
+
+Self-contained terraform-ls layer of a generic code-intelligence discipline - apply the rows below directly. Recommended companion: the `code-intelligence` plugin (same `antonbabenko/agent-plugins` marketplace) carries the generic discipline (position anchoring, degradation gate, disclosure format, anti-phantom-shim) and ships `/code-intelligence:doctor` for readiness. If it is installed, defer to its generic protocol; this skill stays fully self-contained without it.
+
+| Goal | Use | Tradeoff |
+|------|-----|----------|
+| Find definition / all references | terraform-ls `goToDefinition` / `findReferences` | Needs `init` + a position anchor |
+| Rename value symbol (var/local/output/provider alias) | Manual: `findReferences` -> per-file fresh Read -> edit -> `validate` | No rename provider |
+| Rename resource/module address | `moved` block + `plan` shows 0 destroy | Text rename forces destroy/recreate |
+| Exact text / known name / `.tfvars` / non-HCL | `rg` + Read | No semantic scope |
+
+✅ Supported: `goToDefinition`, `findReferences`, `documentSymbol`, `hover`, `workspaceSymbol`.
+❌ Unsupported: `goToImplementation`, call hierarchy, rename provider. Do not call these then report their absence as a finding.
+
+- ✅ Prereq: local `terraform`/`tofu` on PATH, `terraform init` run; cold start may need one retry.
+- ✅ LSP calls are position-anchored (`file:line:character`) - anchor with `rg` first, never symbol-name-only.
+- ❌ Do not claim "LSP broken, using rg" until the [Degradation Gate](references/code-intelligence-lsp#degradation-gate) passes; disclose any tool substitution on the first line.
+
+Depth: [Code Intelligence](references/code-intelligence-lsp#terraform-ls-capability-matrix).
+
+## Reference Files
+
+Progressive disclosure — essentials here, depth on demand:
+
+- [Testing Frameworks](references/testing-frameworks) — static analysis, native tests, Terratest, mock providers
+- [Module Patterns](references/module-patterns) — structure, variable/output contracts, `terraform_remote_state` rules, release checklist
+- [CI/CD Workflows](references/ci-cd-workflows) — GitHub Actions, GitLab CI, Atlantis, cost control
+- [Security & Compliance](references/security-compliance) — trivy/checkov, secrets handling, compliance mappings
+- [State Management](references/state-management) — backends, locking, migration, multi-team, recovery
+- [Code Patterns](references/code-patterns) — block ordering, `count`/`for_each` deep dive, modern features, version management, locals
+- [Code Intelligence](references/code-intelligence-lsp) - terraform-ls capabilities, position-anchored calls, manual rename, degradation gate
+- [Quick Reference](references/quick-reference) — command cheat sheets, flowcharts, troubleshooting
 
 ## License
 
-This skill is licensed under the **Apache License 2.0**. See the LICENSE file for full terms.
+Apache License 2.0. See LICENSE for full terms.
 
 **Copyright © 2026 Anton Babenko**

--- a/misc/website/docs/skills/terraform-skill/references/ci-cd-workflows.md
+++ b/misc/website/docs/skills/terraform-skill/references/ci-cd-workflows.md
@@ -41,14 +41,17 @@ This document provides detailed CI/CD workflow templates and optimization strate
 # .github/workflows/terraform.yml
 name: Terraform
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v2
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
 
       - name: Terraform Format
         run: terraform fmt -check -recursive
@@ -59,26 +62,29 @@ jobs:
       - name: Terraform Validate
         run: terraform validate
 
+      - uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: v0.50.3
+      - name: TFLint Init
+        run: tflint --init
       - name: TFLint
-        run: |
-          curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
-          tflint --init
-          tflint
+        run: tflint
 
   test:
     needs: validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
 
       - name: Run Terraform Tests
         run: terraform test
 
       # Or for Terratest:
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: 'stable'
 
       - name: Run Terratest
         run: |
@@ -89,8 +95,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v2
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
 
       - name: Terraform Init
         run: terraform init
@@ -99,7 +105,7 @@ jobs:
         run: terraform plan -out=tfplan
 
       - name: Upload Plan
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tfplan
           path: tfplan
@@ -110,13 +116,16 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment: production
     steps:
-      - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v2
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
 
       - name: Download Plan
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tfplan
+
+      - name: Terraform Init
+        run: terraform init
 
       - name: Terraform Apply
         run: terraform apply tfplan
@@ -129,7 +138,7 @@ jobs:
     needs: plan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Infracost
         uses: infracost/actions/setup@v2
@@ -182,9 +191,9 @@ test:
   stage: test
   script:
     - terraform test
-  only:
-    - merge_requests
-    - main
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH == "main"'
 
 plan:
   extends: .terraform_template
@@ -195,9 +204,9 @@ plan:
     paths:
       - ${TF_ROOT}/tfplan
     expire_in: 1 week
-  only:
-    - merge_requests
-    - main
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH == "main"'
 
 apply:
   extends: .terraform_template
@@ -206,9 +215,9 @@ apply:
     - terraform apply tfplan
   dependencies:
     - plan
-  only:
-    - main
-  when: manual
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      when: manual
   environment:
     name: production
 ```
@@ -236,9 +245,6 @@ test:
 
     - name: Run Integration Tests
       if: github.ref == 'refs/heads/main'
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: |
         cd tests
         go test -v -timeout 30m
@@ -253,7 +259,7 @@ terraformOptions := &terraform.Options{
     Vars: map[string]interface{}{
         "tags": map[string]string{
             "Environment": "test",
-            "TTL":         "2h",
+            "CreatedAt":   time.Now().Format(time.RFC3339),
             "CreatedBy":   "CI",
             "JobID":       os.Getenv("GITHUB_RUN_ID"),
         },
@@ -270,17 +276,29 @@ terraformOptions := &terraform.Options{
 ```bash
 #!/bin/bash
 # cleanup-test-resources.sh
+# Resources are tagged with CreatedAt = ISO8601 timestamp (RFC3339).
+# AWS resourcegroupstaggingapi tag filters only support equality, so we
+# fetch by Environment=test and filter by timestamp client-side with jq.
 
-# Find and terminate instances older than 2 hours with test tag
+set -euo pipefail
+
+CUTOFF=$(date -u -d '2 hours ago' +%s)
+
 aws resourcegroupstaggingapi get-resources \
   --tag-filters Key=Environment,Values=test \
-  --query 'ResourceTagMappingList[?Tags[?Key==`TTL` && Value<`'$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%S)'`]].ResourceARN' \
-  --output text | \
-  while read arn; do
-    instance_id=$(echo $arn | grep -oP 'instance/\K[^/]+')
-    if [ ! -z "$instance_id" ]; then
+  --query 'ResourceTagMappingList[]' \
+  --output json | \
+  jq -r --argjson cutoff "$CUTOFF" '
+    .[]
+    | select(
+        any(.Tags[]; .Key == "CreatedAt" and (.Value | fromdateiso8601) < $cutoff)
+      )
+    | .ResourceARN
+  ' | while read -r arn; do
+    instance_id=$(echo "$arn" | grep -oP 'instance/\K[^/]+' || true)
+    if [ -n "$instance_id" ]; then
       echo "Terminating instance: $instance_id"
-      aws ec2 terminate-instances --instance-ids $instance_id
+      aws ec2 terminate-instances --instance-ids "$instance_id"
     fi
   done
 ```
@@ -296,17 +314,20 @@ on:
     - cron: '0 */2 * * *'  # Every 2 hours
   workflow_dispatch:        # Manual trigger
 
+permissions:
+  id-token: write   # required for OIDC role assumption
+  contents: read
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_CLEANUP_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Run Cleanup Script
@@ -347,11 +368,11 @@ jobs:
 ### 2. Require Approvals for Production
 
 ```yaml
+# GitHub Actions — configure required reviewers on the `production`
+# environment in repo Settings -> Environments -> Protection rules.
 apply:
   environment:
     name: production
-    # Requires manual approval in GitHub
-  when: manual
 ```
 
 ### 3. Use Remote State
@@ -360,11 +381,11 @@ apply:
 # backend.tf
 terraform {
   backend "s3" {
-    bucket         = "my-terraform-state"
-    key            = "prod/terraform.tfstate"
-    region         = "us-east-1"
-    dynamodb_table = "terraform-locks"
-    encrypt        = true
+    bucket       = "my-terraform-state"
+    key          = "prod/terraform.tfstate"
+    region       = "us-east-1"
+    use_lockfile = true # 1.10+, native S3 locking (replaces DynamoDB)
+    encrypt      = true
   }
 }
 ```
@@ -380,13 +401,28 @@ terraform {
 ### 5. Cache Terraform Plugins
 
 ```yaml
-# GitHub Actions
-- name: Cache Terraform Plugins
-  uses: actions/cache@v3
-  with:
-    path: |
-      ~/.terraform.d/plugin-cache
-    key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
+# GitHub Actions — set TF_PLUGIN_CACHE_DIR so `terraform init` actually
+# writes into the cached path, then restore the cache between runs.
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    env:
+      TF_PLUGIN_CACHE_DIR: ${{ runner.temp }}/terraform-plugin-cache
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+
+      - name: Create plugin cache dir
+        run: mkdir -p "$TF_PLUGIN_CACHE_DIR"
+
+      - name: Cache Terraform Plugins
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/terraform-plugin-cache
+          key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
+
+      - name: Terraform Init
+        run: terraform init
 ```
 
 ### 6. Security Scanning in CI
@@ -395,19 +431,92 @@ terraform {
 security-scan:
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Run Trivy
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@0.29.0
       with:
         scan-type: 'config'
         scan-ref: '.'
 
     - name: Run Checkov
-      uses: bridgecrewio/checkov-action@master
+      uses: bridgecrewio/checkov-action@v12.2.0
       with:
         directory: .
         framework: terraform
+```
+
+### OIDC Trust Policy Correctness
+
+| Platform | Expected `aud` | Where to pin `sub` |
+|----------|----------------|---------------------|
+| GitHub Actions → AWS | `sts.amazonaws.com` | `repo:<org>/<repo>:ref:refs/heads/<branch>` |
+| GitHub Actions → Azure AD | `api://AzureADTokenExchange` | `repo:<org>/<repo>:environment:<env>` |
+| GitHub Actions → GCP | value passed via `audience` parameter | repo + ref or environment |
+| GitLab CI → AWS | matches `$CI_SERVER_URL` | project path + ref |
+
+Use keyless OIDC for all three clouds (AWS OIDC / Azure federated credentials / GCP Workload Identity Federation). Static keys only if OIDC is unavailable (non-OIDC CI / self-hosted runners) - prefer keyless.
+
+**Rules:**
+- ✅ pin `aud` to the exact value from the table
+- ✅ pin `sub` to a specific repo + branch or environment — no wildcards across org/repo
+- ❌ `sub` wildcards like `repo:*:*` or `repo:<org>/*:ref:*` let any repo assume the role
+- ❌ mismatched `aud` → token rejected with opaque error; fix `aud` per table, do not relax `sub`
+
+✅ DO — AWS IAM trust-policy `Condition` block (the only non-boilerplate fragment):
+
+```json
+"Condition": {
+  "StringEquals": {
+    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+  },
+  "StringLike": {
+    "token.actions.githubusercontent.com:sub": "repo:my-org/my-repo:ref:refs/heads/main"
+  }
+}
+```
+
+### Drift Detection — Alert, Do Not Auto-Apply
+
+Scheduled drift detection alerts; it never auto-applies.
+
+✅ DO — scheduled plan with alert on drift (exit code 2):
+
+```yaml
+# .github/workflows/drift-detection.yml
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+      - run: terraform init
+      - name: Plan (detect drift)
+        id: plan
+        run: terraform plan -detailed-exitcode -out=plan.bin
+        continue-on-error: true
+      - name: Alert on drift
+        if: steps.plan.outcome == 'failure' && steps.plan.outputs.exitcode == '2'
+        run: |
+          echo "Drift detected. Requires human review before apply."
+          # send to Slack / PagerDuty / issue tracker
+```
+
+`plan -detailed-exitcode` exit codes: `0` = no drift, `1` = plan failed, `2` = drift detected.
+
+❌ DON'T — scheduled auto-apply that silently reconciles drift:
+
+```yaml
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: terraform apply -auto-approve
 ```
 
 ---
@@ -424,7 +533,7 @@ projects:
   - name: production
     dir: environments/prod
     workspace: default
-    terraform_version: v1.6.0
+    terraform_version: 1.12.0
     workflow: custom
 
 workflows:
@@ -433,7 +542,7 @@ workflows:
       steps:
         - init
         - plan:
-            extra_args: ["-lock", "false"]
+            extra_args: ["-lock=false"]
     apply:
       steps:
         - apply
@@ -483,6 +592,24 @@ bucketName := fmt.Sprintf("test-bucket-%s-%s",
     os.Getenv("GITHUB_RUN_ID"),
     uniqueId)
 ```
+
+---
+
+## LLM Mistake Checklist — CI/CD
+
+Common model mistakes to correct before returning pipeline recommendations:
+
+- generates a pipeline with no lockfile strategy (`.terraform.lock.hcl` uncommitted or unreviewed)
+- re-runs `terraform plan` inside the apply job instead of consuming the reviewed plan artifact from the plan stage
+- omits environment protection / approval gates on production apply
+- uses unpinned provider versions, causing drift between local and CI runs
+- skips the policy/security stage despite the pipeline claiming compliance
+- grants CI long-lived static cloud credentials instead of OIDC / workload-identity federation
+- writes OIDC trust policies with wildcard `sub` claims (`repo:*:*`, `repo:<org>/*:ref:*`) — any repo or branch can assume the role
+- mismatches the `aud` claim between CI platform and cloud provider, then relaxes `sub` to "fix" the resulting error
+- implements scheduled "drift detection" as `terraform apply -auto-approve` on cron — silently reverts out-of-band changes; use `plan -detailed-exitcode` + alert
+- fails to restrict artifact access when `terraform show -json` results may contain sensitive plan output
+- merges provider/runtime upgrades with functional changes in the same PR
 
 ---
 

--- a/misc/website/docs/skills/terraform-skill/references/code-intelligence-lsp.md
+++ b/misc/website/docs/skills/terraform-skill/references/code-intelligence-lsp.md
@@ -1,0 +1,154 @@
+---
+title: "Code Intelligence (terraform-ls)"
+description: ""
+custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/skills/terraform-skill/references/code-intelligence-lsp.md
+format: md
+---
+
+:::info[Source]
+This page is generated from [skills/terraform-skill/references/code-intelligence-lsp.md](https://github.com/aws-samples/sample-apex-skills/blob/main/skills/terraform-skill/references/code-intelligence-lsp.md). Edit the source, not this page.
+:::
+
+
+:::caution[Third-party skill]
+This skill is maintained by **Anton Babenko ([terraform-best-practices.com](https://terraform-best-practices.com), [Compliance.tf](https://compliance.tf))** under the Apache-2.0 license. Upstream: [https://github.com/antonbabenko/terraform-skill](https://github.com/antonbabenko/terraform-skill)
+:::
+
+# Code Intelligence (terraform-ls)
+
+Semantic navigation for HCL via the `terraform-ls` language server. Use the LSP
+for symbol relationships; use `rg` + Read for text. Pick by task, not by habit.
+
+terraform-ls is optional. Without it, every operation below degrades to a
+disclosed `rg` + Read fallback (see Degradation Gate). It is not a hard
+dependency of this skill.
+
+Self-contained terraform-ls specialization (capability matrix,
+`terraform init`, `moved` blocks, `.tfvars`) of a generic code-intelligence
+discipline - apply it directly.
+
+Recommended companion: the `code-intelligence` plugin (same
+`antonbabenko/agent-plugins` marketplace) is the single source of truth for the
+generic discipline - tool precedence, position anchoring, the two-case
+degradation gate, the first-line disclosure format, anti-phantom-shim proof -
+and ships `/code-intelligence:doctor`. When it is installed, defer to its
+generic protocol; the Terraform-specific capability matrix, routing, rename
+workflow, and operational notes below remain owned here and work without it.
+
+Security: `terraform init` may download modules and providers over the network.
+Do not auto-run it in untrusted working directories. terraform-ls indexes local
+source only; it does not execute the configuration.
+
+### Setup (host prerequisites)
+
+terraform-ls is optional; everything below degrades to a disclosed `rg` + Read
+fallback without it. To get the semantic tier:
+
+1. Install the language server:
+   - macOS: `brew install hashicorp/tap/terraform-ls`
+   - Any (Go): `go install github.com/hashicorp/terraform-ls@latest`
+   - Verify: `terraform-ls --version`
+2. Enable the agent's LSP tool. In Claude Code, export `ENABLE_LSP_TOOL=1`
+   in your shell rc and reload; LSP tools require explicit opt-in.
+3. Install an LSP transport that exposes a POSITION-based terraform-ls tool
+   (`filePath`, `line`, `character`). One option is the third-party
+   `terraform-ls` bridge from the `boostvolt/claude-code-lsps` marketplace:
+   `/plugin marketplace add boostvolt/claude-code-lsps` then
+   `/plugin install terraform-ls@claude-code-lsps`. If the only LSP tool
+   exposed takes a bare symbol name, the transport is wrong/old - reinstall
+   and fully restart the agent.
+4. Fully restart the agent (kill the process, not just a new session) -
+   plugins loading without a clean restart is the most common silent failure.
+5. Verify readiness. If the companion `code-intelligence` plugin is installed,
+   run `/code-intelligence:doctor` (checks `rg` + language servers including
+   terraform-ls). Otherwise verify by hand: `rg --version` prints
+   `ripgrep x.y.z`, `terraform-ls --version` succeeds, and a `documentSymbol`
+   call on a `variables.tf` returns symbols (liveness probe). An initialized
+   workspace (`terraform init` run, `.terraform/` present) is required for
+   cross-module and provider resolution.
+
+### terraform-ls Capability Matrix
+
+Anchor target for the SKILL.md diagnose row. What the server can and cannot do.
+
+| Operation | Supported | Semantic guarantee |
+|-----------|-----------|--------------------|
+| `goToDefinition` | ✅ | Jumps usage -> declaration (var/local/output/module/resource) |
+| `findReferences` | ✅ | Enumerates references to the symbol at the given position, workspace-scoped |
+| `documentSymbol` | ✅ | Outline of one file (blocks, variables, outputs, resources, modules) |
+| `hover` | ✅ | Provider/resource attribute docs and inferred type at position |
+| `workspaceSymbol` | ✅ | Broad symbol inventory; expensive, avoid for single-name lookup |
+| `goToImplementation` | ❌ | Not implemented by terraform-ls |
+| `prepareCallHierarchy` / `incomingCalls` / `outgoingCalls` | ❌ | No call hierarchy in terraform-ls |
+| rename provider | ❌ | No server-side rename; renames are manual (see below) |
+
+- ❌ Do not call unsupported operations and report their absence as a finding.
+  Redirect call-hierarchy intent to `findReferences`.
+- ✅ Treat `findReferences` as the authoritative reference set once the
+  Degradation Gate passes.
+
+### Position-Anchored Calls
+
+terraform-ls resolves by source position, not by symbol name.
+
+- ✅ Call with `file:line:character` pointing at an occurrence of the symbol.
+- ✅ Anchor the position first with `rg`/Grep (find a known occurrence), then
+  issue the LSP call at that location.
+- ❌ Never pass a bare symbol name and expect resolution. A name-only call
+  returning empty is a usage defect, not server degradation.
+- ✅ Prereq: a local `terraform` (or `tofu`) binary on PATH, and
+  `terraform init` run in the workspace, before relying on cross-module or
+  provider resolution.
+- ✅ Cold start: the first call after server launch may return empty while
+  indexing. Retry once before concluding anything.
+
+### Manual Rename Workflow
+
+terraform-ls has no rename provider. Branch by what is being renamed.
+
+**(a) Value symbol** - variable, local, output, or provider alias:
+
+1. `findReferences` at an anchored position to enumerate every reference.
+2. For EACH file with references: do a fresh Read of that file immediately
+   before editing it. Offsets shift after a prior in-file edit; a stale view
+   produces corrupted edits.
+3. Apply the edit, then re-run `terraform validate` and check LSP diagnostics
+   are clean.
+
+**(b) Resource or module address** - this is NOT a text rename:
+
+- Add a `moved` block and run `terraform plan`; confirm it shows 0 destroy /
+  0 create for the moved address.
+- See [Code Patterns: Moved Blocks](code-patterns#moved-blocks-terraform-11)
+  for block syntax and the count/for_each address rules.
+
+❌ Never blind-replace a resource address as text - it forces destroy/recreate.
+
+### Degradation Gate
+
+Pass ALL three before claiming "LSP unavailable, using rg instead". A vendored
+or uninitialized workspace can legitimately return empty.
+
+1. `documentSymbol` on a file in scope returns symbols -> server is
+   responsive. (Responsiveness only; NOT proof of complete reference coverage.)
+2. The failing call was position-anchored (not symbol-name-only).
+3. That anchored call still returned empty.
+
+Only then is a disclosed `rg` fallback warranted. State the substitution on the
+first line of the response:
+
+`Intended: terraform-ls findReferences. Actual: rg. Reason: <gate result>.
+Impact: text matches only, no semantic scoping - may include comments/strings.`
+
+❌ Do not assert a fallback without running the gate.
+❌ Do not bury the substitution at the end of the response.
+
+### When to Use rg Instead
+
+LSP is the wrong tool for these; go straight to `rg` + Read:
+
+- Exact text or a known literal string.
+- Known-name lookup where you already have the file and only need the line.
+- `.tfvars` files (values, not HCL symbol graph).
+- Comments, generated docs, READMEs, lockfiles.
+- Any non-HCL file.

--- a/misc/website/docs/skills/terraform-skill/references/code-patterns.md
+++ b/misc/website/docs/skills/terraform-skill/references/code-patterns.md
@@ -84,6 +84,8 @@ resource "aws_nat_gateway" "this" {
 }
 ```
 
+> Pattern applies identically on Azure/GCP; for resource equivalents see [Module Patterns: Cross-cloud resource map](module-patterns#cross-cloud-resource-map).
+
 ### Variable Definition Structure
 
 **Variable block ordering:**
@@ -253,11 +255,9 @@ variable "environments" {
   default = {
     dev = {
       instance_type = "t3.micro"
-      instance_count = 1
     }
     prod = {
       instance_type = "t3.large"
-      instance_count = 3
     }
   }
 }
@@ -266,7 +266,6 @@ resource "aws_instance" "app" {
   for_each = var.environments
 
   instance_type = each.value.instance_type
-  count         = each.value.instance_count
 
   tags = {
     Environment = each.key  # "dev" or "prod"
@@ -341,16 +340,81 @@ moved {
 # terraform plan should show "moved" operations, not destroy/create
 ```
 
-**Benefits after migration:**
-- Removing "us-east-1b" only destroys that subnet (not c)
-- Adding new AZ doesn't affect existing subnets
-- Resources have stable addresses by AZ name
+After migration: removing `us-east-1b` destroys only that subnet; adding an AZ does not churn existing resources; addresses are stable by AZ name.
+
+### `for_each` keys must be known at plan time
+
+`for_each` (0.12+) requires its key set resolvable during plan.
+
+| Case | Use | Why |
+|------|-----|-----|
+| stable key set known at plan | `for_each` over static map/var | avoids count index churn on insert/remove |
+| key set unknowable at plan | `count = bool ? 1 : 0` for singleton | keys derived from values unknown until apply |
+
+- ❌ `depends_on` does NOT fix `Invalid for_each argument` — it orders applies, not plan-time value resolution
+- ❌ deriving `for_each` keys from another resource's computed attrs (IDs, ARNs)
+- ✅ drive `for_each` from user-supplied variables or static locals
+
+```hcl
+# ❌ BAD - keys derived from computed IDs; plan fails
+resource "aws_eip" "web" {
+  for_each = toset([for i in aws_instance.web : i.id])
+  instance = each.key
+}
+
+# ✅ GOOD - drive for_each from user-supplied keys
+variable "instances" {
+  type = map(object({ instance_type = string }))
+}
+
+resource "aws_instance" "web" {
+  for_each      = var.instances
+  ami           = "ami-0123"
+  instance_type = each.value.instance_type
+}
+
+resource "aws_eip" "web" {
+  for_each = var.instances
+  instance = aws_instance.web[each.key].id
+}
+
+# ✅ GOOD - singleton when exact ID not known at plan
+resource "aws_eip" "bastion" {
+  count    = var.create_bastion ? 1 : 0
+  instance = aws_instance.bastion[0].id
+}
+```
 
 ---
 
 ## Modern Terraform Features (1.0+)
 
-### try() Function (Terraform 0.13+)
+### Feature Guard Table — Version Floor & Common LLM Errors
+
+Before emitting a feature, verify the runtime floor. Each feature here is also a known hallucination surface — the error pattern column names the mistake to avoid.
+
+| Feature | Min version | Common LLM error pattern |
+|---------|-------------|--------------------------|
+| `for_each` over `count` for stable identities | 0.12+ | defaults to `count` for every collection, causing index churn |
+| `try()` function | 0.12.20+ | falls back to `element(concat())` legacy pattern |
+| `nonsensitive()` function | 0.15+ | used to 'unwrap' sensitive outputs into plan artifacts, effectively laundering secrets into logs |
+| `nullable = false` | 1.1+ | omits it, letting `null` silently override defaults |
+| `moved` blocks | 1.1+ | omitted during refactor, causing destroy/create |
+| `optional()` with defaults | 1.3+ | emits wrapper variables and loose `map(any)` contracts |
+| declarative `import` blocks | 1.5+ | recommends ad-hoc CLI `terraform import` only |
+| `check` blocks | 1.5+ | ignores runtime assertions entirely |
+| native `terraform test` | 1.6+ | treats mocked-provider tests as full integration coverage |
+| mock providers | 1.7+ | asserts computed values in `command = plan` mode |
+| `removed` blocks | 1.7+ | deletes resources with no lifecycle transition |
+| provider-defined functions | 1.8+ | overuses data sources for simple transformations |
+| cross-variable validation | 1.9+ | pushes checks into postconditions only |
+| S3 native lock-file | 1.10+ | recommends DynamoDB lock table even on 1.10+ |
+| `ephemeral` values | 1.10+ | treats as interchangeable with `sensitive`; ephemeral values are scrubbed from state, `sensitive` only masks display |
+| `write_only` arguments | 1.11+ | uses `sensitive = true` and assumes state is safe |
+
+If target runtime is below a feature floor, emit the pre-floor fallback explicitly instead of silently downgrading.
+
+### try() Function (Terraform 0.12.20+)
 
 **Use try() instead of element(concat()):**
 
@@ -372,7 +436,7 @@ output "first_subnet_id" {
 
 # ❌ BAD - Legacy pattern
 output "security_group_id" {
-  value = element(concat(aws_security_group.this.*.id, [""]), 0)
+  value = element(concat(aws_security_group.this[*].id, [""]), 0)
 }
 ```
 
@@ -419,7 +483,7 @@ database_config = {
 
 ### Moved Blocks (Terraform 1.1+)
 
-**Rename resources without destroy/recreate:**
+**Rename resources without destroy/recreate.** Omitting `moved` during a refactor is one of the most common LLM mistakes — the model renames the address and silently turns the rename into destroy/create. Always emit `moved` in the same change as the rename, then verify `terraform plan` shows a move operation, not replacement.
 
 ```hcl
 # Rename a resource
@@ -441,17 +505,47 @@ moved {
 }
 ```
 
+**Limits of `moved` (1.1+):**
+
+| Limit | Can `moved` cross this? | Alternative |
+|-------|-------------------------|-------------|
+| Provider boundary | No | use `removed` (1.7+) + `import` (1.5+) |
+| State file / backend key | No | `state mv` across backends + pre-migration backup |
+| Module removal (module deleted from config) | `moved` block inside removed module silently stops working | add `moved` in the **parent**, not the removed module |
+
+### ignore_changes (Lifecycle Escape Hatch)
+
+- ✅ attribute-level `ignore_changes = [tags["X"]]` with a comment naming the external system
+- ❌ `ignore_changes = all` — hides real drift, turns every attribute unmanaged
+- ❌ use `ignore_changes` to silence noisy plans instead of diagnosing root cause
+
+```hcl
+# ❌ BAD - blanket ignore hides all drift
+resource "aws_db_instance" "this" {
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+# ✅ GOOD - narrow ignore with justification
+resource "aws_db_instance" "this" {
+  lifecycle {
+    # External compliance scanner rewrites this tag hourly
+    ignore_changes = [tags["LastScanned"]]
+  }
+}
+```
+
 ### Provider-Defined Functions (Terraform 1.8+)
 
 **Use provider-specific functions for data transformation:**
 
 ```hcl
 # AWS provider function example
-data "aws_region" "current" {}
-
 locals {
-  # Provider function (Terraform 1.8+)
-  bucket_name = provider::aws::arn_build("s3", "my-bucket", data.aws_region.current.name)
+  # provider::aws::arn_build(partition, service, region, account_id, resource)
+  # S3 ARNs are global: region and account_id are empty strings.
+  bucket_arn = provider::aws::arn_build("aws", "s3", "", "", "my-bucket")
 }
 
 # Check provider documentation for available functions
@@ -501,9 +595,20 @@ variable "backup_retention" {
 }
 ```
 
+### Validation Mechanism Timing
+
+Four mechanisms look similar and are routinely confused. Only three actually gate apply.
+
+| Mechanism | When it runs | Can reference | Blocks apply? |
+|-----------|--------------|---------------|---------------|
+| `validation` (in `variable`) | var evaluation, before plan | the variable's own value; other vars on 1.9+ | yes |
+| `precondition` (in `lifecycle`) | before resource create/update | other resources, data sources, vars | yes |
+| `postcondition` (in `lifecycle`) | after apply | the resource's own computed attrs | yes |
+| `check` block (1.5+) | every plan + apply | anything | **NO — advisory only, warnings not errors** |
+
 ### Write-Only Arguments (Terraform 1.11+)
 
-**Always use write-only arguments or external secret management:**
+**Always use write-only arguments or external secret management.** A common LLM mistake is to mark a variable `sensitive = true` and assume the value is kept out of state — it is not. `sensitive` only masks display; write-only arguments (or external secret lookups at runtime) are what actually keep material out of state. Verify on 1.11+: prefer `*_wo` arguments for credentials; on older runtimes, source secrets from a secret manager and never store them in variables or tfvars.
 
 ```hcl
 # ✅ GOOD - External secret with write-only argument
@@ -520,7 +625,10 @@ resource "aws_db_instance" "this" {
   instance_class = "db.t3.micro"
   username       = "admin"
 
-  # write-only: Terraform sends to AWS then forgets it (not in state)
+  # password_wo keeps the resource argument out of state (1.11+),
+  # but the data source still reads secret_string into state on refresh.
+  # For true state exclusion: use ephemeral (1.10+), manage_master_user_password,
+  # or inject via CI env var outside Terraform.
   password_wo = data.aws_secretsmanager_secret_version.db_password.secret_string
 }
 
@@ -539,6 +647,111 @@ resource "aws_db_instance" "this" {
 }
 ```
 
+### nonsensitive() and ephemeral (Terraform 0.15+ / 1.10+)
+
+| Goal | Use | Tradeoff |
+|------|-----|----------|
+| derived non-secret incorrectly inferred as sensitive | `nonsensitive()` (0.15+) | only safe when provably not secret; value enters plan |
+| short-lived credential that must never persist | `ephemeral` (1.10+) | never in state or plan; provider/resource must support it |
+| value must persist but not display | `sensitive = true` | still in state; masks terminal only |
+
+```hcl
+# ✅ GOOD - ephemeral keeps short-lived creds out of state (1.10+)
+# requires random provider >= 3.7.0
+ephemeral "random_password" "session" {
+  length = 32
+}
+
+# ❌ BAD - unwrapping a real secret to silence a warning
+output "db_endpoint" {
+  value = nonsensitive(aws_db_instance.this.password)
+}
+```
+
+### Dynamic Blocks — Iterator Shadowing + Set Ordering
+
+| Gotcha | Cause | Fix |
+|--------|-------|-----|
+| outer `each.*` inside nested `dynamic` | block-name iterator shadows `each` | `iterator = rule` rename |
+| non-deterministic block order | `for_each = toset([...])` on a map/object | use map keyed by stable field |
+
+- ❌ bare `dynamic "ingress"` inside outer `for_each` — `ingress.value` shadows `each.value`
+- ✅ rename inner iterator with `iterator = rule`; reference outer via `each.*`
+
+```hcl
+# ✅ GOOD - explicit iterator rename removes ambiguity
+resource "aws_security_group" "this" {
+  for_each = var.security_groups
+
+  name = each.key
+
+  dynamic "ingress" {
+    for_each = each.value.rules
+    iterator = rule
+    content {
+      from_port   = rule.value.from_port
+      to_port     = rule.value.to_port
+      protocol    = rule.value.protocol
+      description = each.value.description  # outer iterator clear
+    }
+  }
+}
+```
+
+---
+
+## Provisioners as Last Resort
+
+| Goal | Use |
+|------|-----|
+| Instance bootstrap | `user_data` + cloud-init via `templatefile()` |
+| Orchestration with explicit re-run (1.4+) | `terraform_data` + `triggers_replace` (list; `null_resource` uses `triggers` map) |
+| Ongoing OS config | External: Ansible / SSM Run Command / SSM State Manager |
+| Last-resort one-shot | `terraform_data` + `provisioner` (1.4+) or `null_resource` (pre-1.4) |
+
+**Provisioner costs (`local-exec` + `remote-exec`):**
+
+- ❌ Non-idempotent — re-runs duplicate side effects
+- ❌ Create-only — updates don't re-run; `when = destroy` is fragile
+- ❌ `remote-exec` needs SSH/WinRM from runner to target
+- ❌ No drift detection — Terraform can't observe what scripts changed
+- ❌ Script stdout/stderr leaks to CI logs; `sensitive` won't redact it
+
+**❌ DON'T — `null_resource` for bootstrap on 1.4+:**
+
+```hcl
+resource "null_resource" "bootstrap" {
+  provisioner "local-exec" {
+    command = "ssh ec2-user@${aws_instance.web.public_ip} 'bash setup.sh'"
+  }
+}
+```
+
+**✅ DO — bootstrap via `user_data` + cloud-init:**
+
+```hcl
+resource "aws_instance" "web" {
+  ami           = data.aws_ami.al2023.id
+  instance_type = "t3.small"
+  user_data = templatefile("${path.module}/cloud-init.yaml", {
+    app_version = var.app_version
+  })
+  user_data_replace_on_change = true
+}
+```
+
+**✅ DO — declarative orchestration on 1.4+:**
+
+```hcl
+resource "terraform_data" "migration" {
+  triggers_replace = [aws_rds_cluster.this.id, var.schema_version]
+
+  provisioner "local-exec" {
+    command = "./run-migration.sh"
+  }
+}
+```
+
 ---
 
 ## Version Management
@@ -550,9 +763,9 @@ resource "aws_db_instance" "this" {
 version = "5.0.0"
 
 # Pessimistic constraint (recommended for stability)
-# Allows patch updates only
-version = "~> 5.0"      # Allows 5.0.x (any x), but not 5.1.0
-version = "~> 5.0.1"    # Allows 5.0.x where x >= 1, but not 5.1.0
+# The rightmost component is the one that's allowed to increment.
+version = "~> 5.0"      # 5.x: >= 5.0, < 6.0 — allows 5.1, 5.2, 5.99
+version = "~> 5.0.1"    # 5.0.x patches only: >= 5.0.1, < 5.1.0
 
 # Range constraints
 version = ">= 5.0, < 6.0"     # Any 5.x version
@@ -708,7 +921,7 @@ terraform {
 ```hcl
 # Before (0.12 style)
 output "security_group_id" {
-  value = element(concat(aws_security_group.this.*.id, [""]), 0)
+  value = element(concat(aws_security_group.this[*].id, [""]), 0)
 }
 
 variable "config" {
@@ -736,87 +949,55 @@ variable "config" {
 
 ### Secrets Remediation
 
-**Pattern:** Move secrets out of Terraform state into external secret management.
+Move secret material out of state into external secret management. Canonical depth lives in [security-compliance.md](security-compliance) — patterns below are the minimum refactor shape.
 
-#### Before - Secrets in State
+❌ BAD — both shapes land the secret in state:
 
 ```hcl
-# ❌ BAD - Secret generated and stored in state
+# random_password.result lives in state
 resource "random_password" "db" {
   length  = 16
   special = true
 }
-
 resource "aws_db_instance" "this" {
-  engine   = "mysql"
-  username = "admin"
-  password = random_password.db.result  # In state!
+  password = random_password.db.result
 }
 
-# OR
-
-# ❌ BAD - Secret passed via variable and stored in state
+# var + sensitive = true still writes to state (sensitive only masks display)
 variable "db_password" {
-  description = "Database password"
-  type        = string
-  sensitive   = true  # Marked sensitive but still in state!
+  type      = string
+  sensitive = true
 }
-
 resource "aws_db_instance" "this" {
-  password = var.db_password  # In state!
+  password = var.db_password
 }
 ```
 
-#### After - External Secret Management
-
-**Option 1: Write-only arguments (Terraform 1.11+)**
+✅ GOOD — 1.11+ write-only argument, secret created outside Terraform:
 
 ```hcl
-# ✅ GOOD - Fetch from AWS Secrets Manager
-data "aws_secretsmanager_secret" "db_password" {
-  name = "prod-database-password"
-}
-
 data "aws_secretsmanager_secret_version" "db_password" {
-  secret_id = data.aws_secretsmanager_secret.db_password.id
+  secret_id = "prod-database-password"
 }
 
 resource "aws_db_instance" "this" {
   engine   = "mysql"
   username = "admin"
-
-  # write-only: Sent to AWS, not stored in state
+  # password_wo: resource argument stays out of state (1.11+).
+  # Data source still reads secret_string into state on refresh.
+  # For true state exclusion: ephemeral (1.10+), manage_master_user_password, or CI env var.
   password_wo = data.aws_secretsmanager_secret_version.db_password.secret_string
 }
 ```
 
-**Option 2: Separate secret creation (if Terraform 1.11+ not available)**
-
-```hcl
-# ✅ GOOD - Reference pre-existing secret
-# Secret created outside Terraform (manually or separate process)
-
-data "aws_secretsmanager_secret" "db_password" {
-  name = "prod-database-password"
-}
-
-data "aws_secretsmanager_secret_version" "db_password" {
-  secret_id = data.aws_secretsmanager_secret.db_password.id
-}
-
-# Note: Without write-only, you may need to handle secret rotation
-# outside Terraform or accept that the secret value appears in state
-# during initial creation but not after rotation
-```
+Pre-1.11 fallback: use the same data source without `password_wo`; rotation must happen outside Terraform.
 
 **Migration steps:**
 
-1. Create secret in AWS Secrets Manager (outside Terraform)
-2. Update Terraform to use data sources
-3. Use write-only argument (if Terraform 1.11+)
-4. Remove `random_password` resource or variable
-5. Run `terraform apply` to update
-6. Verify secret not in state: `terraform show` should not display password
+1. Create secret in AWS Secrets Manager outside Terraform
+2. Replace `random_password` / variable with `data "aws_secretsmanager_secret_version"`
+3. On 1.11+: use `password_wo`
+4. Apply, then `terraform show | grep -i password` — must be empty
 
 ---
 
@@ -860,15 +1041,39 @@ resource "aws_subnet" "public" {
 # With local: Subnets deleted first, then CIDR association, then VPC ✓
 ```
 
-**Why this matters:**
-- Prevents deletion errors when destroying infrastructure
-- Ensures correct dependency order without explicit `depends_on`
-- Particularly useful for complex VPC configurations with secondary CIDR blocks
-
 **Common use cases:**
 - VPC with secondary CIDR blocks
-- Resources that depend on optional configurations
-- Complex deletion order requirements
+- Resources depending on optional configurations
+- Complex deletion-order requirements
+
+---
+
+## LLM Mistake Checklist — Code Patterns
+
+Common model mistakes when generating HCL. Correct these before returning code:
+
+- defaults to `count` for every collection — prefer `for_each` with stable keys whenever identity matters
+- omits `moved` blocks during rename/refactor, silently turning the change into destroy/create
+- builds `for_each` keys from computed IDs not known until apply — planning will fail
+- uses list index as long-lived identity (`count.index`) instead of business-meaningful keys
+- marks variables `sensitive = true` and assumes the value stays out of state — on 1.11+ use `write_only` / `*_wo` arguments
+- falls back to `element(concat(...))` instead of `try()` on 0.12.20+
+- accepts untyped `map(any)` / `any` for long-lived module contracts instead of `optional()` with typed defaults (1.3+)
+- suggests `terraform state mv` where `moved` blocks are safer and reviewable
+- recommends ad-hoc CLI `terraform import` instead of declarative `import` blocks (1.5+)
+- emits an exact `version = "5.0.0"` pin where `~> 5.0` would be more maintainable
+- silently emits 1.11+ features (S3 native lock, `write_only`, `removed`) without checking the runtime floor
+- uses `nonsensitive()` to "fix" a sensitive value appearing in plan output — this leaks secrets into CI artifacts
+- conflates `sensitive = true` with `ephemeral` (1.10+); only `ephemeral` actually stays out of state
+- writes a `moved` block expecting it to cross provider boundaries; it cannot
+- leaves `moved` blocks inside a module that itself is being removed — the moves silently no-op, resources get destroyed
+- emits CLI `terraform import` in automation when declarative `import` blocks (1.5+) give a reviewable, VCS-tracked alternative
+- emits `ignore_changes = all` or broad ignore lists to silence plan output instead of diagnosing drift root cause
+- uses `check` block expecting it to block apply; `check` is advisory, emits warnings only. Use `precondition`/`postcondition` to gate.
+- uses `each.value` inside a `dynamic` block intending the outer iterator — shadowed by the inner block name; rename with `iterator = ...`
+- emits hardcoded cloud IDs/ARNs (`vpc-0abc...`, pattern-matched `arn:aws:iam::` patterns) from training data instead of using data sources or input variables
+- pairs `password_wo` with `aws_secretsmanager_secret_version` — the data source still reads `secret_string` into state on refresh. Use `ephemeral` (1.10+) or CI-injected env var.
+- iterates `dynamic` blocks over `toset(...)` of maps/objects — the set's undefined ordering causes non-deterministic block ordering in the plan diff; sort the list or use a map keyed by a stable field
 
 ---
 

--- a/misc/website/docs/skills/terraform-skill/references/module-patterns.md
+++ b/misc/website/docs/skills/terraform-skill/references/module-patterns.md
@@ -40,8 +40,6 @@ This document provides detailed guidance on creating reusable, maintainable Terr
 
 ### Module Type Classification
 
-Terraform modules can be organized into three distinct types, each serving a specific purpose:
-
 | Type | When to Use | Scope | Example |
 |------|-------------|-------|---------|
 | **Resource Module** | Single logical group of connected resources | Tightly coupled resources that always work together | VPC + subnets, Security group + rules, IAM role + policies |
@@ -174,11 +172,7 @@ data.tf           # Optional: Data sources (if main.tf gets large)
 backend.tf        # ONLY at composition level (remote state config)
 ```
 
-**Why separate files?**
-- **Consistency:** Same structure across all modules
-- **Discoverability:** Know where to find specific types of configuration
-- **Maintainability:** Easier to navigate and modify
-- **Terraform Registry:** Required structure for publishing
+Required structure for Terraform Registry publishing; keeps navigation consistent across modules.
 
 ---
 
@@ -186,11 +180,7 @@ backend.tf        # ONLY at composition level (remote state config)
 
 ### 1. Smaller Scopes = Better Performance + Reduced Blast Radius
 
-**Benefits:**
-- Faster `terraform plan` and `terraform apply` operations
-- Isolated failures don't affect unrelated infrastructure
-- Easier to reason about changes
-- Parallel development by multiple teams
+Faster `plan`/`apply`, isolated failures, parallel team development.
 
 **Example:**
 
@@ -212,43 +202,42 @@ environments/prod/
 
 ### 2. Always Use Remote State
 
-**Why:**
-- **Prevents race conditions** with multiple developers
-- **Provides disaster recovery** (state versioning)
-- **Enables team collaboration** (shared access)
-- **Supports state locking** (prevents concurrent modifications)
+- ❌ local `terraform.tfstate` — no locking, no backup, no team access
+- ✅ remote backend — locking, versioning, encryption, audit log
 
-**Never:**
 ```hcl
-# ❌ BAD - Local state (default)
-# State stored in local terraform.tfstate file
-# Lost if computer crashes
-# Can't share with team
-```
-
-**Always:**
-```hcl
-# ✅ GOOD - Remote state
 terraform {
   backend "s3" {
-    bucket         = "my-terraform-state"
-    key            = "prod/networking/terraform.tfstate"
-    region         = "us-east-1"
-    dynamodb_table = "terraform-locks"  # State locking
-    encrypt        = true                # Encryption at rest
+    bucket       = "my-terraform-state"
+    key          = "prod/networking/terraform.tfstate"
+    region       = "us-east-1"
+    encrypt      = true
+    use_lockfile = true   # Terraform 1.10+; native S3 locking
+    # Pre-1.10 runtime: use dynamodb_table = "terraform-locks" instead
   }
 }
 ```
 
-### 3. Use terraform_remote_state as Glue
+### 3. Use terraform_remote_state Sparingly — Only at True Ownership Boundaries
 
-**Pattern:** Connect compositions via remote state data sources
+**Pattern:** Connect separately-owned compositions via remote state data sources. Reserve it for genuine team/lifecycle boundaries, not as convenient glue inside a single-team stack.
 
-**Why:**
-- Loose coupling between infrastructure components
-- Teams can work independently
-- Changes to one stack don't require rebuilding others
-- Outputs from one stack become inputs to another
+**Use it when ALL of these are true:**
+- Consumer and producer are owned by **different teams** or have **different release cadences**
+- The producer's state is already split for lifecycle reasons (networking vs. compute vs. data)
+- You cannot reasonably pass the same values as module inputs
+
+**Do NOT use it when:**
+- You control both stacks and can wire via module outputs
+- You're reading values that would be better served by a cloud data source (e.g., `aws_vpc` by tag)
+- You're reaching across >2 remote states in one composition — that is a signal to reshape boundaries, not add more wiring
+
+**Common LLM mistakes:**
+- reaches for `terraform_remote_state` as default integration pattern
+- chains many `terraform_remote_state` reads, creating hidden cross-stack coupling
+- reads values that can drift at the provider level (use cloud data sources instead)
+
+At real boundaries, outputs from one stack become typed inputs to another — teams release independently without shared mutable state.
 
 **Example:**
 
@@ -282,11 +271,8 @@ module "ec2" {
 }
 ```
 
-**Best practices:**
-- Use remote state for cross-team dependencies
-- Document which outputs are consumed by other stacks
-- Version outputs (don't break downstream consumers)
-- Consider using data sources instead for provider-managed resources
+- ✅ document which outputs are consumed externally; version outputs, never break downstream consumers silently
+- ✅ prefer cloud data sources (`aws_vpc` by tag) over `terraform_remote_state` for provider-managed resources
 
 ### 4. Keep Resource Modules Simple
 
@@ -329,6 +315,16 @@ resource "aws_instance" "web" {
   tags = var.tags
 }
 ```
+
+### Cross-cloud resource map
+
+| Resource | AWS | Azure | GCP |
+|----------|-----|-------|-----|
+| Network | `aws_vpc` | `azurerm_virtual_network` | `google_compute_network` |
+| Subnet | `aws_subnet` | `azurerm_subnet` | `google_compute_subnetwork` |
+| Compute instance | `aws_instance` | `azurerm_linux_virtual_machine` | `google_compute_instance` |
+| Managed relational DB | `aws_db_instance` / `aws_rds_cluster` | `azurerm_*_flexible_server` | `google_sql_database_instance` |
+| Object storage | `aws_s3_bucket` | `azurerm_storage_account` + `azurerm_storage_container` | `google_storage_bucket` |
 
 ### 5. Composition Layer: Environment-Specific Values Only
 
@@ -392,74 +388,46 @@ my-module/
     └── module_test.tftest.hcl  # Or .go
 ```
 
-### Why This Structure?
+### File Role
 
-- **README.md** - First thing users see, should explain module purpose
-- **LICENSE** - Legal terms for public modules (MIT or Apache 2.0)
-- **.pre-commit-config.yaml** - Automated validation before commits
-- **main.tf** - Primary resources, keep focused
-- **variables.tf** - All inputs in one place with descriptions
-- **outputs.tf** - All outputs documented
-- **versions.tf** - Lock provider versions for stability
-- **examples/** - Serve as both documentation and test fixtures
-- **tests/** - Automated testing
+- `README.md` — module purpose, first file users see
+- `LICENSE` — legal terms for public modules (MIT or Apache 2.0)
+- `.pre-commit-config.yaml` — automated validation before commits
+- `main.tf` — primary resources, keep focused
+- `variables.tf` — all inputs, with descriptions
+- `outputs.tf` — all outputs, with descriptions
+- `versions.tf` — pinned provider versions
+- `examples/` — docs + test fixtures
+- `tests/` — automated tests
 
 ### License Files
 
-For public modules, always include a LICENSE file:
-- **MIT License** - Simple, permissive (common for public modules)
-- **Apache 2.0** - Permissive with patent grant protection
-
-**Important:** Do NOT store LICENSE templates in this skill. Generate them during module creation using user preference.
-
-**When to include:**
-- ✅ Public modules (GitHub, Terraform Registry)
-- ✅ Open-source projects
-- ❌ Private internal modules (optional)
-- ❌ Environment-specific configurations
+- ✅ Public modules / open-source projects — include LICENSE (MIT = permissive; Apache 2.0 = permissive + patent grant)
+- ❌ Private internal modules / environment-specific configs — optional
+- ❌ Do NOT store LICENSE templates in this skill; generate them on demand from user preference
 
 ### Terraform vs OpenTofu Preference
 
-**Before generating any module or configuration:**
+HCL is identical; choice affects commands, README, CI invocations, binary references only. Ask before generating if not specified.
 
-1. **Ask the user:** "Will this be for Terraform or OpenTofu? (Both are supported equally)"
+**Inference signals (when a project already exists):**
+- `required_version` constraint or comments pinning the runtime
+- CI pipelines invoking `terraform` vs `tofu` explicitly
+- `.terraform.lock.hcl` provenance (check commit history / init script)
+- ❌ `.terraform/` working directory — both runtimes share it, not a differentiator
 
-2. **Use the preference throughout:**
-   - Command examples: `terraform` vs `tofu`
-   - README documentation
-   - CI/CD workflow templates
-   - Version constraints
-   - Binary references
+If signals are mixed, ask the user rather than guessing, or show both command variants in docs.
 
-3. **Document the choice:**
-   ```markdown
-   ## Requirements
+Document the chosen runtime in the module README:
 
-   | Name | Version |
-   |------|---------|
-   | [terraform/tofu] | >= 1.7.0 |
-   | aws | >= 6.0 |
-   ```
+```markdown
+## Requirements
 
-4. **Example command variations:**
-   ```bash
-   # Terraform
-   terraform init
-   terraform test
-   terraform plan
-
-   # OpenTofu
-   tofu init
-   tofu test
-   tofu plan
-   ```
-
-**Note:** The choice is primarily about commands and documentation. The HCL code itself is identical.
-
-**Default behavior:**
-- If user doesn't specify: Ask explicitly
-- If project already exists: Detect from existing files (`.terraform/` or `.tofu/`)
-- If still unclear: Default to showing both options in documentation
+| Name | Version |
+|------|---------|
+| [terraform/tofu] | >= 1.7.0 |
+| aws | ~> 5.0 |
+```
 
 ---
 
@@ -514,6 +482,55 @@ var.type
 var.value
 ```
 
+### Provider Requirements and Alias Passing
+
+- ✅ Child module declares aliased providers: `configuration_aliases = [aws.primary, aws.replica]`
+- ✅ Caller passes them explicitly: `providers = { aws.primary = aws.<caller-alias> }` on the `module` block
+- ❌ Default provider inheritance applies ONLY to a single unaliased provider — never for aliases
+
+Child module — declare aliases in `versions.tf`, bind per resource:
+
+```hcl
+# modules/replicated-s3/versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 5.0"
+      configuration_aliases = [aws.primary, aws.replica]
+    }
+  }
+}
+
+# in any resource:
+provider = aws.primary
+```
+
+Caller — pass the `providers` map on the `module` block:
+
+```hcl
+module "bucket" {
+  source      = "./modules/replicated-s3"
+  bucket_name = "app-data"
+
+  providers = {
+    aws.primary = aws.us_east_1
+    aws.replica = aws.eu_west_1
+  }
+}
+```
+
+❌ DON'T — missing `providers` map on the module call:
+
+```hcl
+module "bucket" {
+  source      = "./modules/replicated-s3"
+  bucket_name = "app-data"
+  # MISSING: providers = { aws.primary = ..., aws.replica = ... }
+  # Plan fails: "No configuration for provider aws.primary"
+}
+```
+
 ---
 
 ## Output Best Practices
@@ -558,36 +575,11 @@ output "connection_info" {
 
 ## Common Patterns
 
-### ✅ DO: Use `for_each` for Resources
+### Iteration: `for_each` vs `count`
 
-```hcl
-# Good: Maintain stable resource addresses
-resource "aws_instance" "server" {
-  for_each = toset(["web", "api", "worker"])
+Use `for_each` with stable keys whenever a collection has meaningful identity — removing or reordering an element leaves unrelated addresses untouched. Reserve `count` for optional singletons (`0` or `1`) and cases where keys cannot be known at plan time.
 
-  instance_type = "t3.micro"
-  tags = {
-    Name = each.key
-  }
-}
-```
-
-**Why?** When you remove an item from the middle, `for_each` doesn't reshuffle other resources.
-
-### ❌ DON'T: Use `count` When Order Matters
-
-```hcl
-# Bad: Removing middle item reshuffles all subsequent resources
-resource "aws_instance" "server" {
-  count = length(var.server_names)
-
-  tags = {
-    Name = var.server_names[count.index]
-  }
-}
-```
-
-**Problem:** If you remove `var.server_names[1]`, Terraform will destroy and recreate all instances after it.
+For the decision matrix, migration playbook, and known-at-plan failure patterns, see [Code Patterns: count vs for_each](code-patterns#count-vs-for_each-deep-dive).
 
 ### ✅ DO: Separate Root Module from Reusable Modules
 
@@ -603,7 +595,7 @@ modules/webapp/
   variables.tf     # Configurable inputs
 ```
 
-**Why?** Root modules are environment-specific, reusable modules are generic.
+Root modules are environment-specific; reusable modules are generic.
 
 ### ✅ DO: Use Locals for Computed Values
 
@@ -638,7 +630,7 @@ module "vpc" {
 }
 ```
 
-**Why?** Prevents unexpected breaking changes.
+Prevents unexpected breaking changes from upstream major bumps.
 
 ---
 
@@ -723,24 +715,7 @@ environments/
 
 ### ❌ DON'T: Use `terraform_remote_state` Everywhere
 
-```hcl
-# Overused: Creates tight coupling
-data "terraform_remote_state" "vpc" {
-  # ...
-}
-
-data "terraform_remote_state" "database" {
-  # ...
-}
-
-data "terraform_remote_state" "security" {
-  # ...
-}
-```
-
-**Problem:** Changes to one state file break others.
-
-**Fix:** Use module outputs when possible, reserve remote state for truly separate teams.
+Use module outputs when possible. Reserve remote state for ownership boundaries between teams. See [Use terraform_remote_state Sparingly](#3-use-terraform_remote_state-sparingly--only-at-true-ownership-boundaries) for the full rule set.
 
 ---
 
@@ -773,369 +748,47 @@ acme-terraform-aws-rds
 
 ---
 
-## Testing Your Modules
+## Module Release Checklist
 
-For testing guidance, see [testing-frameworks.md](testing-frameworks).
+Before publishing or handing off a reusable module:
 
-Quick checklist:
-
-- [ ] Ask: Terraform or OpenTofu?
-- [ ] Ask: Public or private module?
-- [ ] Include `examples/` directory
-- [ ] Write tests (native or Terratest)
-- [ ] Document inputs and outputs in README.md
-- [ ] Version your module
-- [ ] Create `.gitignore` (from template below)
-- [ ] Create `.pre-commit-config.yaml` (from template above)
-- [ ] Create `LICENSE` file (MIT or Apache 2.0 for public modules)
-- [ ] Add attribution footer to README.md (see template below)
-
-### Pre-commit Hooks
-
-When creating new modules, always include pre-commit hooks for automated validation and documentation generation:
-
-**Standard .pre-commit-config.yaml template:**
-
-```yaml
-# .pre-commit-config.yaml
-repos:
-  - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.92.0  # Use latest version from releases
-    hooks:
-      - id: terraform_fmt
-      - id: terraform_validate
-      - id: terraform_tflint
-      - id: terraform_docs
-```
-
-**Installation:**
-
-```bash
-# Install pre-commit
-pip install pre-commit
-
-# Install hooks
-pre-commit install
-
-# Run manually
-pre-commit run -a
-```
-
-**Best practices:**
-- Include `.pre-commit-config.yaml` in all new modules
-- Pin to specific pre-commit-terraform version
-- Update version regularly
-
-**For module generation:**
-When generating new modules, also create:
-- `.pre-commit-config.yaml` (from template above)
-- `LICENSE` file (MIT or Apache 2.0, based on user preference)
-- `.gitignore` (from template below)
-- `README.md` with attribution footer (see template below)
-
-#### README.md Attribution Template
-
-When generating module README.md files, include this attribution footer:
-
-```markdown
-## Attribution
-
-This module was created following best practices from [terraform-skill](https://github.com/antonbabenko/terraform-skill) by Anton Babenko.
-
-Additional resources:
-- [terraform-best-practices.com](https://terraform-best-practices.com)
-- [Compliance.tf](https://compliance.tf)
-```
-
-**When to include attribution:**
-- ✅ All new modules created with terraform-skill guidance
-- ✅ Public modules (GitHub, Terraform Registry)
-- ✅ Private modules shared within organizations
-- ⚠️ Optional for one-off environment configurations
-
-**Rationale:** This is a derivative work as defined in the Apache 2.0 License Section 1. Attribution supports the open-source ecosystem and helps others discover these best practices.
-
-**README Structure with Attribution:**
-```markdown
-# Module Name
-
-## Description
-[Module purpose]
-
-## Usage
-[Usage examples]
-
-## Inputs
-[Input variables]
-
-## Outputs
-[Output values]
-
-## Requirements
-[Terraform/OpenTofu versions, providers]
-
-## Attribution
-[Attribution footer from template above]
-```
-
-#### .gitignore Template
-
-**Standard .gitignore for Terraform/OpenTofu projects:**
-
-```gitignore
-# .gitignore - Terraform/OpenTofu projects
-# Based on terraform-skill best practices
-
-# Local .terraform directories
-**/.terraform/*
-
-.terraform.lock.hcl
-
-# .tfstate files - NEVER commit state files
-*.tfstate
-*.tfstate.*
-
-# Crash log files
-crash.log
-crash.*.log
-
-# Exclude all .tfvars files (may contain sensitive data)
-*.tfvars
-*.tfvars.json
-
-# Ignore override files (local development)
-override.tf
-override.tf.json
-*_override.tf
-*_override.tf.json
-
-# CLI configuration files
-.terraformrc
-terraform.rc
-
-# Environment variables and secrets
-.env
-.env.*
-secrets/
-*.secret
-*.pem
-*.key
-
-# IDE and editor files
-.idea/
-.vscode/
-*.swp
-*.swo
-*~
-.DS_Store
-
-# Terraform plan output files
-*.tfplan
-*.tfplan.json
-```
+- [ ] Runtime and provider choice explicit (Terraform vs OpenTofu, version floor in `required_version`)
+- [ ] Public vs private scope decided (affects naming + license)
+- [ ] `examples/` directory with at least `minimal` and `complete`
+- [ ] Tests written (native `terraform test` on 1.6+, or Terratest) — see [testing-frameworks.md](testing-frameworks)
+- [ ] README documents all inputs/outputs (Description → Usage → Inputs → Outputs → Requirements)
+- [ ] Module source pinned with `version` in consumer code
+- [ ] `pre-commit-terraform` hooks configured (`terraform_fmt`, `terraform_validate`, `terraform_tflint`, `terraform_docs`), pinned to a specific `rev`
+- [ ] `LICENSE` present for public modules (MIT or Apache-2.0)
+- [ ] `.gitignore` excludes `.terraform/`, `*.tfstate*`, `*.tfvars`, override files, and editor artifacts
 
 ---
 
-## Testing Philosophy & Patterns
+## Module Testing — Pointer
 
-### What to Test in Terraform Modules
+Module testing (what to test, tiered layers, mocking, idempotency, cost control, strategy by module type) is canonical in [Testing Frameworks](testing-frameworks). Module-specific rules that belong with the module contract:
 
-**Core testing areas:**
-- **Input validation** - Variables accept valid values and reject invalid ones
-- **Resource creation** - Resources are created as expected with correct attributes
-- **Output correctness** - Outputs return expected values and types
-- **Idempotency** - Applying twice doesn't recreate resources
-- **Destroy completeness** - All resources are cleaned up properly
+- Every reusable module must exercise its `validation` blocks in tests — reject cases are as important as happy paths.
+- Tier tests by module role: **resource modules** → input validation + attribute assertions; **infrastructure modules** → composition + cross-module wiring; **compositions** → smoke-plan + production-like values + remote-state connectivity.
+- Mock providers (1.7+) for unit tests; reserve real cloud runs for main-branch or scheduled jobs.
 
-**When to write tests:**
-- During development for reusable modules
-- Before publishing modules to registry
-- After significant refactoring
-- For modules with complex logic or conditionals
+---
 
-### Testing Layers
+## LLM Mistake Checklist — Modules
 
-**1. Syntax validation:**
-```bash
-terraform fmt -check -recursive
-```
+Common model mistakes to correct when generating or reviewing modules:
 
-**2. Configuration validity:**
-```bash
-terraform validate
-```
-
-**3. Plan preview:**
-```bash
-terraform plan
-# Review: Are expected resources being created?
-# Verify: Count and types of resources match expectations
-```
-
-**4. Integration testing:**
-```bash
-# Apply and verify
-terraform apply -auto-approve
-
-# Verify resources exist (use AWS CLI, etc.)
-aws ec2 describe-vpcs --vpc-ids $(terraform output -raw vpc_id)
-
-# Test idempotency - should show no changes
-terraform plan
-# Expected: "No changes. Your infrastructure matches the configuration."
-
-# Clean up
-terraform destroy -auto-approve
-```
-
-### Input Validation Testing
-
-Test that variables reject invalid values:
-
-```hcl
-# In variables.tf
-variable "environment" {
-  description = "Environment name"
-  type        = string
-
-  validation {
-    condition     = contains(["dev", "staging", "prod"], var.environment)
-    error_message = "Environment must be one of: dev, staging, prod."
-  }
-}
-
-# Test: terraform plan with invalid value should fail
-# terraform plan -var="environment=invalid"
-# Expected: Error message about validation failure
-```
-
-### Output Verification Testing
-
-After apply, verify outputs contain expected values:
-
-```bash
-# Verify output is not empty
-VPC_ID=$(terraform output -raw vpc_id)
-[ -z "$VPC_ID" ] && echo "ERROR: VPC ID is empty" || echo "OK: VPC ID is $VPC_ID"
-
-# Verify output format
-SUBNET_IDS=$(terraform output -json subnet_ids)
-echo $SUBNET_IDS | jq 'length'  # Should match expected subnet count
-```
-
-### Idempotency Testing
-
-**Critical test** - ensures Terraform doesn't recreate resources unnecessarily:
-
-```bash
-# Apply configuration
-terraform apply -auto-approve
-
-# Immediately run plan - should show no changes
-terraform plan -detailed-exitcode
-# Exit code 0 = no changes (idempotent) ✓
-# Exit code 2 = changes detected (not idempotent) ✗
-```
-
-**Why idempotency matters:**
-- Proves configuration is stable
-- No resource churn on repeated applies
-- Safe to run in CI/CD pipelines
-- Indicates proper use of computed values
-
-### Destroy Testing
-
-Verify all resources are properly cleaned up:
-
-```bash
-# Before destroy - count resources
-BEFORE_COUNT=$(terraform state list | wc -l)
-
-# Destroy
-terraform destroy -auto-approve
-
-# After destroy - verify state is empty
-AFTER_COUNT=$(terraform state list | wc -l)
-[ "$AFTER_COUNT" -eq 0 ] && echo "OK: All resources destroyed" || echo "ERROR: Resources remain"
-```
-
-### Testing Anti-patterns
-
-**❌ Don't:**
-- Skip idempotency testing (most important test)
-- Test only happy paths (test validation failures too)
-- Forget to clean up test resources
-- Run expensive integration tests on every commit
-- Test Terraform syntax (terraform validate does this)
-
-**✅ Do:**
-- Test that validation blocks reject invalid input
-- Verify outputs have expected types and formats
-- Test conditional resource creation (count/for_each)
-- Document expected resource counts in tests
-- Use mocking for unit tests (Terraform 1.7+)
-- Run integration tests only on main branch or scheduled
-
-### Testing Strategy by Module Type
-
-**Resource modules:**
-- Focus on input validation
-- Test resource creation with minimal config
-- Verify outputs are correct
-- Test idempotency
-
-**Infrastructure modules:**
-- Test module composition works
-- Verify cross-module dependencies
-- Test with different configurations
-- Integration tests in test account
-
-**Compositions:**
-- Smoke tests (can it plan?)
-- Test with production-like values
-- Verify remote state connectivity
-- Manual QA in lower environments first
-
-### Cost Control for Testing
-
-**Strategies:**
-
-1. **Use mocking for unit tests** (Terraform 1.7+)
-   ```hcl
-   mock_provider "aws" {
-     mock_data "aws_ami" {
-       defaults = {
-         id = "ami-12345678"
-       }
-     }
-   }
-   ```
-
-2. **Tag test resources for tracking**
-   ```hcl
-   tags = {
-     Environment = "test"
-     TTL         = "2h"
-     ManagedBy   = "terraform-test"
-   }
-   ```
-
-3. **Run integration tests only on main branch**
-   ```yaml
-   if: github.ref == 'refs/heads/main'
-   ```
-
-4. **Use smaller instance types**
-   ```hcl
-   instance_type = var.environment == "test" ? "t3.micro" : var.instance_type
-   ```
-
-5. **Implement auto-cleanup**
-   - Use AWS Lambda to delete resources with expired TTL tags
-   - Run destroy in CI/CD after tests complete
-   - Use terraform-compliance to enforce TTL tags
-
-**For testing framework details, see:** [Testing Frameworks Guide](testing-frameworks)
+- bundles unrelated resources into one "god module" instead of splitting by single responsibility
+- hardcodes environment-specific values (`instance_type = "m5.large"`, `Environment = "production"`) inside a reusable module
+- accepts untyped `map(any)` / `any` for core module inputs instead of typed objects with `optional()` defaults
+- exposes entire provider or resource objects as outputs, leaking the whole contract instead of a stable subset
+- omits `description` on inputs and outputs, forcing consumers to read the implementation
+- uses `this` for multiple resources of the same type — reserve `this` for genuine singletons only
+- reaches for `terraform_remote_state` inside a single team's stack instead of wiring via module outputs
+- floats module sources (no `version` pin) in consumer code
+- pushes environment-specific policy (prod-only allowlists, region pins) into primitive/resource modules where it cannot be overridden
+- omits `configuration_aliases` in a multi-provider child module's `required_providers` — callers cannot pass aliased providers
+- drops the `providers = { aws = aws.region }` map from the module call on multi-region or multi-account deploys — resources land on the default provider
 
 ---
 

--- a/misc/website/docs/skills/terraform-skill/references/quick-reference.md
+++ b/misc/website/docs/skills/terraform-skill/references/quick-reference.md
@@ -77,6 +77,70 @@ terraform show -json tfplan | jq -r '.' > tfplan.json
 terraform show tfplan | grep "will be created"
 ```
 
+### State Management
+
+```bash
+# View all resources in state
+terraform state list
+
+# Show specific resource details
+terraform state show aws_instance.web
+
+# Move/rename resource in state (refactoring)
+terraform state mv aws_instance.old aws_instance.new
+terraform state mv aws_instance.app module.compute.aws_instance.app
+
+# Remove resource from state (keeps actual resource)
+terraform state rm aws_instance.temporary
+
+# Import existing resource into state
+terraform import aws_instance.web i-1234567890abcdef0
+
+# Import using import blocks (1.5+)
+# Define in .tf: import { to = aws_instance.web, id = "i-123..." }
+# Note: File must not exist — Terraform refuses to overwrite.
+terraform plan -generate-config-out=imported.tf
+
+# Detect configuration drift
+terraform plan -refresh-only
+
+# Update state to match reality (no infrastructure changes)
+terraform apply -refresh-only
+
+# Backup state to file
+terraform state pull > backup-$(date +%Y%m%d).tfstate
+
+# Restore state from backup (DANGEROUS)
+terraform state push backup.tfstate
+
+# Force unlock stuck state lock
+# Default: prompts for y/N confirmation
+terraform force-unlock LOCK_ID
+
+# CI-friendly (skips prompt):
+terraform force-unlock -force LOCK_ID
+```
+
+### State Backend Migration
+
+```bash
+# Migrate from local to remote backend
+# 1. Add backend config to backend.tf
+# 2. Run migration
+terraform init -migrate-state
+
+# Change backend without migrating state
+terraform init -reconfigure
+
+# Pass backend config at runtime
+terraform init \
+  -backend-config="key=prod/terraform.tfstate" \
+  -backend-config="dynamodb_table=terraform-locks"
+
+# Or use config file
+terraform init -backend-config=backend-prod.hcl
+```
+
 ---
 
 ## Decision Flowchart
@@ -149,10 +213,10 @@ Need to test Terraform/OpenTofu code?
 
 ### Terraform 1.6+ / OpenTofu 1.6+
 
-- ✅ NEW: Native `terraform test` / `tofu test`
+- ✅ NEW: Native `terraform test` / `tofu test` framework with `.tftest.hcl` files
 - ✅ Consider migrating simple tests from Terratest
 - ✅ Keep Terratest for complex integration
-- ✅ All Terraform 1.0+ features available
+- ✅ Import blocks from 1.5 available for declarative imports with `-generate-config-out`
 
 ### Terraform 1.7+ / OpenTofu 1.7+
 
@@ -163,39 +227,22 @@ Need to test Terraform/OpenTofu code?
 
 ### Terraform vs OpenTofu Comparison
 
-Both Terraform and OpenTofu are fully supported by this skill. The choice depends on your requirements:
-
-**Quick Decision Matrix:**
-
 | Factor | Terraform | OpenTofu |
 |--------|-----------|----------|
-| **Licensing** | Business Source License (BSL) 1.1 | Mozilla Public License 2.0 (MPL 2.0) |
+| **Licensing** | Business Source License 1.1 (BUSL-1.1) | Mozilla Public License 2.0 (MPL 2.0) |
 | **Governance** | HashiCorp (single vendor) | Linux Foundation (community-driven) |
 | **Latest Version** | 1.14+ | 1.11+ |
 | **Native Testing** | 1.6+ | 1.6+ |
 | **Mock Providers** | 1.7+ | 1.7+ |
 | **Feature Parity** | Reference implementation | Compatible fork with some additions |
 | **Enterprise Support** | HCP Terraform, Terraform Cloud | Multiple vendors |
-| **Migration Path** | N/A | Drop-in replacement for Terraform ≤1.5 |
+| **Migration Path** | N/A | Drop-in replacement for Terraform ≤1.5.x; feature-compatible fork thereafter with divergence on encryption, mock providers, provider functions, and other post-1.6 additions. Verify specific feature availability per version. |
 
-**When to choose Terraform:**
-- Using HashiCorp Terraform Cloud or HCP Terraform
-- Enterprise support contract with HashiCorp
-- Need absolute latest features first
+**Choose Terraform for:** HCP Terraform / Terraform Cloud, HashiCorp enterprise support, first access to latest features.
 
-**When to choose OpenTofu:**
-- Prefer open-source governance model
-- Want to avoid vendor lock-in concerns
-- Building on community-driven development
-- BSL 1.1 license doesn't fit your use case
+**Choose OpenTofu for:** open-source governance, vendor-lock-in avoidance, BUSL-1.1 incompatibility.
 
-**For this skill:**
-- Commands are shown for both: `terraform` and `tofu`
-- Most patterns work identically, though differences exist (see release notes)
-- Version-specific features noted (1.6+, 1.7+, etc.)
-- **Note:** Since OpenTofu 1.6, the platforms have diverged with unique features
-
-**When creating modules, Claude will ask your preference** to generate appropriate commands and documentation.
+Since OpenTofu 1.6 the platforms have diverged — this skill notes version floors explicitly and shows both `terraform` and `tofu` commands. When creating modules, Claude asks preference to pick commands/docs.
 
 ---
 
@@ -283,6 +330,148 @@ bucketName := fmt.Sprintf("test-bucket-%s", uniqueId)
    - VPCs, security groups (rarely change)
    - Don't share: instances, databases (change often)
 
+### Issue: State lock is stuck
+
+**Symptoms:**
+```
+Error: Error acquiring the state lock
+Lock Info:
+  ID: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  Who: user@hostname
+  Created: 2026-01-20 12:00:00
+```
+
+**Common Causes:**
+1. Terraform process crashed or was killed
+2. Network interruption during operation
+3. CI/CD job terminated unexpectedly
+
+**Solution:**
+
+```bash
+# 1. Verify the operation is NOT actually running
+# Check the host mentioned in lock info
+ssh user@hostname "ps aux | grep terraform"
+
+# Or check CI/CD job status
+# GitHub Actions: Check workflow runs
+# GitLab CI: Check pipeline jobs
+
+# 2. Only if confirmed the operation is not running:
+terraform force-unlock LOCK_ID
+
+# 3. Document why you unlocked
+echo "Force-unlocked due to CI job timeout" > unlock-notes.txt
+```
+
+**Prevention:**
+```yaml
+# GitHub Actions - Use concurrency control
+concurrency:
+  group: terraform-${{ github.ref }}
+  cancel-in-progress: false  # Wait, don't cancel
+```
+
+### Issue: State file is corrupted or lost
+
+**Symptoms:**
+- Error: "state snapshot was created by Terraform v1.8.0"
+- Error: "Failed to load state"
+- State file missing or unreadable
+
+**Solutions:**
+
+**If versioning enabled (S3):**
+```bash
+# List versions
+aws s3api list-object-versions \
+  --bucket my-terraform-state \
+  --prefix prod/terraform.tfstate
+
+# Restore previous version
+aws s3api get-object \
+  --bucket my-terraform-state \
+  --key prod/terraform.tfstate \
+  --version-id PREVIOUS_VERSION_ID \
+  terraform.tfstate.restored
+
+# Push restored state
+terraform state push terraform.tfstate.restored
+```
+
+**If no backup exists:**
+```bash
+# Recreate state by importing all resources
+terraform import aws_vpc.main vpc-12345678
+terraform import aws_subnet.private[0] subnet-abcd1234
+# ... continue for all resources
+
+# Or use import blocks (1.5+)
+# In .tf file:
+# import { to = aws_vpc.main, id = "vpc-12345678" }
+# Note: File must not exist — Terraform refuses to overwrite.
+terraform plan -generate-config-out=imported.tf
+```
+
+### Issue: Configuration drift detected
+
+**Symptoms:**
+```
+Note: Objects have changed outside of Terraform
+```
+
+**Cause:** Manual changes in console or by other tools
+
+**Solutions:**
+
+```bash
+# View drift
+terraform plan -refresh-only
+
+# Accept drift (update state to match reality)
+terraform apply -refresh-only
+
+# Or fix drift (update resources to match config)
+terraform apply
+
+# Prevent drift with detective controls
+# - Enable CloudTrail
+# - Use AWS Config rules
+# - Regular terraform plan in CI
+```
+
+### Issue: Cannot migrate state between backends
+
+**Symptoms:**
+- `terraform init -migrate-state` fails
+- Backend authentication errors
+
+**Solutions:**
+
+```bash
+# Ensure credentials are configured
+export AWS_PROFILE=terraform
+# or
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+
+# Try migration again
+terraform init -migrate-state
+
+# If still failing, manual migration:
+# 1. Pull state from old backend
+terraform state pull > old-state.json
+
+# 2. Switch backend config
+# Edit backend.tf
+
+# 3. Initialize new backend
+terraform init -reconfigure
+
+# 4. Push state to new backend
+terraform state push old-state.json
+```
+
 ---
 
 ## Migration Paths
@@ -340,29 +529,11 @@ tests/
 
 ### From Terraform → OpenTofu
 
-**Good news:** OpenTofu is a drop-in replacement!
+OpenTofu is a drop-in replacement for Terraform ≤1.5.x; a feature-compatible fork thereafter with divergence on encryption, mock providers, provider functions, and other post-1.6 additions. See the [Terraform vs OpenTofu Comparison](#terraform-vs-opentofu-comparison) and verify per-version feature availability.
 
-1. **No code changes needed**
-   - All Terraform syntax works
-   - Same provider ecosystem
-   - Compatible state files
-
-2. **Update CI/CD:**
-   ```bash
-   # Replace
-   terraform init
-   terraform plan
-   terraform apply
-
-   # With
-   tofu init
-   tofu plan
-   tofu apply
-   ```
-
-3. **Update documentation:**
-   - README mentions OpenTofu compatibility
-   - CI/CD workflows use `tofu` command
+1. **HCL ≤1.5.x** — no code changes; providers and state files compatible. Verify post-1.6 features per version.
+2. **CI/CD** — swap `terraform` for `tofu` in `init`/`plan`/`apply` invocations.
+3. **Docs** — note OpenTofu compatibility in README; update workflow templates to the `tofu` binary.
 
 ---
 
@@ -436,8 +607,8 @@ Required documentation for all modules:
 | Syntax | Meaning | Use Case |
 |--------|---------|----------|
 | `"5.0.0"` | Exact version | Avoid (inflexible) |
-| `"~> 5.0"` | Pessimistic (5.0.x) | Recommended for stability |
-| `"~> 5.0.1"` | Pessimistic (5.0.x where x >= 1) | Specific patch minimum |
+| `"~> 5.0"` | Pessimistic (>= 5.0, < 6.0 — any 5.x) | Allow minor and patch updates within 5.x |
+| `"~> 5.0.1"` | Pessimistic (>= 5.0.1, < 5.1.0 — 5.0.x patches) | Lock to 5.0.x patch updates only |
 | `">= 5.0, < 6.0"` | Range | Any 5.x version |
 | `">= 5.0"` | Minimum | Risky (breaking changes) |
 

--- a/misc/website/docs/skills/terraform-skill/references/security-compliance.md
+++ b/misc/website/docs/skills/terraform-skill/references/security-compliance.md
@@ -42,8 +42,9 @@ This document provides security hardening guidance and compliance automation str
 trivy config .
 checkov -d .
 
-# Compliance testing
-terraform-compliance -f compliance/ -p tfplan.json
+# Compliance testing (policy-as-code against a terraform plan JSON)
+terraform plan -out=tfplan && terraform show -json tfplan > tfplan.json
+conftest test tfplan.json --policy policy/
 ```
 
 ### Trivy Integration
@@ -64,7 +65,7 @@ curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/inst
     scan-ref: '.'
 ```
 
-**Note:** Trivy is the successor to tfsec, maintained by Aqua Security.
+**Note:** Trivy now includes tfsec's rule set; tfsec itself is in maintenance mode since its absorption into Trivy (2022), but still receives maintenance releases. Both are maintained by Aqua Security.
 
 **Example Output:**
 
@@ -123,6 +124,16 @@ resource "aws_db_instance" "this" {
 }
 ```
 
+<a id="secret-string-state-caveat"></a>
+
+> **Note — data source `secret_string` persists to state:** The `aws_secretsmanager_secret_version` data source reads `secret_string` into Terraform state during refresh. `password_wo` (AWS provider v5.71+, Terraform 1.11+) keeps the **resource argument** out of state, but the data source still persists the value. For true state exclusion:
+>
+> - Prefer `manage_master_user_password = true` (AWS-managed, for RDS)
+> - Use `ephemeral` providers/resources (Terraform 1.10+)
+> - Inject via CI environment variable outside Terraform
+>
+> Examples below use the data-source pattern; apply one of the alternatives above when the value must not land in state.
+
 ### ❌ DON'T: Use Default VPC
 
 ```hcl
@@ -178,15 +189,17 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
 }
 ```
 
+> **SSE-S3 vs SSE-KMS:** `AES256` above is SSE-S3 (AWS-managed key, no per-request audit trail in CloudTrail). For regulated workloads (HIPAA/PCI/FedRAMP), prefer `aws:kms` with a customer-managed CMK + key rotation enabled.
+
 ### ❌ DON'T: Open Security Groups to Internet
 
 ```hcl
-# BAD: Security group open to internet
+# BAD: Security group open to internet on all protocols
 resource "aws_security_group_rule" "allow_all" {
   type              = "ingress"
   from_port         = 0
-  to_port           = 65535
-  protocol          = "tcp"
+  to_port           = 0
+  protocol          = "-1"            # ❌ All protocols (worst case)
   cidr_blocks       = ["0.0.0.0/0"]  # ❌ Never do this
   security_group_id = aws_security_group.this.id
 }
@@ -206,45 +219,103 @@ resource "aws_security_group_rule" "app_https" {
 }
 ```
 
+### ❌ DON'T: Use Inline Security Group Rules
+
+```hcl
+# BAD: Inline ingress/egress blocks
+resource "aws_security_group" "web" {
+  name        = "web-sg"
+  description = "Web server security group"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {  # ❌ Inline rules cause issues
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"]
+  }
+
+  egress {  # ❌ Avoid inline rules
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+```
+
+### ✅ DO: Use Separate Security Group Rule Resources
+
+**Preferred (AWS provider v5+):** Use `aws_vpc_security_group_ingress_rule` / `aws_vpc_security_group_egress_rule`:
+
+```hcl
+# Best: Modern individual rule resources (AWS provider v5+)
+resource "aws_security_group" "web" {
+  name        = "web-sg"
+  description = "Web server security group"
+  vpc_id      = aws_vpc.this.id
+
+  # No inline rules - managed separately
+}
+
+resource "aws_vpc_security_group_ingress_rule" "web_https" {
+  security_group_id = aws_security_group.web.id
+  description       = "HTTPS from internal VPC"
+  cidr_ipv4         = "10.0.0.0/16"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+}
+
+# Scope egress to needed ports when possible — avoid 0.0.0.0/0 with ip_protocol = "-1"
+resource "aws_vpc_security_group_egress_rule" "web_https_out" {
+  security_group_id = aws_security_group.web.id
+  description       = "HTTPS to external services"
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+}
+```
+
+**Also acceptable:** `aws_security_group_rule` (older but still supported):
+
+```hcl
+resource "aws_security_group_rule" "web_https_ingress" {
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["10.0.0.0/16"]
+  security_group_id = aws_security_group.web.id
+}
+```
+
+**Why avoid inline rules:**
+
+| Issue | Inline Rules | Separate Resources |
+|-------|--------------|-------------------|
+| Rule changes | Recreates entire SG (downtime) | Updates only the rule |
+| Mixing approaches | Conflicts and overwrites | N/A - consistent pattern |
+| Dynamic rules | Complex `dynamic` blocks needed | Native `for_each` per resource |
+| State management | Rules buried in SG state | Each rule tracked separately |
+| Conditional rules | Complex nested dynamics | Simple `count` or `for_each` |
+
 ---
 
 ## Compliance Testing
 
-### terraform-compliance
+### Policy-as-code for Terraform plans
 
-**Install:**
-
-```bash
-pip install terraform-compliance
-```
-
-**Example Compliance Test:**
-
-```gherkin
-# compliance/aws-encryption.feature
-Feature: AWS Resources must be encrypted
-
-  Scenario: S3 buckets must have encryption
-    Given I have aws_s3_bucket defined
-    When it has aws_s3_bucket_server_side_encryption_configuration
-    Then it must contain rule
-    And it must contain apply_server_side_encryption_by_default
-
-  Scenario: RDS instances must be encrypted
-    Given I have aws_db_instance defined
-    Then it must contain storage_encrypted
-    And its value must be true
-```
-
-**Run Tests:**
+Generate a plan JSON and evaluate it with a policy engine. The modern, actively-maintained options are Conftest (OPA/Rego) and Open Policy Agent directly. The `terraform-compliance` BDD project is archived and no longer maintained; prefer Conftest/OPA for new work.
 
 ```bash
-# Generate plan in JSON
+# Generate plan JSON
 terraform plan -out=tfplan
 terraform show -json tfplan > tfplan.json
 
-# Run compliance tests
-terraform-compliance -f compliance/ -p tfplan.json
+# Evaluate with Conftest (OPA under the hood)
+conftest test tfplan.json --policy policy/
 ```
 
 ### Open Policy Agent (OPA)
@@ -253,12 +324,46 @@ terraform-compliance -f compliance/ -p tfplan.json
 # policy/s3_encryption.rego
 package terraform.s3
 
-deny[msg] {
-  resource := input.resource_changes[_]
-  resource.type == "aws_s3_bucket"
-  not resource.change.after.server_side_encryption_configuration
+# AWS provider v4+ moved S3 encryption to the separate
+# aws_s3_bucket_server_side_encryption_configuration resource.
+# Iterate those resources and verify the rule block sets an accepted algorithm.
 
-  msg := sprintf("S3 bucket '%s' must have encryption enabled", [resource.address])
+valid_algorithms := {"aws:kms", "aws:kms:dsse", "AES256"}
+
+# Collect buckets that have an encryption config with a valid algorithm
+encrypted_buckets[bucket] {
+  sse := input.resource_changes[_]
+  sse.type == "aws_s3_bucket_server_side_encryption_configuration"
+  rule := sse.change.after.rule[_]
+  algo := rule.apply_server_side_encryption_by_default[_].sse_algorithm
+  valid_algorithms[algo]
+  bucket := sse.change.after.bucket
+}
+
+deny[msg] {
+  sse := input.resource_changes[_]
+  sse.type == "aws_s3_bucket_server_side_encryption_configuration"
+  rule := sse.change.after.rule[_]
+  algo := rule.apply_server_side_encryption_by_default[_].sse_algorithm
+  not valid_algorithms[algo]
+
+  msg := sprintf(
+    "S3 encryption config '%s' uses unsupported sse_algorithm '%s' (expected aws:kms or AES256)",
+    [sse.address, algo],
+  )
+}
+
+# Flag buckets that have no matching encryption configuration at all.
+deny[msg] {
+  bucket := input.resource_changes[_]
+  bucket.type == "aws_s3_bucket"
+  bucket_name := bucket.change.after.bucket
+  not encrypted_buckets[bucket_name]
+
+  msg := sprintf(
+    "S3 bucket '%s' has no aws_s3_bucket_server_side_encryption_configuration",
+    [bucket.address],
+  )
 }
 ```
 
@@ -268,35 +373,41 @@ deny[msg] {
 
 ### AWS Secrets Manager Pattern
 
+See the [data-source `secret_string` persistence caveat](#secret-string-state-caveat) above — both `random_password.result` and data-source reads of `secret_string` land in Terraform state. The recommended RDS pattern avoids both.
+
 ```hcl
-# Create secret
-resource "aws_secretsmanager_secret" "db_password" {
-  name        = "prod/database/password"
-  description = "RDS master password"
-
-  recovery_window_in_days = 30
-}
-
-resource "aws_secretsmanager_secret_version" "db_password" {
-  secret_id     = aws_secretsmanager_secret.db_password.id
-  secret_string = random_password.db_password.result
-}
-
-# Generate secure password
-resource "random_password" "db_password" {
-  length  = 32
-  special = true
-}
-
-# Use secret in RDS
-data "aws_secretsmanager_secret_version" "db_password" {
-  secret_id = aws_secretsmanager_secret.db_password.id
+# Recommended: let RDS generate and manage the master password in Secrets Manager
+resource "aws_kms_key" "db" {
+  description             = "KMS CMK for RDS-managed master password"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
 }
 
 resource "aws_db_instance" "this" {
-  password = data.aws_secretsmanager_secret_version.db_password.secret_string
+  # Option 1 (recommended): AWS-managed master password in Secrets Manager
+  manage_master_user_password   = true
+  master_user_secret_kms_key_id = aws_kms_key.db.arn
+
+  # Option 2 (Terraform 1.11+ + AWS provider v5.71+): write-only password
+  # password_wo         = ephemeral.random_password.db.result
+  # password_wo_version = 1
   # ...
 }
+```
+
+If you need a manually-managed secret for a non-RDS consumer, keep the value out of state by sourcing it outside Terraform (CI env var, ephemeral resource, or a write-only argument) rather than via `random_password` + a `data` lookup:
+
+```hcl
+# Only use this shape when the consumer cannot use manage_master_user_password
+# and you are comfortable with the caveat linked above.
+resource "aws_secretsmanager_secret" "app_api_key" {
+  name                    = "prod/app/api-key"
+  description             = "Third-party API key"
+  recovery_window_in_days = 30
+}
+
+# secret_string populated out-of-band (console, CLI, or a write-only argument on
+# providers that support it) — not via random_password stored in state.
 ```
 
 ### Environment Variables
@@ -326,14 +437,17 @@ secrets/
 # backend.tf
 terraform {
   backend "s3" {
-    bucket         = "my-terraform-state"
-    key            = "prod/terraform.tfstate"
-    region         = "us-east-1"
-    dynamodb_table = "terraform-locks"
-    encrypt        = true  # ✅ Always enable encryption
+    bucket       = "my-terraform-state"
+    key          = "prod/vpc/terraform.tfstate"
+    region       = "us-east-1"
+    encrypt      = true                                             # Enables SSE on PUT
+    kms_key_id   = "arn:aws:kms:us-east-1:ACCOUNT:key/KEY-ID"       # Customer-managed CMK
+    use_lockfile = true                                             # Terraform 1.10+
   }
 }
 ```
+
+> **`encrypt = true` alone is SSE-S3 (AWS-managed AES-256 key, no per-request CloudTrail audit trail).** State often holds secrets, so pair `encrypt = true` with `kms_key_id` pointing at a customer-managed CMK. `use_lockfile = true` (Terraform 1.10+) replaces the need for a DynamoDB lock table.
 
 ### Secure State Bucket
 
@@ -351,16 +465,27 @@ resource "aws_s3_bucket_versioning" "terraform_state" {
   }
 }
 
-# Enable encryption
+# Enable encryption — customer-managed KMS CMK with bucket key to control request costs
+resource "aws_kms_key" "terraform_state" {
+  description             = "KMS CMK for Terraform state bucket"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
   bucket = aws_s3_bucket.terraform_state.id
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.terraform_state.arn
     }
+    bucket_key_enabled = true
   }
 }
+
+# Note: for regulated workloads (HIPAA/PCI/FedRAMP), customer-managed KMS with
+# rotation enabled is typically required — SSE-S3 (AES256) is usually insufficient.
 
 # Block public access
 resource "aws_s3_bucket_public_access_block" "terraform_state" {
@@ -380,23 +505,50 @@ resource "aws_s3_bucket_public_access_block" "terraform_state" {
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "AllowListBucket",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:role/TerraformRole"
+      },
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::my-terraform-state"
+    },
+    {
+      "Sid": "AllowObjectRW",
       "Effect": "Allow",
       "Principal": {
         "AWS": "arn:aws:iam::123456789012:role/TerraformRole"
       },
       "Action": [
-        "s3:ListBucket",
         "s3:GetObject",
-        "s3:PutObject"
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:GetObjectVersion"
       ],
+      "Resource": "arn:aws:s3:::my-terraform-state/*"
+    },
+    {
+      "Sid": "DenyInsecureTransport",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:*",
       "Resource": [
         "arn:aws:s3:::my-terraform-state",
         "arn:aws:s3:::my-terraform-state/*"
-      ]
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      }
     }
   ]
 }
 ```
+
+- `s3:ListBucket` must target the bucket ARN; object actions must target `/*` — splitting avoids IAM silently no-op'ing the mismatched pairings.
+- `s3:DeleteObject` + `s3:GetObjectVersion` are required to rotate state objects when versioning is enabled.
+- The `Deny` statement enforces TLS — any HTTP request is rejected regardless of other grants.
 
 ---
 
@@ -444,6 +596,17 @@ resource "aws_iam_policy" "bad_policy" {
 
 ---
 
+### Cross-cloud security map
+
+| Concern | AWS | Azure | GCP |
+|---------|-----|-------|-----|
+| Secret manager | `aws_secretsmanager_secret` | `azurerm_key_vault_secret` | `google_secret_manager_secret` |
+| Network firewalling | `aws_security_group` + `aws_vpc_security_group_*_rule` | `azurerm_network_security_group` + `azurerm_network_security_rule` | `google_compute_firewall` |
+| Identity | IAM (`aws_iam_role` / `aws_iam_policy`) | RBAC (`azurerm_role_assignment`) | IAM (`google_project_iam_*`) |
+| Encryption at rest | explicit (SSE / KMS) | default-on (optional CMK) | default-on (optional CMEK) |
+
+---
+
 ## Compliance Checklists
 
 ### SOC 2 Compliance
@@ -452,7 +615,7 @@ resource "aws_iam_policy" "bad_policy" {
 - [ ] Encryption in transit (TLS/SSL)
 - [ ] IAM policies follow least privilege
 - [ ] Logging enabled for all resources
-- [ ] MFA required for privileged access
+- [ ] MFA required for privileged access (enforced at org/IdP level, not per-resource)
 - [ ] Regular security scanning in CI/CD
 
 ### HIPAA Compliance
@@ -473,12 +636,27 @@ resource "aws_iam_policy" "bad_policy" {
 
 ---
 
+## LLM Mistake Checklist — Security & Compliance
+
+Common model mistakes to correct before returning security/compliance recommendations:
+
+- assumes `sensitive = true` keeps the value out of state — it only masks display; use `write_only` / `*_wo` arguments on 1.11+ or an external secret lookup
+- proposes plaintext defaults in `variable` blocks or committed `.tfvars` "for demo convenience"
+- echoes secrets through `provisioner` commands or `local-exec` stdout into CI logs (see [Provisioners as Last Resort](code-patterns#provisioners-as-last-resort) for the broader pattern)
+- emits outputs that expose full connection strings or credentials (even when marked `sensitive`)
+- mentions a compliance framework (SOC 2, PCI, HIPAA, GDPR, FedRAMP) but provides no enforceable gate — no policy stage, no approval model, no evidence artifact
+- confuses security best practices with compliance evidence (an encrypted bucket is not the same as a retained audit artifact proving it)
+- omits artifact retention and access controls for plan JSON exports
+- ignores data-residency obligations for GDPR/FedRAMP contexts
+
+---
+
 ## Resources
 
 - [Trivy Documentation](https://aquasecurity.github.io/trivy/)
 - [Checkov Documentation](https://www.checkov.io/)
-- [terraform-compliance](https://terraform-compliance.com/)
 - [Open Policy Agent](https://www.openpolicyagent.org/)
+- [Conftest](https://www.conftest.dev/)
 - [AWS Security Best Practices](https://aws.amazon.com/security/best-practices/)
 
 ---

--- a/misc/website/docs/skills/terraform-skill/references/state-management.md
+++ b/misc/website/docs/skills/terraform-skill/references/state-management.md
@@ -1,0 +1,1838 @@
+---
+title: "State Management"
+description: ""
+custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/skills/terraform-skill/references/state-management.md
+format: md
+---
+
+:::info[Source]
+This page is generated from [skills/terraform-skill/references/state-management.md](https://github.com/aws-samples/sample-apex-skills/blob/main/skills/terraform-skill/references/state-management.md). Edit the source, not this page.
+:::
+
+
+:::caution[Third-party skill]
+This skill is maintained by **Anton Babenko ([terraform-best-practices.com](https://terraform-best-practices.com), [Compliance.tf](https://compliance.tf))** under the Apache-2.0 license. Upstream: [https://github.com/antonbabenko/terraform-skill](https://github.com/antonbabenko/terraform-skill)
+:::
+
+# State Management
+
+> **Part of:** [terraform-skill](../)
+> **Purpose:** Comprehensive state management patterns and best practices for Terraform/OpenTofu
+
+This document provides detailed guidance on state management, from remote backend configuration to recovery strategies and multi-team isolation patterns.
+
+---
+
+## Table of Contents
+
+1. [Remote State Configuration](#remote-state-configuration)
+2. [State Locking](#state-locking)
+3. [State Security](#state-security)
+4. [State Migration](#state-migration)
+5. [Multi-Team State Isolation](#multi-team-state-isolation)
+6. [State Recovery & Troubleshooting](#state-recovery--troubleshooting)
+7. [State Best Practices Summary](#state-best-practices-summary)
+
+---
+
+## Remote State Configuration
+
+### Why Remote State?
+
+**Never use local state in teams or production:**
+- ❌ No locking → concurrent operations → state corruption
+- ❌ No backup → accidental deletion → infrastructure loss
+- ❌ No versioning → rollback impossible
+- ❌ No collaboration → single point of failure
+- ❌ Secrets in plaintext → security risk
+
+**Use remote backends for:**
+- ✅ Automatic state locking
+- ✅ Encryption at rest and in transit
+- ✅ State versioning and backup
+- ✅ Team collaboration
+- ✅ Audit logging
+
+### Choosing a Remote Backend
+
+| Backend | Use when |
+|---------|----------|
+| `s3` | AWS workloads, existing AWS state |
+| `azurerm` | Azure workloads |
+| `gcs` | GCP workloads |
+| `cloud` / TF Cloud / HCP | hosted state, run management, policy enforcement |
+
+Locking mechanism per backend: see [Backend Locking Support](#backend-locking-support) below.
+
+### Cross-cloud equivalents
+
+| Concern | AWS | Azure | GCP |
+|---------|-----|-------|-----|
+| Backend block | `backend "s3" { bucket, key, region, encrypt, use_lockfile }` | `backend "azurerm" { resource_group_name, storage_account_name, container_name, key }` | `backend "gcs" { bucket, prefix }` |
+| Access control | IAM policy on bucket/role | RBAC role assignment on storage account/container | IAM binding on the bucket |
+| Remote-state data source | `terraform_remote_state` (backend `s3`) | `terraform_remote_state` (backend `azurerm`) | `terraform_remote_state` (backend `gcs`) |
+
+### Bootstrap parity
+
+| Concern | AWS | Azure | GCP |
+|---------|-----|-------|-----|
+| Versioning | S3 bucket versioning | storage account / blob versioning | GCS object versioning |
+| Encryption at rest | explicit: SSE / KMS (`aws_s3_bucket_server_side_encryption_configuration`) | default-on (SSE; optional CMK) | default-on (Google-managed; optional CMEK) |
+| Public-access block | `aws_s3_bucket_public_access_block` | `allow_nested_items_to_be_public = false` + private container | uniform bucket-level access + public access prevention |
+| Bootstrap auth | IAM / OIDC | RBAC / federated credentials | IAM / Workload Identity Federation |
+
+### AWS S3 Backend (Recommended)
+
+#### S3 with Native Lock-File (Terraform 1.10+, Recommended)
+
+**Simplest setup - no DynamoDB required:**
+
+```hcl
+# backend.tf
+terraform {
+  backend "s3" {
+    bucket       = "my-terraform-state"
+    key          = "prod/vpc/terraform.tfstate"
+    region       = "us-east-1"
+    encrypt      = true
+    use_lockfile = true  # Native S3 locking (Terraform 1.10+)
+    
+    # Optional but recommended
+    kms_key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+  }
+}
+```
+
+Tradeoffs vs DynamoDB locking: no separate table, no DynamoDB charges, state and locks co-located in one bucket.
+
+#### S3 with DynamoDB Locking (Pre-1.10 or Legacy)
+
+**Complete setup with DynamoDB:**
+
+```hcl
+# backend.tf
+terraform {
+  backend "s3" {
+    bucket         = "my-terraform-state"
+    key            = "prod/vpc/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+    dynamodb_table = "terraform-state-lock"
+    
+    # Optional but recommended
+    kms_key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+  }
+}
+```
+
+**When to use DynamoDB locking:**
+- Terraform versions < 1.10
+- Existing infrastructure already using DynamoDB
+- Need DynamoDB for other purposes
+
+**Migration note:** Existing setups using DynamoDB will continue to work. The `use_lockfile` option is opt-in.
+
+**Backend infrastructure setup (Terraform 1.10+ with lock-file):**
+
+```hcl
+# bootstrap/main.tf - Run this ONCE to create state backend
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = "my-terraform-state"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.terraform_state.arn
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# MFA Delete for production
+# Note: Terraform cannot enable S3 MFA Delete. This must be configured
+# outside of Terraform using the AWS CLI or an SDK with the root account.
+#
+# Example (run once, after bucket creation and versioning are enabled):
+#
+# aws s3api put-bucket-versioning \
+#   --bucket my-terraform-state \
+#   --versioning-configuration Status=Enabled,MFADelete=Enabled \
+#   --mfa "arn-of-mfa-device mfa-code"
+
+# KMS key for encryption
+resource "aws_kms_key" "terraform_state" {
+  description             = "KMS key for Terraform state encryption"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+
+  tags = {
+    Name = "terraform-state-encryption"
+  }
+}
+
+resource "aws_kms_alias" "terraform_state" {
+  name          = "alias/terraform-state"
+  target_key_id = aws_kms_key.terraform_state.key_id
+}
+```
+
+**Backend infrastructure setup (Pre-1.10 with DynamoDB):**
+
+```hcl
+# If using DynamoDB locking, add this resource to the above configuration:
+
+# DynamoDB table for state locking
+resource "aws_dynamodb_table" "terraform_state_lock" {
+  name         = "terraform-state-lock"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    Name        = "Terraform State Lock Table"
+    Environment = "shared"
+  }
+}
+```
+
+**Key organization pattern:**
+
+```
+s3://my-terraform-state/
+├── prod/
+│   ├── vpc/terraform.tfstate
+│   ├── eks/terraform.tfstate
+│   └── rds/terraform.tfstate
+├── staging/
+│   ├── vpc/terraform.tfstate
+│   └── eks/terraform.tfstate
+└── dev/
+    └── vpc/terraform.tfstate
+```
+
+### Azure Storage Backend
+
+```hcl
+# backend.tf
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "terraform-state-rg"
+    storage_account_name = "tfstatestorage"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
+    
+    # Optional: Use service principal or managed identity
+    use_azuread_auth = true
+  }
+}
+```
+
+**Backend setup:**
+
+```hcl
+# bootstrap/main.tf
+resource "azurerm_resource_group" "terraform_state" {
+  name     = "terraform-state-rg"
+  location = "East US"
+}
+
+resource "azurerm_storage_account" "terraform_state" {
+  name                     = "tfstatestorage"
+  resource_group_name      = azurerm_resource_group.terraform_state.name
+  location                 = azurerm_resource_group.terraform_state.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"  # Geo-redundant
+  
+  # Security settings
+  min_tls_version                 = "TLS1_2"
+  allow_nested_items_to_be_public = false
+  
+  blob_properties {
+    versioning_enabled = true
+  }
+}
+
+resource "azurerm_storage_container" "terraform_state" {
+  name                  = "tfstate"
+  storage_account_name  = azurerm_storage_account.terraform_state.name
+  container_access_type = "private"
+}
+```
+
+### Google Cloud Storage Backend
+
+```hcl
+# backend.tf
+terraform {
+  backend "gcs" {
+    bucket = "my-terraform-state"
+    prefix = "prod/vpc"
+
+    # For customer-managed encryption, configure the bucket itself with
+    # `default_kms_key_name` (see bootstrap below) rather than the backend.
+    # The backend's `encryption_key` attribute is for CSEK (a base64-encoded
+    # 32-byte AES-256 key), NOT a Cloud KMS resource name.
+  }
+}
+```
+
+**Backend setup:**
+
+```hcl
+# bootstrap/main.tf
+resource "google_storage_bucket" "terraform_state" {
+  name          = "my-terraform-state"
+  location      = "US"
+  force_destroy = false
+
+  versioning {
+    enabled = true
+  }
+
+  encryption {
+    default_kms_key_name = google_kms_crypto_key.terraform_state.id
+  }
+
+  uniform_bucket_level_access = true
+
+  lifecycle_rule {
+    condition {
+      num_newer_versions = 10
+    }
+    action {
+      type = "Delete"
+    }
+  }
+}
+
+resource "google_kms_key_ring" "terraform_state" {
+  name     = "terraform-state"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "terraform_state" {
+  name     = "terraform-state-key"
+  key_ring = google_kms_key_ring.terraform_state.id
+
+  rotation_period = "7776000s"  # 90 days
+}
+```
+
+### Terraform Cloud/Enterprise Backend
+
+```hcl
+# backend.tf
+terraform {
+  cloud {
+    organization = "my-org"
+    
+    workspaces {
+      name = "prod-infrastructure"
+      # Or use tags for dynamic workspace selection
+      # tags = ["prod", "networking"]
+    }
+  }
+}
+
+# Alternative: Terraform Enterprise with custom hostname
+terraform {
+  cloud {
+    hostname     = "terraform.company.com"
+    organization = "my-org"
+    
+    workspaces {
+      name = "prod-infrastructure"
+    }
+  }
+}
+```
+
+Terraform Cloud provides: built-in state management and locking, remote execution, Sentinel policy enforcement, cost estimation, private module registry, VCS integration — no backend infra to manage.
+
+### Backend Configuration Best Practices
+
+✅ **DO:**
+- Use separate state files per logical component
+- Enable versioning on state storage
+- Use encryption at rest (KMS)
+- Configure state locking
+- Use separate backends per environment
+- Store backend config in version control
+- Use partial configuration for sensitive values
+
+❌ **DON'T:**
+- Use local state for teams or production
+- Share state files across unrelated resources
+- Hardcode credentials in backend config
+- Disable versioning
+- Skip encryption
+- Use same state for all environments
+
+**Partial backend configuration:**
+
+```hcl
+# backend.tf - No sensitive values
+terraform {
+  backend "s3" {
+    bucket = "my-terraform-state"
+    region = "us-east-1"
+    # key, dynamodb_table specified via -backend-config
+  }
+}
+```
+
+```bash
+# Pass sensitive config at init time
+terraform init \
+  -backend-config="key=prod/vpc/terraform.tfstate" \
+  -backend-config="dynamodb_table=terraform-state-lock"
+
+# Or use a file
+terraform init -backend-config=backend-prod.hcl
+```
+
+---
+
+## State Locking
+
+### Why Locking Matters
+
+**Without locking:**
+```
+User A: terraform apply  (starts)
+User B: terraform apply  (starts at same time)
+Result: Both read same state, make conflicting changes
+        → State corruption
+        → Infrastructure drift
+        → Potential outages
+```
+
+**With locking:**
+```
+User A: terraform apply  (acquires lock)
+User B: terraform apply  (waits for lock)
+Result: Operations are serialized
+        → State consistency maintained
+```
+
+### Backend Locking Support
+
+| Backend | Locking | Lock Mechanism |
+|---------|---------|----------------|
+| **S3** (Terraform 1.10+) | ✅ Native | Lock files |
+| **S3** (Pre-1.10) | ✅ With DynamoDB | DynamoDB table |
+| **Azure Storage** | ✅ Native | Blob lease |
+| **GCS** | ✅ Native | Object metadata |
+| **Terraform Cloud** | ✅ Native | Built-in |
+| **Consul** | ✅ Native | Consul KV |
+| **Postgres** | ✅ Native | Row locking |
+| **Local** | ❌ None | N/A |
+
+### S3 Native Lock-File (Terraform 1.10+)
+
+**How it works:**
+- Uses regular S3 objects as lock files
+- Lock files stored in the same bucket as state files
+- No additional AWS services required
+- Automatically deleted when operations complete
+
+**Configuration:**
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket       = "my-terraform-state"
+    key          = "prod/terraform.tfstate"
+    region       = "us-east-1"
+    encrypt      = true
+    use_lockfile = true  # Enable native S3 locking
+  }
+}
+```
+
+**Migration from DynamoDB:** Set both `dynamodb_table` and `use_lockfile = true` during Terraform 1.10+ migration — locks acquire via both mechanisms. Once every workflow runs on 1.10+, remove `dynamodb_table`.
+
+### DynamoDB Locking for S3 (Pre-1.10 or Legacy)
+
+**Lock table attributes:**
+- `LockID` (String, Hash Key) - Must be exactly "LockID"
+- No other attributes needed
+- Pay-per-request billing recommended
+
+**Lock behavior:**
+
+```bash
+# Terraform acquires lock
+terraform plan
+# Creates lock: LockID = "bucket/path/to/state"
+
+# Another user attempts operation
+terraform apply
+# Sees: Error acquiring the state lock
+# Default: `-lock-timeout=0s` — fail immediately on lock contention.
+# Set `-lock-timeout=<duration>` (e.g. `5m`) to retry with backoff for the specified window.
+#   terraform apply -lock-timeout=5m
+```
+
+**View current locks:**
+
+```bash
+# Check DynamoDB for active locks
+aws dynamodb scan \
+  --table-name terraform-state-lock \
+  --projection-expression "LockID,Info"
+```
+
+### Handling Lock Conflicts
+
+#### Scenario 1: Lock Already Held
+
+**Symptom:**
+```
+Error: Error acquiring the state lock
+
+Lock Info:
+  ID:        a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  Path:      bucket/prod/terraform.tfstate
+  Operation: OperationTypeApply
+  Who:       user@host
+  Created:   2026-01-20 12:00:00.123456789 +0000 UTC
+```
+
+**Solutions:**
+
+1. **Wait for operation to complete** (recommended)
+   ```bash
+   # Just wait - the other operation will release the lock
+   ```
+
+2. **Check if operation is actually running**
+   ```bash
+   # If user@host is accessible, check if terraform is running
+   ssh user@host "ps aux | grep terraform"
+   ```
+
+3. **Force unlock if operation crashed** (DANGEROUS)
+   ```bash
+   # Only if you're CERTAIN the lock is stale
+   terraform force-unlock a1b2c3d4-e5f6-7890-abcd-ef1234567890
+   ```
+
+#### Scenario 2: Stale Lock (Operation Crashed)
+
+**When to force-unlock:**
+- ✅ Process crashed/killed
+- ✅ Network interruption
+- ✅ CI/CD job terminated
+- ✅ You verified no operation is running
+
+**When NOT to force-unlock:**
+- ❌ Just because you're impatient
+- ❌ Without checking if operation is running
+- ❌ In automation (should fail instead)
+
+**Safe force-unlock workflow:**
+
+```bash
+# 1. Verify lock exists
+terraform plan
+# Note the Lock ID from error message
+
+# 2. Check if operation is actually running
+# - SSH to the host if accessible
+# - Check CI/CD job status
+# - Ask team members
+
+# 3. Only if confirmed stale, force unlock
+terraform force-unlock LOCK_ID
+
+# 4. Document why you force-unlocked
+git commit -m "Force-unlocked state after CI job termination"
+```
+
+### Automatic Lock Timeout
+
+**Terraform Cloud lock timeout:**
+
+Lock timeout in Terraform Cloud is configured through workspace settings in the Terraform Cloud UI under "General Settings" → "Remote Operations" → "Lock Timeout". It cannot be configured through the `cloud` block in Terraform code.
+
+**For other backends, implement timeout in automation:**
+
+```bash
+#!/bin/bash
+# wrapper-script.sh
+LOCK_TIMEOUT=300  # 5 minutes
+
+timeout $LOCK_TIMEOUT terraform apply -auto-approve
+
+if [ $? -eq 124 ]; then
+  echo "Terraform timed out - likely lock held"
+  exit 1
+fi
+```
+
+### State Locking in CI/CD
+
+**Prevent concurrent runs:**
+
+```yaml
+# GitHub Actions - Use concurrency control
+concurrency:
+  group: terraform-${{ github.ref }}
+  cancel-in-progress: false  # Don't cancel, wait instead
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Terraform Apply
+        run: terraform apply -auto-approve
+```
+
+**GitLab CI:**
+
+```yaml
+# .gitlab-ci.yml
+terraform-apply:
+  script:
+    - terraform apply -auto-approve
+  resource_group: terraform-prod  # Only one job at a time
+```
+
+---
+
+## State Security
+
+### Encryption at Rest
+
+**S3 Backend:**
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket     = "my-terraform-state"
+    key        = "prod/terraform.tfstate"
+    region     = "us-east-1"
+    encrypt    = true  # ✅ Always enable
+    kms_key_id = "arn:aws:kms:us-east-1:123456789012:key/..."  # Optional: Use customer-managed key
+  }
+}
+```
+
+**Encryption options:**
+
+| Method | Key Management | Cost | Use Case |
+|--------|----------------|------|----------|
+| **SSE-S3** (AES-256) | AWS-managed | Included | Basic encryption |
+| **SSE-KMS** | Customer-managed | $$$ per 10K requests | Compliance requirements |
+| **SSE-C** | Client-managed | Included | Full control needed |
+
+### Encryption in Transit
+
+**All backends use TLS by default:**
+- S3: HTTPS
+- Azure Storage: HTTPS
+- GCS: HTTPS
+- Terraform Cloud: HTTPS
+
+**Enforce TLS-only access:**
+
+```json
+// S3 bucket policy
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyInsecureTransport",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::my-terraform-state",
+        "arn:aws:s3:::my-terraform-state/*"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Access Control Patterns
+
+#### IAM Policy for S3 Backend (AWS)
+
+**Minimal permissions:**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": "arn:aws:s3:::my-terraform-state"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": "arn:aws:s3:::my-terraform-state/prod/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:DescribeTable",
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:DeleteItem"
+      ],
+      "Resource": "arn:aws:dynamodb:us-east-1:*:table/terraform-state-lock"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:DescribeKey",
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey"
+      ],
+      "Resource": "arn:aws:kms:us-east-1:*:key/*"
+    }
+  ]
+}
+```
+
+**Read-only policy (for auditing):**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::my-terraform-state",
+        "arn:aws:s3:::my-terraform-state/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "kms:Decrypt",
+      "Resource": "arn:aws:kms:us-east-1:*:key/*"
+    }
+  ]
+}
+```
+
+#### Environment Isolation with IAM
+
+**Principle:** Each environment gets its own IAM role with scoped access
+
+```hcl
+# prod-role can only access prod state
+resource "aws_iam_role" "terraform_prod" {
+  name = "terraform-prod"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::123456789012:root"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "terraform_prod_state" {
+  role = aws_iam_role.terraform_prod.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetObject",
+          "s3:PutObject"
+        ]
+        Resource = [
+          "arn:aws:s3:::my-terraform-state",
+          "arn:aws:s3:::my-terraform-state/prod/*"  # Only prod path
+        ]
+      }
+    ]
+  })
+}
+```
+
+### Sensitive Data in State Files
+
+**What gets stored in state:**
+- Resource attributes (including computed values)
+- Variable values
+- Output values
+- Sensitive data like:
+  - Database passwords
+  - API keys
+  - SSH keys
+  - Certificate private keys
+
+#### ❌ DON'T: Store Secrets in Variables
+
+```hcl
+# BAD: Secret visible in state
+variable "database_password" {
+  type      = string
+  sensitive = true
+  default   = "SuperSecret123!"  # ❌ Still stored in state
+}
+```
+
+#### ✅ DO: Use Write-Only Arguments (Terraform 1.11+)
+
+```hcl
+# Good: Password never stored in state
+resource "aws_db_instance" "this" {
+  # ... other config ...
+  
+  manage_master_user_password = true  # AWS generates and stores password
+  
+  lifecycle {
+    ignore_changes = [master_user_secret]
+  }
+}
+
+# Access password via Secrets Manager
+data "aws_secretsmanager_secret_version" "db_password" {
+  secret_id = aws_db_instance.this.master_user_secret[0].secret_arn
+}
+```
+
+> **Caveat:** Reading a secret through `data "aws_secretsmanager_secret_version"`
+> pulls `secret_string` into the state file on every refresh. If the goal is to
+> keep the raw secret out of state, use an `ephemeral` resource/data source
+> (Terraform 1.10+), `manage_master_user_password`, or inject the value via a
+> CI-only environment variable instead of a data source.
+
+#### ✅ DO: Reference External Secrets
+
+```hcl
+# Good: Fetch secret at runtime, not stored in state
+data "aws_secretsmanager_secret_version" "db_password" {
+  secret_id = "prod/database/master-password"
+}
+
+resource "aws_db_instance" "this" {
+  password = data.aws_secretsmanager_secret_version.db_password.secret_string
+  # Password still in state, but not hardcoded
+}
+```
+
+> **Caveat:** The data source writes `secret_string` into state on every refresh,
+> so this pattern avoids hardcoding — it does not exclude the secret from state.
+> For true state exclusion, use an `ephemeral` resource/data source
+> (Terraform 1.10+), `manage_master_user_password`, or a CI-injected env var.
+
+#### Best Practice: Reconcile State After External Secret Rotation
+
+```bash
+# After rotation (handled outside Terraform), refresh state so it reflects
+# the new value. This does not rotate the secret itself.
+terraform apply -refresh-only
+```
+
+### State File Audit Logging
+
+**S3 Bucket logging:**
+
+```hcl
+resource "aws_s3_bucket_logging" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  target_bucket = aws_s3_bucket.logs.id
+  target_prefix = "terraform-state-access/"
+}
+
+# CloudTrail for API-level logging
+resource "aws_cloudtrail" "terraform_state" {
+  name           = "terraform-state-trail"
+  s3_bucket_name = aws_s3_bucket.cloudtrail_logs.id
+
+  event_selector {
+    read_write_type           = "All"
+    include_management_events = true
+
+    data_resource {
+      type   = "AWS::S3::Object"
+      values = ["arn:aws:s3:::my-terraform-state/*"]
+    }
+  }
+}
+```
+
+**Azure Storage logging:**
+
+`azurerm_storage_account.blob_properties` does NOT expose a `logging` sub-block.
+Configure blob-service audit logs via `azurerm_monitor_diagnostic_setting`
+targeting the storage account's `blobServices` resource.
+
+**What to monitor:**
+- Who accessed state files
+- When state was modified
+- What changes were made
+- Failed access attempts
+
+---
+
+## State Migration
+
+### Migrating Between Backends
+
+#### Local → S3 Migration
+
+**Step 1: Set up S3 backend infrastructure**
+
+```bash
+# In bootstrap directory
+terraform init
+terraform apply
+```
+
+**Step 2: Add backend config to your Terraform code**
+
+```hcl
+# backend.tf - Add this file
+terraform {
+  backend "s3" {
+    bucket         = "my-terraform-state"
+    key            = "prod/vpc/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+    dynamodb_table = "terraform-state-lock"
+  }
+}
+```
+
+**Step 3: Initialize with migration**
+
+```bash
+# Backup local state first
+cp terraform.tfstate terraform.tfstate.backup
+
+# Migrate to S3
+terraform init -migrate-state
+
+# Terraform will ask: "Do you want to copy existing state to the new backend?"
+# Answer: yes
+
+# Verify migration
+terraform plan  # Should show no changes
+
+# Verify state in S3
+aws s3 ls s3://my-terraform-state/prod/vpc/
+```
+
+**Step 4: Clean up local state** (AFTER verifying S3 works)
+
+```bash
+# Remove local state files
+rm terraform.tfstate*
+
+# Commit backend config
+git add backend.tf
+git commit -m "Migrate state to S3 backend"
+```
+
+#### S3 → Terraform Cloud Migration
+
+**Step 1: Authenticate to Terraform Cloud**
+
+```bash
+# Authenticate the CLI
+terraform login
+```
+
+The Terraform Cloud workspace is created automatically on first `terraform init`
+against the `cloud {}` block below (provided the org permits auto-creation).
+Alternatively, pre-create it in the TFC UI or with the `tfe_workspace` resource.
+Do NOT use `terraform workspace new` here — CLI workspaces are a different
+concept from Terraform Cloud workspaces.
+
+**Step 2: Update backend config**
+
+```hcl
+# backend.tf - Change from S3 to cloud
+terraform {
+  cloud {
+    organization = "my-org"
+    
+    workspaces {
+      name = "prod-infrastructure"
+    }
+  }
+}
+
+# Remove old S3 backend config
+```
+
+**Step 3: Migrate state**
+
+```bash
+# Initialize with migration
+terraform init -migrate-state
+
+# Confirm migration
+# State will be uploaded to Terraform Cloud
+```
+
+**Step 4: Verify and clean up**
+
+```bash
+# Verify in Terraform Cloud UI or CLI
+terraform state list
+
+# Old S3 state remains as backup - don't delete immediately
+# Keep for 30-90 days, then remove
+```
+
+#### Backend Change Without Migration
+
+**When recreating infrastructure is acceptable:**
+
+```bash
+# Change backend config in backend.tf
+
+# Re-initialize (will create new empty state)
+terraform init -reconfigure
+
+# Import existing resources
+terraform import aws_vpc.this vpc-12345678
+terraform import aws_subnet.private subnet-abcd1234
+# ... import all resources ...
+
+# Or destroy and recreate
+terraform destroy  # In old backend
+terraform apply    # In new backend
+```
+
+### State Refactoring with `terraform state mv`
+
+**Use cases:**
+- Renaming resources
+- Moving resources between modules
+- Reorganizing state structure
+- Splitting monolithic state
+
+#### Renaming a Resource
+
+```bash
+# Before: aws_instance.server
+# After:  aws_instance.web_server
+
+terraform state mv aws_instance.server aws_instance.web_server
+
+# Update code to match
+# In main.tf: resource "aws_instance" "web_server" { ... }
+
+# Verify
+terraform plan  # Should show no changes
+```
+
+#### Moving Resource to Module
+
+```bash
+# Before: aws_s3_bucket.logs (in root module)
+# After:  module.logging.aws_s3_bucket.logs
+
+# Step 1: Create module with resource
+# Step 2: Move state
+terraform state mv aws_s3_bucket.logs module.logging.aws_s3_bucket.logs
+
+# Step 3: Remove old resource from root module
+# Step 4: Add module call
+# Step 5: Verify
+terraform plan  # Should show no changes
+```
+
+#### Moving Resource Between Modules
+
+```bash
+# Move from module.old to module.new
+terraform state mv \
+  module.old.aws_instance.app \
+  module.new.aws_instance.app
+```
+
+#### Moving Resource to Different State File
+
+**Scenario:** Splitting state into separate files
+
+**Note:** `terraform state mv` only works within the same state file. To move resources between different state files, use the approach below.
+
+**Recommended approach: Use `terraform state rm` and `import`**
+
+```bash
+# In source state - remove resource
+terraform state rm aws_rds_cluster.main
+
+# In destination state - import resource
+terraform import aws_rds_cluster.main cluster-identifier
+```
+
+### State Push/Pull Operations
+
+**Pull state (download):**
+
+```bash
+# View current state
+terraform state pull
+
+# Save to file
+terraform state pull > terraform.tfstate.backup
+
+# View specific resource
+terraform state show aws_instance.web
+```
+
+**Push state (upload):**
+
+```bash
+# Restore from backup
+terraform state push terraform.tfstate.backup
+
+# DANGEROUS: Overwrites remote state
+# Only use for disaster recovery
+```
+
+**When to use push/pull:**
+- ✅ Creating backups
+- ✅ Disaster recovery
+- ✅ Debugging state issues
+- ✅ Manual state surgery (advanced)
+- ❌ Regular operations (use terraform commands)
+- ❌ Concurrent team access
+
+### State Backup Strategies
+
+#### Automatic Backups
+
+**S3 versioning (automatic):**
+
+```bash
+# List all versions
+aws s3api list-object-versions \
+  --bucket my-terraform-state \
+  --prefix prod/vpc/terraform.tfstate
+
+# Restore specific version
+aws s3api get-object \
+  --bucket my-terraform-state \
+  --key prod/vpc/terraform.tfstate \
+  --version-id VERSION_ID \
+  terraform.tfstate.restored
+```
+
+**Pre-operation backup:**
+
+```bash
+# Manual backup before major changes
+terraform state pull > backup-$(date +%Y%m%d-%H%M%S).tfstate
+
+# Or in automation
+#!/bin/bash
+BACKUP_DIR="./state-backups"
+mkdir -p $BACKUP_DIR
+
+terraform state pull > "$BACKUP_DIR/terraform.tfstate.$(date +%Y%m%d-%H%M%S)"
+
+# Keep last 30 backups
+ls -t $BACKUP_DIR/terraform.tfstate.* | tail -n +31 | xargs rm -f
+```
+
+#### Disaster Recovery Plan
+
+**1. Backup checklist:**
+- [ ] State file backed up (versioning enabled)
+- [ ] Backend config documented
+- [ ] IAM policies documented
+- [ ] Encryption keys accessible
+- [ ] Restore procedure tested
+
+**2. Recovery procedure:**
+
+```bash
+# If state corrupted
+# Step 1: Download last known good version
+aws s3api get-object \
+  --bucket my-terraform-state \
+  --key prod/vpc/terraform.tfstate \
+  --version-id PREVIOUS_VERSION_ID \
+  terraform.tfstate.recovered
+
+# Step 2: Push recovered state
+terraform state push terraform.tfstate.recovered
+
+# Step 3: Verify
+terraform plan
+
+# Step 4: If resources drifted, reconcile
+terraform apply -refresh-only
+```
+
+### Provider Removal
+
+Terraform calls the provider plugin's `Destroy` RPC during apply. Keep the provider installed until every resource for that provider is destroyed or removed from state.
+
+| Goal | Use | Tradeoff |
+|------|-----|----------|
+| Remove provider and destroy the real resource | Two-phase removal (default) | Safe; requires `apply` |
+| Remove provider and keep the real resource | `removed` block (Terraform 1.7+, OpenTofu 1.7+) | Declarative; real resource stays but becomes unmanaged |
+| Remove from state manually | `terraform state rm <addr>` | Orphans the real resource; use only when intentionally abandoning |
+
+**Two-phase removal**
+
+1. **Phase 1 — destroy resources, keep provider:** Delete resource blocks from config (or mark for destruction). Keep the `provider` block and `required_providers` entry. Run `terraform plan` and confirm target resources show `destroy`. Run `terraform apply`. Run `terraform state list` and verify no resources remain for that provider.
+2. **Phase 2 — remove provider:** Remove the `provider` block and the `required_providers` entry. Run `terraform init`. Run `terraform plan` and expect no changes and no errors.
+
+**`removed` block**
+
+```hcl
+removed {
+  from = vault_policy.ops
+
+  lifecycle {
+    destroy = false
+  }
+}
+```
+
+**Rules**
+
+- ❌ Remove the provider block first: plan cannot resolve the resource type → hard error.
+- ✅ Same rule applies to provider aliases and multi-provider modules.
+- ✅ Plain `terraform init` after removal; `-upgrade` is for bumping existing providers, not required here.
+
+---
+
+## Multi-Team State Isolation
+
+### State Organization Patterns
+
+#### Pattern 1: State Per Environment
+
+**Structure:**
+
+```
+my-company-tf-state/
+├── dev/
+│   ├── networking/terraform.tfstate
+│   ├── compute/terraform.tfstate
+│   └── data/terraform.tfstate
+├── staging/
+│   ├── networking/terraform.tfstate
+│   └── compute/terraform.tfstate
+└── prod/
+    ├── networking/terraform.tfstate
+    ├── compute/terraform.tfstate
+    └── data/terraform.tfstate
+```
+
+**Benefits:**
+- ✅ Clear environment separation
+- ✅ Different IAM roles per environment
+- ✅ Blast radius limited to environment
+- ✅ Easy to understand
+
+**Drawbacks:**
+- ⚠️ Duplicate code across environments
+- ⚠️ Harder to keep environments in sync
+
+#### Pattern 2: State Per Team/Component
+
+**Structure:**
+
+```
+my-company-tf-state/
+├── networking-team/
+│   ├── prod-vpc/terraform.tfstate
+│   ├── staging-vpc/terraform.tfstate
+│   └── vpn/terraform.tfstate
+├── platform-team/
+│   ├── prod-eks/terraform.tfstate
+│   └── staging-eks/terraform.tfstate
+└── data-team/
+    ├── prod-rds/terraform.tfstate
+    └── prod-redshift/terraform.tfstate
+```
+
+**Benefits:**
+- ✅ Team ownership clear
+- ✅ Team-specific access control
+- ✅ Independent release cycles
+- ✅ Reduced coordination overhead
+
+**Drawbacks:**
+- ⚠️ Cross-team dependencies complex
+- ⚠️ Need data sharing mechanisms
+
+#### Pattern 3: Hybrid (Environment + Component)
+
+**Structure:**
+
+```
+my-company-tf-state/
+├── prod/
+│   ├── 01-networking/terraform.tfstate  # VPC, subnets
+│   ├── 02-platform/terraform.tfstate    # EKS, ALB
+│   ├── 03-data/terraform.tfstate        # RDS, Redis
+│   └── 04-applications/terraform.tfstate
+├── staging/
+│   ├── 01-networking/terraform.tfstate
+│   └── 02-platform/terraform.tfstate
+```
+
+**Benefits:**
+- ✅ Clear environment boundaries
+- ✅ Component isolation within environment
+- ✅ Numbered prefixes show dependencies
+- ✅ Team ownership possible
+
+**Recommended:** This pattern for most teams
+
+### Cross-State Data Sharing
+
+#### Using terraform_remote_state
+
+**Producer module (networking):**
+
+```hcl
+# outputs.tf in networking module
+output "vpc_id" {
+  description = "VPC ID for other modules"
+  value       = aws_vpc.main.id
+}
+
+output "private_subnet_ids" {
+  description = "Private subnet IDs"
+  value       = aws_subnet.private[*].id
+}
+
+output "database_security_group_id" {
+  description = "Security group for databases"
+  value       = aws_security_group.database.id
+}
+```
+
+**Consumer module (compute):**
+
+```hcl
+# data.tf in compute module
+data "terraform_remote_state" "networking" {
+  backend = "s3"
+  
+  config = {
+    bucket = "my-terraform-state"
+    key    = "prod/networking/terraform.tfstate"
+    region = "us-east-1"
+  }
+}
+
+# Use networking outputs
+resource "aws_instance" "app" {
+  subnet_id              = data.terraform_remote_state.networking.outputs.private_subnet_ids[0]
+  vpc_security_group_ids = [data.terraform_remote_state.networking.outputs.database_security_group_id]
+}
+```
+
+**Best practices:**
+- ✅ Document what outputs are for cross-module use
+- ✅ Version outputs (add v2 suffix if breaking change)
+- ✅ Keep outputs stable (don't rename casually)
+- ✅ Use descriptive output names
+
+#### Alternative: SSM Parameter Store
+
+**Producer:**
+
+```hcl
+# Store values in SSM
+resource "aws_ssm_parameter" "vpc_id" {
+  name  = "/terraform/prod/networking/vpc_id"
+  type  = "String"
+  value = aws_vpc.main.id
+}
+```
+
+**Consumer:**
+
+```hcl
+# Read from SSM
+data "aws_ssm_parameter" "vpc_id" {
+  name = "/terraform/prod/networking/vpc_id"
+}
+
+resource "aws_instance" "app" {
+  subnet_id = data.aws_ssm_parameter.vpc_id.value
+}
+```
+
+**Benefits over remote_state:**
+- ✅ No direct state dependency
+- ✅ Can be read by non-Terraform tools
+- ✅ Can be updated without Terraform
+- ✅ Fine-grained IAM control
+
+**Drawbacks:**
+- ⚠️ Extra resources to manage
+- ⚠️ Potential for values to be out of sync
+
+### When to Split vs Combine State
+
+#### Split State When:
+
+✅ **Different lifecycles:**
+- VPC (rarely changes) vs EC2 instances (frequently updated)
+
+✅ **Different teams own components:**
+- Networking team manages VPC
+- Platform team manages Kubernetes
+- App teams manage applications
+
+✅ **Different risk profiles:**
+- Critical infrastructure vs experimental features
+
+✅ **Large state files:**
+- State operations becoming slow (>1000 resources — rough heuristic, depends on provider refresh time)
+
+✅ **Independent deployment cadence:**
+- Database needs weekly updates
+- Application needs daily updates
+
+#### Combine State When:
+
+✅ **Tightly coupled resources:**
+- EC2 instance + EBS volume + ENI
+
+✅ **Same lifecycle:**
+- All resources created/destroyed together
+
+✅ **Simple, small project:**
+- < 100 resources
+- Single team ownership
+
+✅ **Resources reference each other frequently:**
+- Security groups that reference each other
+
+### Decision Matrix
+
+| Factor | Split State | Single State |
+|--------|-------------|--------------|
+| **Team size** | Multiple teams | Single team |
+| **Resource count** | >500 resources | <100 resources (rough heuristics — depends on provider refresh time) |
+| **Update frequency** | Different cadences | Same cadence |
+| **Risk tolerance** | Low (production) | High (dev/test) |
+| **Coupling** | Loosely coupled | Tightly coupled |
+| **Ownership** | Multiple owners | Single owner |
+
+---
+
+## State Recovery & Troubleshooting
+
+### Recovering from State Corruption
+
+#### Scenario 1: State File Corrupted
+
+**Symptoms:**
+```
+Error: state snapshot was created by Terraform v1.8.0,
+       which is newer than current v1.6.0
+```
+
+**Solutions:**
+
+**A) Restore from backup:**
+
+```bash
+# S3 versioning
+aws s3api list-object-versions \
+  --bucket my-terraform-state \
+  --prefix prod/terraform.tfstate
+
+aws s3api get-object \
+  --bucket my-terraform-state \
+  --key prod/terraform.tfstate \
+  --version-id PREVIOUS_VERSION \
+  terraform.tfstate.restored
+
+terraform state push terraform.tfstate.restored
+```
+
+**B) Upgrade Terraform:**
+
+```bash
+# Download newer version
+tfenv install 1.8.0
+tfenv use 1.8.0
+
+# Verify
+terraform version
+```
+
+#### Scenario 2: State Completely Lost
+
+**If no backup exists:**
+
+1. **Recreate state from existing infrastructure:**
+
+```bash
+# List all resources to import
+# (You'll need to know what was managed)
+
+# Import resources one by one
+terraform import aws_vpc.main vpc-12345678
+terraform import aws_subnet.private[0] subnet-abcd1234
+terraform import aws_subnet.private[1] subnet-efgh5678
+# ... continue for all resources ...
+
+# Verify
+terraform plan  # Should eventually show no changes
+```
+
+2. **Use import blocks (Terraform 1.5+):**
+
+```hcl
+# import.tf
+import {
+  to = aws_vpc.main
+  id = "vpc-12345678"
+}
+
+import {
+  to = aws_subnet.private[0]
+  id = "subnet-abcd1234"
+}
+```
+
+```bash
+terraform plan -generate-config-out=generated.tf
+# Review generated.tf and merge with existing config
+terraform apply
+```
+
+### Handling State Lock Stuck Issues
+
+#### Issue: Lock Persists After Crash
+
+**Check lock status:**
+
+```bash
+# DynamoDB (S3 backend)
+aws dynamodb get-item \
+  --table-name terraform-state-lock \
+  --key '{"LockID":{"S":"my-terraform-state/prod/terraform.tfstate"}}'
+
+# If item exists, lock is held
+```
+
+**Force unlock:**
+
+```bash
+# Get Lock ID from error message or DynamoDB
+terraform force-unlock LOCK_ID
+
+# Confirm when prompted
+```
+
+**Prevent future issues in CI/CD:**
+
+Use concurrency controls instead of automatic force-unlock (see CI/CD section below).
+
+#### Issue: Cannot Acquire Lock in CI/CD
+
+**Problem:** Parallel CI jobs trying to acquire lock
+
+**Solution 1: Use concurrency control**
+
+```yaml
+# GitHub Actions
+concurrency:
+  group: terraform-${{ matrix.environment }}
+  cancel-in-progress: false
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: [dev, staging, prod]
+```
+
+**Solution 2: Separate state per branch/PR**
+
+```bash
+# backend.tf (partial configuration - key provided dynamically)
+terraform {
+  backend "s3" {
+    bucket = "my-terraform-state"
+    region = "us-east-1"
+    # Note: Backend configuration does not support interpolation or env vars.
+    # Set the key dynamically during init in CI/CD:
+  }
+}
+
+# In CI/CD workflow (e.g., GitHub Actions):
+# terraform init -backend-config="key=pr-${GITHUB_PR_NUMBER}/terraform.tfstate"
+```
+
+### State Refresh and Reconciliation
+
+**State drift:** State doesn't match reality
+
+**Detect drift:**
+
+```bash
+# Terraform 0.15.4+
+terraform plan -refresh-only
+
+# Shows what's changed in infrastructure vs state
+```
+
+**Reconcile drift:**
+
+```bash
+# Update state to match reality (no infrastructure changes)
+terraform apply -refresh-only
+
+# Or during regular plan/apply
+terraform plan   # Includes refresh
+terraform apply  # Updates state
+```
+
+**Common drift causes:**
+- Manual changes in AWS console
+- Changes by other tools (aws cli, CDK)
+- Resource deletion outside Terraform
+- Provider API changes
+
+**Prevent drift:**
+- ✅ Use CloudTrail to monitor manual changes
+- ✅ Implement policy to block manual changes
+- ✅ Use drift detection tools (Terraform Cloud drift detection, driftctl)
+- ✅ Regular `terraform plan` in CI/CD
+- ✅ Enable termination protection on critical resources
+
+### Import for State Recovery
+
+**When to use import:**
+- Resources created manually, now want Terraform to manage
+- Recovering from state loss
+- Adopting existing infrastructure
+- Migrating from other IaC tools
+
+**Import workflow:**
+
+**1. Write resource configuration:**
+
+```hcl
+# main.tf
+resource "aws_instance" "web" {
+  ami           = "ami-12345678"
+  instance_type = "t3.micro"
+  # ... other attributes ...
+}
+```
+
+**2. Import existing resource:**
+
+```bash
+# Find resource ID
+aws ec2 describe-instances --filters "Name=tag:Name,Values=web-server"
+
+# Import
+terraform import aws_instance.web i-1234567890abcdef0
+```
+
+**3. Reconcile configuration:**
+
+```bash
+# Plan will show attributes that don't match
+terraform plan
+
+# Update main.tf to match actual resource
+# Or update resource to match main.tf
+```
+
+**4. Verify:**
+
+```bash
+terraform plan  # Should show no changes
+```
+
+**Bulk import:**
+
+```bash
+#!/bin/bash
+# import-instances.sh
+
+# Get all instance IDs
+INSTANCE_IDS=$(aws ec2 describe-instances \
+  --query 'Reservations[].Instances[].InstanceId' \
+  --output text)
+
+# Import each
+for instance_id in $INSTANCE_IDS; do
+  terraform import "aws_instance.imported[\"$instance_id\"]" "$instance_id"
+done
+```
+
+**Terraform 1.5+ import blocks:**
+
+```hcl
+# Generate configuration from imports
+import {
+  to = aws_instance.web
+  id = "i-1234567890abcdef0"
+}
+
+import {
+  to = aws_security_group.web
+  id = "sg-0123456789abcdef"
+}
+```
+
+```bash
+# Generate configuration
+terraform plan -generate-config-out=imported.tf
+
+# Review and merge
+terraform apply
+```
+
+---
+
+## State Best Practices Summary
+
+### Decision Matrix: State Organization
+
+| Scenario | Recommendation | Reasoning |
+|----------|----------------|-----------|
+| **Single team, <100 resources** | Single state file | Simple, low overhead |
+| **Multiple teams** | State per team | Clear ownership, independent deploys |
+| **Mixed update frequencies** | State per lifecycle | Deploy VPC separately from apps |
+| **Production environment** | State per component | Limit blast radius |
+| **Shared infrastructure** | Separate state + remote_state | Core infra stable, apps change often |
+| **Development/testing** | Combined state OK | Less critical, faster to rebuild |
+
+### Common Anti-Patterns to Avoid
+
+❌ **Anti-Pattern 1: Manual state editing**
+```bash
+# DON'T manually edit state files
+vim terraform.tfstate  # ❌ Likely to corrupt
+```
+✅ **Instead:** Use terraform state commands
+```bash
+terraform state mv
+terraform state rm
+terraform import
+```
+
+❌ **Anti-Pattern 2: Sharing state files via git**
+```bash
+git add terraform.tfstate  # ❌ No locking, merge conflicts
+```
+✅ **Instead:** Use remote backend
+
+❌ **Anti-Pattern 3: Bypassing locks**
+```bash
+rm .terraform/terraform.tfstate.lock.info  # ❌ Dangerous
+```
+✅ **Instead:** Investigate why lock exists, then force-unlock if safe
+
+❌ **Anti-Pattern 4: No backup strategy**
+✅ **Instead:** Enable versioning, regular backups, test restore
+
+❌ **Anti-Pattern 5: Monolithic state**
+- 5000+ resources in one state
+- Slow operations
+- High blast radius
+✅ **Instead:** Split by component/team/environment
+
+### LLM Mistake Checklist — State Management
+
+Common model mistakes to correct before returning state-related recommendations:
+
+- recommends local state in team/production contexts
+- proposes one monolithic root state for "convenience"
+- suggests `rm .terraform.tfstate.lock.info` or `force-unlock` without investigating why the lock exists
+- edits `terraform.tfstate` manually instead of using `terraform state mv/rm/import`
+- commits `*.tfstate` to git
+- mixes prod and non-prod in the same backend key
+- recommends workspace-only isolation as a substitute for backend-level IAM separation
+- writes DynamoDB-lock configuration on Terraform 1.10+ instead of using `use_lockfile = true` on the S3 backend
+- reads via `terraform_remote_state` within a single team's stack instead of using module outputs (see [module-patterns.md](module-patterns#3-use-terraform_remote_state-sparingly--only-at-true-ownership-boundaries))
+- omits the rollback/recovery note for destructive state operations
+
+### State Management Checklist
+
+**Setup:** remote backend, locking, encryption at rest, IAM-scoped access, versioning/backup, audit logging.
+
+**Per environment:** separate backend key, scoped IAM role, documented key naming convention, documented DR plan.
+
+**Ongoing:** scheduled drift detection (`plan -detailed-exitcode`), tested state restore, review when a state exceeds ~500 resources, documented force-unlock policy.
+
+**Security:** no secrets in variables/state (use `write_only` or external lookup), TLS enforced, audit log reviewed, encryption keys rotated.
+
+---
+
+**Back to:** [Main Skill File](../)

--- a/misc/website/docs/skills/terraform-skill/references/testing-frameworks.md
+++ b/misc/website/docs/skills/terraform-skill/references/testing-frameworks.md
@@ -19,7 +19,7 @@ This skill is maintained by **Anton Babenko ([terraform-best-practices.com](http
 > **Part of:** [terraform-skill](../)
 > **Purpose:** Detailed guides for Terraform/OpenTofu testing frameworks
 
-This document provides in-depth guidance on testing frameworks for Infrastructure as Code. For the decision matrix and high-level overview, see the [main skill file](../#testing-strategy-framework).
+This document provides in-depth guidance on testing frameworks for Infrastructure as Code. For the decision matrix and high-level overview, see the [main skill file](../#testing-strategy).
 
 ---
 
@@ -99,6 +99,8 @@ terraform show -json tfplan | jq '.'
 
 ### Basic Structure
 
+> **Test discovery:** `terraform test` finds `*.tftest.hcl` files under `tests/` relative to the module root. Use `-filter=<path>` to scope to a specific file.
+
 ```hcl
 # tests/s3_bucket.tftest.hcl
 run "create_bucket" {
@@ -111,14 +113,16 @@ run "create_bucket" {
 }
 
 run "verify_encryption" {
-  command = plan
+  command = apply  # `rule` is a set; use `one(...)` to extract the singleton
 
   assert {
-    condition     = aws_s3_bucket_server_side_encryption_configuration.main.rule[0].apply_server_side_encryption_by_default[0].sse_algorithm == "AES256"
+    condition     = one(aws_s3_bucket_server_side_encryption_configuration.main.rule).apply_server_side_encryption_by_default[0].sse_algorithm == "AES256"
     error_message = "Bucket must use AES256 encryption"
   }
 }
 ```
+
+> Pattern applies identically on Azure/GCP; only provider/resource names change. See [Module Patterns: Cross-cloud resource map](module-patterns#cross-cloud-resource-map).
 
 ### Critical: Validate Resource Schemas First
 
@@ -140,10 +144,11 @@ mcp__terraform__get_provider_details({
 })
 ```
 
-**Why This Matters:**
-- Some blocks are **sets** (unordered, no indexing with `[0]`)
-- Some blocks are **lists** (ordered, indexable)
-- Some attributes are **computed** (only known after apply)
+Block-type distinctions the LLM must verify against the real schema:
+
+- **set** — unordered, cannot index with `[0]`
+- **list** — ordered, indexable
+- **computed** attribute — only known after apply
 
 **Common Schema Patterns:**
 
@@ -151,7 +156,7 @@ mcp__terraform__get_provider_details({
 |--------------|------------|----------|
 | `rule` in `aws_s3_bucket_server_side_encryption_configuration` | **set** | ❌ Cannot use `[0]` |
 | `transition` in `aws_s3_bucket_lifecycle_configuration` | **set** | ❌ Cannot use `[0]` |
-| `noncurrent_version_expiration` in lifecycle | **list** | ✅ Can use `[0]` |
+| `noncurrent_version_expiration` in lifecycle | **nested block (MaxItems=1)** — list-of-1 | ✅ Can use `[0]` |
 
 ### Working with Set-Type Blocks
 
@@ -209,103 +214,37 @@ run "test_encryption_algorithm" {
 
 ### command = plan vs command = apply
 
-**Critical decision:** When to use each command mode
+| Goal | Mode | Why |
+|------|------|-----|
+| Input-derived attribute (bucket name from `var.bucket`) | `plan` | value known before refresh |
+| Variable default / validation | `plan` | fast, no resource creation |
+| Computed attribute (ARN, generated name, cloud ID) | `apply` | only known after provider round-trip |
+| Set-type nested block | `apply` | materializes the set so `for` expressions resolve |
+| Real behavior / mocked provider responses | `apply` | runs the actual create path |
 
-#### Use `command = plan`
-
-**When:**
-- Checking input validation
-- Verifying resource will be created
-- Testing variable defaults
-- Checking resource attributes that are **input-derived** (not computed)
-
-**Example:**
 ```hcl
-run "test_input_validation" {
-  command = plan  # Fast, no resource creation
-
-  variables {
-    bucket = "test-bucket"
-  }
-
+# ✅ plan — input-derived
+run "test_input" {
+  command = plan
+  variables { bucket = "test-bucket" }
   assert {
-    # bucket name is an input, known at plan time
     condition     = aws_s3_bucket.this.bucket == "test-bucket"
     error_message = "Bucket name should match input"
   }
 }
-```
 
-#### Use `command = apply`
-
-**When:**
-- Checking computed attributes (IDs, ARNs, generated names)
-- Accessing set-type blocks
-- Verifying actual resource behavior
-- Testing with real/mocked provider responses
-
-**Example:**
-```hcl
-run "test_computed_values" {
-  command = apply  # Executes and gets computed values
-
-  variables {
-    bucket_prefix = "test-"  # AWS generates full name
-  }
-
+# ✅ apply — computed
+run "test_prefix" {
+  command = apply
+  variables { bucket_prefix = "test-" }
   assert {
-    # bucket name is computed from prefix, only known after apply
-    condition     = length(aws_s3_bucket.this.bucket) > 0
-    error_message = "Bucket should have generated name"
-  }
-}
-```
-
-#### Common Pitfall: Checking Computed Values in Plan Mode
-
-**Problem:**
-```hcl
-run "test_bucket_prefix" {
-  command = plan  # ❌ WRONG MODE
-
-  variables {
-    bucket_prefix = "test-prefix-"
-  }
-
-  assert {
-    # bucket is computed from prefix, unknown at plan time!
-    condition     = aws_s3_bucket.this.bucket == null
-    error_message = "Bucket name should be null when using bucket_prefix"
-  }
-}
-# Error: Condition expression could not be evaluated at this time
-```
-
-**Solution:**
-```hcl
-run "test_bucket_prefix" {
-  command = apply  # ✅ CORRECT MODE or check differently
-
-  variables {
-    bucket_prefix = "test-prefix-"
-  }
-
-  assert {
-    # Now bucket has been generated by provider
-    condition     = startswith(aws_s3_bucket.this.bucket, "test-prefix-")
+    condition     = startswith(aws_s3_bucket.this.bucket, "test-")
     error_message = "Bucket name should start with prefix"
   }
 }
 ```
 
-**Quick Decision Guide:**
-```
-Checking input values? → command = plan
-Checking computed values? → command = apply
-Accessing set-type blocks? → command = apply
-Need fast feedback? → command = plan (with mocks)
-Testing real behavior? → command = apply (without mocks)
-```
+❌ Asserting a computed value in `plan` mode → `Condition expression could not be evaluated at this time`. Fix: switch the `run` block to `command = apply`, or assert a different attribute that is known at plan.
 
 ### With Mocking (1.7+)
 
@@ -433,7 +372,7 @@ run "verify_lifecycle_transitions" {
   assert {
     # Check that both transitions exist using for expression
     condition = length([
-      for rule in aws_s3_bucket_lifecycle_configuration.this[0].rule :
+      for rule in aws_s3_bucket_lifecycle_configuration.this.rule :
       rule.id if rule.id == "archive"
     ]) == 1
     error_message = "Lifecycle rule should exist"
@@ -442,7 +381,7 @@ run "verify_lifecycle_transitions" {
   assert {
     # Verify transition count using length
     condition = alltrue([
-      for rule in aws_s3_bucket_lifecycle_configuration.this[0].rule :
+      for rule in aws_s3_bucket_lifecycle_configuration.this.rule :
       length(rule.transition) == 2
     ])
     error_message = "Should have 2 transitions"
@@ -470,6 +409,7 @@ package test
 
 import (
     "testing"
+    "github.com/gruntwork-io/terratest/modules/random"
     "github.com/gruntwork-io/terratest/modules/terraform"
     "github.com/stretchr/testify/assert"
 )
@@ -480,7 +420,7 @@ func TestS3Module(t *testing.T) {
     terraformOptions := &terraform.Options{
         TerraformDir: "../examples/complete",
         Vars: map[string]interface{}{
-            "bucket_name": "test-bucket-" + uniqueId(),
+            "bucket_name": "test-bucket-" + random.UniqueId(),
         },
     }
 
@@ -563,7 +503,7 @@ stage(t, "teardown", func() {
 Quick syntax check? → terraform validate + fmt
 Security scan? → trivy + checkov
 Terraform 1.6+, simple logic? → Native tests
-Pre-1.6, or complex integration? → Terratest
+Complex integration or multi-cloud orchestration? → Terratest
 ```
 
 ### Cost Optimization
@@ -573,6 +513,21 @@ Pre-1.6, or complex integration? → Terratest
 3. Run integration tests only on main branch
 4. Use smaller instance types in tests
 5. Share test resources when safe
+
+---
+
+## LLM Mistake Checklist — Testing
+
+Common model mistakes when generating test code:
+
+- asserts computed values (ARNs, generated names, cloud-assigned IDs) in `command = plan` mode — must use `command = apply`
+- indexes set-type nested blocks with `[0]` — sets are unordered, use `for` expressions or `command = apply` to materialize
+- treats mocked-provider tests as integration coverage — mocks validate logic only, not provider behavior
+- forgets to exercise `validation` blocks with invalid inputs — only tests the happy path
+- skips idempotency (`terraform plan -detailed-exitcode` after apply) — the most common regression detector
+- asserts on Terraform syntax instead of module behavior (`terraform validate` already covers syntax)
+- runs expensive real-cloud integration tests on every commit instead of gating them behind main/scheduled
+- omits cleanup, leaving orphaned resources billed against the test account
 
 ---
 

--- a/misc/website/static/manifests/skills.json
+++ b/misc/website/static/manifests/skills.json
@@ -51,7 +51,7 @@
   },
   {
     "name": "terraform-skill",
-    "description": "Use when working with Terraform or OpenTofu - creating modules, writing tests (native test framework, Terratest), setting up CI/CD pipelines, reviewing configurations, choosing between testing approaches, debugging state issues, implementing security scanning (trivy, checkov), or making infrastructure-as-code architecture decisions",
+    "description": "Use when writing, reviewing, or debugging Terraform/OpenTofu modules, tests, CI, scans, or state ops - diagnoses failure mode (identity churn, secrets, blast radius, CI drift, state corruption) with version-aware guards.",
     "path": "/docs/skills/terraform-skill"
   },
   {


### PR DESCRIPTION
## Summary

- The vendor-update workflow only ran `update-all-references.sh` but skipped `update-pages.sh`, so Docusaurus wrappers and `skills.json` went stale after vendor PRs merged
- Added the missing `update-pages.sh` call to the "Regenerate docs" step
- Regenerated all stale pages from the terraform-skill and eks-upgrade-check vendor updates

## Test plan

- [ ] `docs-sync` CI job passes (no drift detected)
- [ ] `docs` workflow builds successfully with the new pages