### PR TITLE
feat: npm release automation (M1+M2+M4)

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,70 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    if: github.event.release.target_commitish == 'main'
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    defaults:
+      run:
+        working-directory: misc/installer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify version matches tag
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Smoke test
+        run: node bin/cli.mjs --help
+
+      - name: Check if version already published
+        id: check
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "apex-skills@${VERSION}" version 2>/dev/null; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Determine dist-tag
+        id: dist-tag
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if echo "$VERSION" | grep -q '-'; then
+            echo "tag=next" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish
+        if: steps.check.outputs.already_published == 'false'
+        # M3: remove --dry-run after OIDC trusted publisher is configured
+        run: npm publish --dry-run --provenance --tag ${{ steps.dist-tag.outputs.tag }}
+        # M3: when enabling OIDC trusted publisher, remove this env block —
+        # provenance uses OIDC automatically; NPM_TOKEN + --provenance = error
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ misc/website/build/
 *.log
 HISTORY.md
 *.code-workspace
+PLAN-npm-release.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -385,6 +385,20 @@ GitHub provides additional document on [forking a repository](https://help.githu
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
 
+## Releasing to npm
+
+1. Run `./misc/bump-version.sh <version>` (e.g. `./misc/bump-version.sh 1.2.0`)
+2. Commit the version bump
+3. Push to main
+4. Create a GitHub Release tagged `v<version>` targeting main
+5. The `release-npm.yml` workflow auto-publishes to npm via OIDC trusted publisher
+6. Verify: `npm view apex-skills` shows the new version
+
+**Pre-releases:** Tags containing `-` (e.g. `1.2.0-rc.1`) publish to the `next` dist-tag.
+
+**Rollback:** `npm deprecate apex-skills@<version> "reason"` + publish a patch.
+
+
 ## Finding Contributions to Work On
 
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Detects Claude Code and/or Kiro CLI, clones the repo to `~/.apex-skills/`, and s
 
 ```bash
 npx apex-skills --update              # Pull latest skills
-npx apex-skills --version v1.1.0      # Pin to a specific release
+npx apex-skills --version v1.1.1      # Pin to a specific release
 npx apex-skills --branch feat/new-eks # Install from a branch
 npx apex-skills --help                # See all options
 ```

--- a/misc/bump-version.sh
+++ b/misc/bump-version.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+VERSION="${1:-}"
+
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: $0 <version>" >&2
+  echo "Example: $0 1.2.0" >&2
+  exit 1
+fi
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: '$VERSION' does not look like a valid semver (expected X.Y.Z)" >&2
+  exit 1
+fi
+
+# 1. misc/installer/package.json — update version field via jq (preserve 2-space indent)
+jq --indent 2 --arg v "$VERSION" '.version = $v' misc/installer/package.json > tmp.$$.json && mv tmp.$$.json misc/installer/package.json
+echo "Updated misc/installer/package.json -> version $VERSION"
+
+# 2. README.md — update --version vX.Y.Z (pattern match, not line number)
+sed -i'' -E 's/(--version v)[0-9]+\.[0-9]+\.[0-9]+/\1'"$VERSION"'/' README.md
+if ! grep -qE -- "--version v${VERSION}" README.md; then
+  echo "Error: failed to update version in README.md" >&2
+  exit 1
+fi
+echo "Updated README.md -> v$VERSION"
+
+# 3. misc/website/docs/getting-started.md — update --version vX.Y.Z
+sed -i'' -E 's/(--version v)[0-9]+\.[0-9]+\.[0-9]+/\1'"$VERSION"'/' misc/website/docs/getting-started.md
+if ! grep -qE -- "--version v${VERSION}" misc/website/docs/getting-started.md; then
+  echo "Error: failed to update version in misc/website/docs/getting-started.md" >&2
+  exit 1
+fi
+echo "Updated misc/website/docs/getting-started.md -> v$VERSION"
+
+# 4. misc/installer/README.md line 32 — update e.g. `vX.Y.Z` in options table
+sed -i'' -E 's/(e\.g\. `v)[0-9]+\.[0-9]+\.[0-9]+/\1'"$VERSION"'/' misc/installer/README.md
+if ! grep -qE "e\.g\. \`v${VERSION}\`" misc/installer/README.md; then
+  echo "Error: failed to update version in misc/installer/README.md" >&2
+  exit 1
+fi
+echo "Updated misc/installer/README.md -> v$VERSION"
+
+echo ""
+echo "Done. All files bumped to v$VERSION"

--- a/misc/installer/LICENSE
+++ b/misc/installer/LICENSE
@@ -1,0 +1,17 @@
+MIT No Attribution
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/misc/installer/README.md
+++ b/misc/installer/README.md
@@ -29,7 +29,7 @@ npx apex-skills --update
 | `--project` | Install to current project directory instead of global |
 | `--no-steering` | Skip steering/commands setup |
 | `--update` | Pull latest and re-symlink (non-interactive) |
-| `--version <tag>` | Pin to a specific release (e.g. `v1.1.0`) |
+| `--version <tag>` | Pin to a specific release (e.g. `v1.1.1`) |
 | `--branch <name>` | Use a specific branch instead of main |
 | `--uninstall` | Remove symlinks (keeps cloned repo) |
 | `-h, --help` | Show help |

--- a/misc/installer/bin/cli.mjs
+++ b/misc/installer/bin/cli.mjs
@@ -5,7 +5,9 @@ import { homedir, platform } from 'os';
 import { execSync } from 'child_process';
 import { createInterface } from 'readline';
 
-const VERSION = '1.1.0';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { version: VERSION } = require('../package.json');
 const REPO_URL = 'https://github.com/aws-samples/sample-apex-skills.git';
 const HOME = homedir();
 const INSTALL_DIR = join(HOME, '.apex-skills');

--- a/misc/installer/package.json
+++ b/misc/installer/package.json
@@ -22,5 +22,12 @@
   ],
   "engines": {
     "node": ">=18"
-  }
+  },
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
+  "files": [
+    "bin/"
+  ]
 }

--- a/misc/website/docs/getting-started.md
+++ b/misc/website/docs/getting-started.md
@@ -23,7 +23,7 @@ The installer detects which tools you have (Claude Code, Kiro CLI, or both), clo
 
 ```bash
 npx apex-skills --update              # Pull latest skills
-npx apex-skills --version v1.1.0      # Pin to a specific release
+npx apex-skills --version v1.1.1      # Pin to a specific release
 npx apex-skills --branch feat/new-eks # Install from a branch
 npx apex-skills --help                # See all options
 ```


### PR DESCRIPTION
## Summary

- Eliminate hardcoded VERSION const in cli.mjs; read from package.json via createRequire
- Add release-npm.yml workflow: OIDC trusted publisher, branch gate, version-tag check, smoke test, idempotency, dist-tag logic (dry-run for now)
- Add bump-version.sh targeting 4 files with pattern-based sed + post-edit verification
- Add publishConfig/files/LICENSE to installer package

## Context

Part of npm release automation plan (PLAN-npm-release.md). Workflow starts as dry-run — will flip to real publish after merge (npmjs.com trusted publisher already configured).

## Test plan

- [ ] Merge to main
- [ ] Flip workflow from --dry-run to real publish
- [ ] Run bump-version.sh 1.1.2, commit, tag v1.1.2, create GitHub Release
- [ ] Verify workflow publishes apex-skills@1.1.2 to npm