### PR TITLE
fix: make update-pages.sh macOS-portable + harden new-skill regenerate step

### DIFF
--- a/misc/update-pages.sh
+++ b/misc/update-pages.sh
@@ -96,10 +96,24 @@ first_heading() {
 }
 
 # --- Derive title from filename -------------------------------------------
+# Replace hyphens with spaces and title-case each word. Uses awk rather than
+# `sed 's/\b\(.\)/\u\1/g'` because the \b word boundary and \u uppercase escape
+# are GNU-only; on BSD/macOS sed they silently no-op and leave titles lowercase.
 title_from_filename() {
   local base="$1"
   base="${base%.md}"
-  echo "$base" | sed 's/-/ /g; s/\b\(.\)/\u\1/g'
+  printf '%s\n' "$base" | awk '{
+    gsub(/-/, " ")
+    cap = 1; out = ""
+    for (i = 1; i <= length($0); i++) {
+      c = substr($0, i, 1)
+      if (cap && c ~ /[a-z]/) { c = toupper(c); cap = 0 }
+      else if (c ~ /[a-zA-Z0-9]/) { cap = 0 }
+      else { cap = 1 }
+      out = out c
+    }
+    print out
+  }'
 }
 
 # --- Strip leading YAML frontmatter from a markdown file ------------------

--- a/misc/website/docs/steering/workflows/new-skill.md
+++ b/misc/website/docs/steering/workflows/new-skill.md
@@ -145,7 +145,11 @@ Steps, in order:
    ./misc/update-all-references.sh
    ./misc/update-pages.sh
    ```
-   Verify the Docusaurus wrapper was generated: `ls misc/website/docs/skills/<name>/index.md` — if missing, the staging step was skipped.
+   Now assert the wrapper was actually generated — if you ran the scripts before `git add`, `update-pages.sh` reads an index without the new skill and silently emits no pages, which fails `docs-sync` CI later:
+   ```bash
+   ls misc/website/docs/skills/<name>/index.md \
+     || { echo "ERROR: wrapper not generated — 'git add' the skill BEFORE running update-pages.sh"; exit 1; }
+   ```
    Stage all generated output and commit:
    ```bash
    git add -A && git commit -m "docs: regenerate reference tables and pages"

--- a/steering/workflows/new-skill.md
+++ b/steering/workflows/new-skill.md
@@ -138,7 +138,11 @@ Steps, in order:
    ./misc/update-all-references.sh
    ./misc/update-pages.sh
    ```
-   Verify the Docusaurus wrapper was generated: `ls misc/website/docs/skills/<name>/index.md` — if missing, the staging step was skipped.
+   Now assert the wrapper was actually generated — if you ran the scripts before `git add`, `update-pages.sh` reads an index without the new skill and silently emits no pages, which fails `docs-sync` CI later:
+   ```bash
+   ls misc/website/docs/skills/<name>/index.md \
+     || { echo "ERROR: wrapper not generated — 'git add' the skill BEFORE running update-pages.sh"; exit 1; }
+   ```
    Stage all generated output and commit:
    ```bash
    git add -A && git commit -m "docs: regenerate reference tables and pages"


### PR DESCRIPTION
Two small contributor-environment robustness fixes (discussed in Slack — thanks @utkarpun for the green light).

## 1. `update-pages.sh` title-casing wasn't portable to BSD/macOS
`title_from_filename` used `sed 's/-/ /g; s/\b\(.\)/\u\1/g'`. The `\b` (word boundary) and `\u` (uppercase) escapes are **GNU-only** — on BSD/macOS `sed` they silently no-op, so titles come out lowercase (`eks security` instead of `Eks Security`). Since the repo builds on EC2 (Linux), this only bites Mac/Windows contributors.

**Fix:** replace the one `sed` with a portable `awk` title-caser. Verified **byte-for-byte equivalent** to the old GNU output across hyphen / dot / all-caps / numeric inputs, and confirmed `update-pages.sh` now runs cleanly on the **default macOS awk** (`/usr/bin/awk`) — `update-pages.sh --check` reports in-sync with no gawk shim. No behavior change on Linux.

*(Scope note: `update-all-references.sh` has no equivalent GNU-isms, so this is one function in one file.)*

## 2. Harden `/apex:new-skill` Phase 5 (stage-before-regenerate)
`update-pages.sh` reads the **git index**, not the filesystem — so running it before `git add`-ing the new skill silently emits zero wrapper pages, which then fails `docs-sync` CI. The Phase-5 verify line was passive prose; turned it into an enforced guard that explains the failure mode:
```bash
ls misc/website/docs/skills/<name>/index.md \
  || { echo "ERROR: wrapper not generated — 'git add' the skill BEFORE running update-pages.sh"; exit 1; }
```

## Validation
- `bash -n` clean; `update-pages.sh` runs end-to-end on default macOS awk → exit 0, only intended diffs.
- `update-pages.sh --check` → ✓ in sync. No title regressions (existing pages use frontmatter/heading titles; the filename path is a fallback).
- 3 files, +25/−3.