### PR TITLE
chore: bump version references to v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Detects Claude Code and/or Kiro CLI, clones the repo to `~/.apex-skills/`, and s
 
 ```bash
 npx apex-skills --update              # Pull latest skills
-npx apex-skills --version v1.0.0      # Pin to a specific release
+npx apex-skills --version v1.1.0      # Pin to a specific release
 npx apex-skills --branch feat/new-eks # Install from a branch
 npx apex-skills --help                # See all options
 ```

--- a/misc/installer/README.md
+++ b/misc/installer/README.md
@@ -29,7 +29,7 @@ npx apex-skills --update
 | `--project` | Install to current project directory instead of global |
 | `--no-steering` | Skip steering/commands setup |
 | `--update` | Pull latest and re-symlink (non-interactive) |
-| `--version <tag>` | Pin to a specific release (e.g. `v1.0.0`) |
+| `--version <tag>` | Pin to a specific release (e.g. `v1.1.0`) |
 | `--branch <name>` | Use a specific branch instead of main |
 | `--uninstall` | Remove symlinks (keeps cloned repo) |
 | `-h, --help` | Show help |

--- a/misc/installer/bin/cli.mjs
+++ b/misc/installer/bin/cli.mjs
@@ -220,14 +220,14 @@ function showHelp() {
   log(`  --project            Install to current project instead of global`);
   log(`  --no-steering        Skip steering/commands setup`);
   log(`  --update             Pull latest and re-symlink (non-interactive)`);
-  log(`  --version <tag>      Pin to a specific release (e.g. v1.0.0)`);
+  log(`  --version <tag>      Pin to a specific release (e.g. v1.1.0)`);
   log(`  --branch <name>      Use a specific branch instead of main`);
   log(`  --uninstall          Remove symlinks (keeps cloned repo)`);
   log(`  -h, --help           Show this help\n`);
   log(`${c.bold}Examples:${c.reset}`);
   log(`  npx apex-skills                        Interactive install`);
   log(`  npx apex-skills --update               Update to latest skills`);
-  log(`  npx apex-skills --version v1.0.0       Pin to release v1.0.0`);
+  log(`  npx apex-skills --version v1.1.0       Pin to release v1.1.0`);
   log(`  npx apex-skills --branch feat/new-eks  Install from a branch`);
   log(`  npx apex-skills --claude-only          Install for Claude Code only`);
   log(`  npx apex-skills --project              Install into current project\n`);

--- a/misc/installer/package.json
+++ b/misc/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-skills",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Install APEX platform engineering skills for Claude Code and Kiro CLI",
   "bin": {
     "apex-skills": "./bin/cli.mjs"
@@ -11,7 +11,15 @@
     "type": "git",
     "url": "https://github.com/aws-samples/sample-apex-skills"
   },
-  "keywords": ["aws", "eks", "platform-engineering", "ai-agent", "claude-code", "kiro", "skills"],
+  "keywords": [
+    "aws",
+    "eks",
+    "platform-engineering",
+    "ai-agent",
+    "claude-code",
+    "kiro",
+    "skills"
+  ],
   "engines": {
     "node": ">=18"
   }

--- a/misc/website/docs/getting-started.md
+++ b/misc/website/docs/getting-started.md
@@ -23,7 +23,7 @@ The installer detects which tools you have (Claude Code, Kiro CLI, or both), clo
 
 ```bash
 npx apex-skills --update              # Pull latest skills
-npx apex-skills --version v1.0.0      # Pin to a specific release
+npx apex-skills --version v1.1.0      # Pin to a specific release
 npx apex-skills --branch feat/new-eks # Install from a branch
 npx apex-skills --help                # See all options
 ```


### PR DESCRIPTION
## Summary

Updates all user-facing version examples from `v1.0.0` to `v1.1.0` following the release.

## Changes

- `README.md` — installer example
- `misc/website/docs/getting-started.md` — docs site example
- `misc/installer/bin/cli.mjs` — help text and examples
- `misc/installer/README.md` — flag table example

## Test plan

- [ ] `node --check misc/installer/bin/cli.mjs` passes
- [ ] Docs site builds cleanly
- [ ] `npx apex-skills --help` shows v1.1.0 in examples