### PR TITLE
fix: npm OIDC publish (npm 11) + bump v1.1.3

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -28,6 +28,9 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      - name: Upgrade npm for OIDC provenance support
+        run: npm install -g npm@11
+
       - name: Verify version matches tag
         run: |
           TAG="${GITHUB_REF_NAME#v}"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Detects Claude Code and/or Kiro CLI, clones the repo to `~/.apex-skills/`, and s
 
 ```bash
 npx apex-skills --update              # Pull latest skills
-npx apex-skills --version v1.1.2      # Pin to a specific release
+npx apex-skills --version v1.1.3      # Pin to a specific release
 npx apex-skills --branch feat/new-eks # Install from a branch
 npx apex-skills --help                # See all options
 ```

--- a/misc/installer/README.md
+++ b/misc/installer/README.md
@@ -29,7 +29,7 @@ npx apex-skills --update
 | `--project` | Install to current project directory instead of global |
 | `--no-steering` | Skip steering/commands setup |
 | `--update` | Pull latest and re-symlink (non-interactive) |
-| `--version <tag>` | Pin to a specific release (e.g. `v1.1.2`) |
+| `--version <tag>` | Pin to a specific release (e.g. `v1.1.3`) |
 | `--branch <name>` | Use a specific branch instead of main |
 | `--uninstall` | Remove symlinks (keeps cloned repo) |
 | `-h, --help` | Show help |

--- a/misc/installer/package.json
+++ b/misc/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-skills",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Install APEX platform engineering skills for Claude Code and Kiro CLI",
   "bin": {
     "apex-skills": "./bin/cli.mjs"

--- a/misc/website/docs/getting-started.md
+++ b/misc/website/docs/getting-started.md
@@ -23,7 +23,7 @@ The installer detects which tools you have (Claude Code, Kiro CLI, or both), clo
 
 ```bash
 npx apex-skills --update              # Pull latest skills
-npx apex-skills --version v1.1.2      # Pin to a specific release
+npx apex-skills --version v1.1.3      # Pin to a specific release
 npx apex-skills --branch feat/new-eks # Install from a branch
 npx apex-skills --help                # See all options
 ```


### PR DESCRIPTION
## Summary

- Add `npm install -g npm@11` step — npm 10.x doesn't support token-free OIDC trusted publishing (requires 11.5.1+)
- Bump version to 1.1.3 for retry

## Context

v1.1.2 failed because provenance signing worked (OIDC id-token) but the actual PUT auth requires npm 11's native trusted publisher support. v1.1.2 release stays as-is on GitHub.