### PR TITLE
docs: move README disclaimer below content

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@
 
 > Curated platform-engineering skills that compress onboarding from months to weeks. Domain knowledge authored by senior AWS SSAs, TAMs, and ProServe, delivered through agentic AI tools (Claude Code, Kiro CLI etc).
 
-> [!WARNING]
-> This repository provides sample code for **educational and demonstration purposes only**. It is not intended for direct production use without proper review, testing, and validation. Always test generated infrastructure artifacts (Terraform, Helm charts, kubectl commands) in non-production environments first. Use at your own risk — the authors are not responsible for any issues, damages, or losses that may result from using this code in production.
-
 **APEX** uses agentic AI (frontier models and agent harness like Claude Code) combined with curated "skills" to give engineers SSA-grade platform engineering output.
 
 Agent Skills are organized folders of instructions, scripts, and resources that frontier LLM models can discover and load dynamically to perform specialized tasks. By codifying expert platform engineering knowledge as Agent Skills, we amplify best practices and scale them across teams while reducing toil. They follow the Agent Skills [Agent Skills open standard](https://agentskills.io/) open standard and are compatible with any supported agent harness.
@@ -185,6 +182,9 @@ All best practices content is sourced from public AWS documentation:
 - [AWS EKS Capabilities](https://docs.aws.amazon.com/eks/latest/userguide/capabilities.html)
 
 ---
+
+> [!WARNING]
+> This repository provides sample code for **educational and demonstration purposes only**. It is not intended for direct production use without proper review, testing, and validation. Always test generated infrastructure artifacts (Terraform, Helm charts, kubectl commands) in non-production environments first. Use at your own risk — the authors are not responsible for any issues, damages, or losses that may result from using this code in production.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -183,8 +183,11 @@ All best practices content is sourced from public AWS documentation:
 
 ---
 
-> [!WARNING]
-> This repository provides sample code for **educational and demonstration purposes only**. It is not intended for direct production use without proper review, testing, and validation. Always test generated infrastructure artifacts (Terraform, Helm charts, kubectl commands) in non-production environments first. Use at your own risk — the authors are not responsible for any issues, damages, or losses that may result from using this code in production.
+## Disclaimer
+
+This repository provides sample code for **educational and demonstration purposes only**. It is not intended for direct production use without proper review, testing, and validation. Always test generated infrastructure artifacts (Terraform, Helm charts, kubectl commands) in non-production environments first. Use at your own risk — the authors are not responsible for any issues, damages, or losses that may result from using this code in production.
+
+---
 
 ## License
 


### PR DESCRIPTION
## Summary
- Moves the `[!WARNING]` disclaimer from directly under the tagline to just above the License section
- Less visually jarring — readers see the value prop first, disclaimer is still visible before the license

## Test plan
- [x] Renders correctly on GitHub (warning admonition above License)