### PR TITLE
chore: enable npm publish + bump to v1.1.2

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -62,9 +62,4 @@ jobs:
 
       - name: Publish
         if: steps.check.outputs.already_published == 'false'
-        # M3: remove --dry-run after OIDC trusted publisher is configured
-        run: npm publish --dry-run --provenance --tag ${{ steps.dist-tag.outputs.tag }}
-        # M3: when enabling OIDC trusted publisher, remove this env block —
-        # provenance uses OIDC automatically; NPM_TOKEN + --provenance = error
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --tag ${{ steps.dist-tag.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Detects Claude Code and/or Kiro CLI, clones the repo to `~/.apex-skills/`, and s
 
 ```bash
 npx apex-skills --update              # Pull latest skills
-npx apex-skills --version v1.1.1      # Pin to a specific release
+npx apex-skills --version v1.1.2      # Pin to a specific release
 npx apex-skills --branch feat/new-eks # Install from a branch
 npx apex-skills --help                # See all options
 ```

--- a/misc/installer/README.md
+++ b/misc/installer/README.md
@@ -29,7 +29,7 @@ npx apex-skills --update
 | `--project` | Install to current project directory instead of global |
 | `--no-steering` | Skip steering/commands setup |
 | `--update` | Pull latest and re-symlink (non-interactive) |
-| `--version <tag>` | Pin to a specific release (e.g. `v1.1.1`) |
+| `--version <tag>` | Pin to a specific release (e.g. `v1.1.2`) |
 | `--branch <name>` | Use a specific branch instead of main |
 | `--uninstall` | Remove symlinks (keeps cloned repo) |
 | `-h, --help` | Show help |

--- a/misc/installer/package.json
+++ b/misc/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-skills",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Install APEX platform engineering skills for Claude Code and Kiro CLI",
   "bin": {
     "apex-skills": "./bin/cli.mjs"

--- a/misc/website/docs/getting-started.md
+++ b/misc/website/docs/getting-started.md
@@ -23,7 +23,7 @@ The installer detects which tools you have (Claude Code, Kiro CLI, or both), clo
 
 ```bash
 npx apex-skills --update              # Pull latest skills
-npx apex-skills --version v1.1.1      # Pin to a specific release
+npx apex-skills --version v1.1.2      # Pin to a specific release
 npx apex-skills --branch feat/new-eks # Install from a branch
 npx apex-skills --help                # See all options
 ```


### PR DESCRIPTION
## Summary

- Flip release-npm.yml from --dry-run to real publish (OIDC trusted publisher configured)
- Bump version to 1.1.2 across all 4 targets

## Context

Test publish to validate the automation pipeline. Content identical to 1.1.1 — only version number changes.