### PR TITLE
docs: add disclaimer for educational/demo-only use

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 > Curated platform-engineering skills that compress onboarding from months to weeks. Domain knowledge authored by senior AWS SSAs, TAMs, and ProServe, delivered through agentic AI tools (Claude Code, Kiro CLI etc).
 
+> [!WARNING]
+> This repository provides sample code for **educational and demonstration purposes only**. It is not intended for direct production use without proper review, testing, and validation. Always test generated infrastructure artifacts (Terraform, Helm charts, kubectl commands) in non-production environments first. Use at your own risk — the authors are not responsible for any issues, damages, or losses that may result from using this code in production.
+
 **APEX** uses agentic AI (frontier models and agent harness like Claude Code) combined with curated "skills" to give engineers SSA-grade platform engineering output.
 
 Agent Skills are organized folders of instructions, scripts, and resources that frontier LLM models can discover and load dynamically to perform specialized tasks. By codifying expert platform engineering knowledge as Agent Skills, we amplify best practices and scale them across teams while reducing toil. They follow the Agent Skills [Agent Skills open standard](https://agentskills.io/) open standard and are compatible with any supported agent harness.

--- a/misc/website/docs/getting-started.md
+++ b/misc/website/docs/getting-started.md
@@ -5,6 +5,10 @@ title: Getting Started
 
 # Getting Started
 
+:::warning Disclaimer
+This project provides sample code for **educational and demonstration purposes only**. It is not intended for direct production use without proper review, testing, and validation. Always test generated infrastructure artifacts (Terraform, Helm charts, kubectl commands) in non-production environments first. Use at your own risk — the authors are not responsible for any issues, damages, or losses that may result from using this code in production.
+:::
+
 APEX skills are plain folders of markdown + scripts. Any agent harness that supports the [Agent Skills](https://agentskills.io/) standard can load them.
 
 ## NPX Installer (recommended)


### PR DESCRIPTION
## Summary
- Adds prominent warning disclaimer to `README.md` (GitHub `[!WARNING]` admonition)
- Adds matching `:::warning` admonition to docs site Getting Started page
- Clarifies repo is sample code for educational/demo purposes, not direct production use

## Test plan
- [x] Docusaurus build passes
- [x] Warning renders correctly on Getting Started page (verified locally)