### PR TITLE
fix(security): sanitize --version/--branch to prevent command injection

### DIFF
--- a/misc/installer/bin/cli.mjs
+++ b/misc/installer/bin/cli.mjs
@@ -245,6 +245,13 @@ async function main() {
     process.exit(1);
   }
 
+  const SAFE_REF = /^[a-zA-Z0-9][a-zA-Z0-9._\-\/]*$/;
+  const ref = flags.version || flags.branch;
+  if (ref && !SAFE_REF.test(ref)) {
+    error(`Invalid ref: "${ref}". Only alphanumeric, dots, hyphens, slashes, and underscores are allowed.`);
+    process.exit(1);
+  }
+
   if (platform() === 'win32') {
     error('Windows is not supported (symlinks require elevated permissions).');
     error('Use WSL (Windows Subsystem for Linux) instead.');


### PR DESCRIPTION
## Summary

- Validate `--version` and `--branch` CLI arguments against `/^[a-zA-Z0-9][a-zA-Z0-9._\-\/]*$/` before passing to `execSync`
- Blocks argument injection (leading dashes) and shell metacharacter injection
- Addresses Socket.dev security finding on apex-skills@1.1.1

## Test plan

- [ ] `npx apex-skills --version v1.1.3` still works (valid ref)
- [ ] `npx apex-skills --version "; rm -rf /"` rejected with clear error
- [ ] `npx apex-skills --branch --orphan` rejected (leading dash)