### PR TITLE
feat(skills): add ecs-genai skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Skills follow the [Agent Skills standard](https://agentskills.io/). Each skill l
 ### ECS Skills
 
 <table>
-<tr><td><a href="https://aws-samples.github.io/sample-apex-skills/docs/skills/ecs/ecs-architect/"><b>ecs-architect</b></a></td><td><a href="https://aws-samples.github.io/sample-apex-skills/docs/skills/ecs/ecs-operation-review/"><b>ecs-operation-review</b></a></td><td><a href="https://aws-samples.github.io/sample-apex-skills/docs/skills/ecs/ecs-security/"><b>ecs-security</b></a></td></tr>
+<tr><td><a href="https://aws-samples.github.io/sample-apex-skills/docs/skills/ecs/ecs-architect/"><b>ecs-architect</b></a></td><td><a href="https://aws-samples.github.io/sample-apex-skills/docs/skills/ecs/ecs-genai/"><b>ecs-genai</b></a></td><td><a href="https://aws-samples.github.io/sample-apex-skills/docs/skills/ecs/ecs-operation-review/"><b>ecs-operation-review</b></a></td><td><a href="https://aws-samples.github.io/sample-apex-skills/docs/skills/ecs/ecs-security/"><b>ecs-security</b></a></td></tr>
 </table>
 
 ### General

--- a/misc/website/docs/skills/ecs/ecs-genai/index.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/index.md
@@ -1,0 +1,131 @@
+---
+title: "ecs-genai"
+description: "Use whenever someone is running a GPU / ML / GenAI / LLM workload on Amazon ECS — phrased as \"GPU on ECS\", \"ECS GPU-optimized AMI\", \"g4dn/g5/g6/p4/p5 on ECS\", \"which ECS launch type for GPU\", \"Inferentia/Trainium/Neuron on ECS\", \"distributed training on ECS\", \"model inference container on ECS\", \"Capacity Blocks for ECS\", \"GPU sharing on ECS\", or \"separate ASG per GPU type\". Covers GPU compute on ECS-on-EC2 (GPU-optimized AMIs, NVIDIA container runtime, instance families), the separate-ASG-per-GPU-type capacity-provider pattern (ECS capacity providers cannot use mixed-instance ASGs), EC2 Capacity Blocks for ML, container inference/serving, Neuron on ECS, distributed ML, GPU observability, and a security baseline. First-class constraint: AWS Fargate has NO GPU support — GPU is ECS-on-EC2 (or ECS Managed Instances / ECS Anywhere) only. Trigger even if \"GenAI\" is never said — any GPU, accelerator, inference-serving, or ML-training decision on ECS qualifies. Use eks-genai for Kubernetes/EKS; SageMaker for fully-managed ML training/hosting; Bedrock for managed foundation models with no self-hosting. For generic ECS launch-type/design with no accelerator or ML workload use ecs-architect."
+custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/SKILL.md
+format: md
+---
+
+:::info[Source]
+This page is generated from [skills/ecs-genai/SKILL.md](https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/SKILL.md). Edit the source, not this page.
+:::
+
+
+# GenAI / GPU / ML Workloads on Amazon ECS
+
+End-to-end opinionated guidance for running GPU-accelerated, ML-training, and GenAI inference workloads on **Amazon ECS-on-EC2**. This skill is scoped to the compute-and-capacity mechanics that are unique to ECS: the GPU-optimized AMI + NVIDIA container runtime, the **separate-ASG-per-GPU-type capacity-provider pattern** (ECS capacity providers cannot use mixed-instance-type Auto Scaling groups), EC2 Capacity Blocks for ML, AWS Neuron (Inferentia/Trainium) on ECS, container inference/serving, distributed ML, and accelerator observability.
+
+**The single most important constraint, stated first: AWS Fargate has no GPU support.** GPUs and AWS accelerators (Inferentia/Trainium) are available only on **ECS-on-EC2**, **ECS Managed Instances**, and **ECS Anywhere/External** — never on Fargate. Every GPU/ML answer on ECS begins by ruling Fargate out for the accelerated container. See [service-boundaries.md](references/service-boundaries) for the exact evidence and the "use EKS / SageMaker / Bedrock instead" routing.
+
+For "which ECS launch model should I use" with no accelerator or ML workload, use `ecs-architect`. For Kubernetes-based GenAI, use `eks-genai`. This skill is the GPU/ML *workload* layer on ECS specifically.
+
+## When to Use This Skill
+
+**Activate when the user wants to:**
+- Run a GPU workload on ECS — choose an instance family (g4dn/g5/g6/g6e/p3/p4d/p5), the ECS GPU-optimized AMI, and the NVIDIA container runtime
+- Serve an LLM / model inference container on ECS, or run ML training/fine-tuning on ECS
+- Design GPU capacity on ECS at scale — the separate-ASG-per-GPU-type + capacity-provider-strategy pattern, Managed Instances, Spot, and Capacity Blocks for ML
+- Use AWS Neuron (Inferentia/Trainium) on ECS — device allocation, compilation, Inf/Trn instance selection
+- Wire GPU/accelerator observability (Container Insights enhanced / DCGM) on ECS
+- Decide **when NOT to use ECS** — when EKS (`eks-genai`), SageMaker, or Bedrock is the better home
+
+**Don't use this skill for:**
+- **Kubernetes / EKS GenAI** (Karpenter, KubeRay, JARK, device plugins, vLLM-on-EKS) → `eks-genai`
+- **Fully-managed ML training or model hosting** with no container orchestration to own → **Amazon SageMaker** (training jobs, endpoints, HyperPod)
+- **Managed foundation-model API with no self-hosting** (no GPU to manage) → **Amazon Bedrock**
+- **Generic ECS launch-type selection / cluster design** with no accelerator or ML workload → `ecs-architect`
+- **Deep Neuron kernel / NKI / model-porting** work → the Neuron-specific skills, not this one
+- Any assumption that **Fargate can run a GPU** — it cannot; do not design around it
+
+## The ECS-GPU Decision Framework
+
+Walk the customer through five decisions, top to bottom. Depth for each is in the references.
+
+```text
+D1  Compute host      ECS-on-EC2 · ECS Managed Instances · ECS Anywhere   (NEVER Fargate for GPU)
+D2  Accelerator       NVIDIA GPU (g4dn/g5/g6/g6e/p3/p4d/p5) · AWS Neuron (Inf2/Trn1/Trn2)
+D3  Capacity model    separate ASG per GPU type + capacity-provider strategy · Managed Instances · Capacity Blocks · Spot
+D4  Workload shape    single-container inference · distributed multi-node training · GPU-shared dev
+D5  Boundary check    stay on ECS · or route to eks-genai / SageMaker / Bedrock
+```
+
+### D1 — Compute host: Fargate is out for GPU (first-class caveat)
+
+**AWS Fargate cannot run GPU or AWS-accelerator workloads.** AWS lists the `gpu` parameter among the task-definition parameters that are **"not valid in Fargate tasks"** (alongside `devices` and `placementConstraints`), and the Fargate task-size model exposes only CPU and memory — valid task sizes run from 256 (.25 vCPU) up to 32768 (32 vCPU), with no GPU dimension at all ([ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)). The `resourceRequirements` `GPU` type and `NeuronDevice` allocation are container-instance (EC2) concepts only. GPU is supported on:
+
+- **ECS-on-EC2** — you own the Auto Scaling group and the GPU-optimized AMI; full control (custom AMI/kernel, EFA, multi-node). The default for training and demanding inference.
+- **ECS Managed Instances** — AWS provisions/patches the EC2 lifecycle for you; supports GPU (e.g. `g4dn`, `g5`, `p3`, `p4d`) with pre-installed NVIDIA drivers + CUDA, and the managed Neuron device-allocation path ([Use GPUs with ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)). GA Sept 2025, all commercial Regions Oct 2025.
+- **ECS Anywhere / External** — on-prem/hybrid GPU hosts registered with `--enable-gpu`.
+
+Also note: **GPUs are not supported on Windows containers on ECS** ([ECS GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)). Details: [compute-hardware.md](references/compute-hardware).
+
+### D2 — Accelerator: NVIDIA GPU vs AWS Neuron
+
+- **NVIDIA GPU** (g4dn/g5/g6/g6e inference; p3/p4d/p5 training) — broadest ecosystem, CUDA, fastest time-to-first-success, multi-modal/novel architectures. The ECS GPU-optimized AMI ships NVIDIA kernel drivers + the NVIDIA Docker runtime pre-installed.
+- **AWS Neuron** (Inf2 inference; Trn1/Trn2 training; Inf1 legacy, EC2 launch type only) — cost-optimized for supported Transformer-family models on the ECS Neuron-optimized AL2023 AMI, at the price of a compilation ramp. Details: [compute-hardware.md](references/compute-hardware), [neuron-on-ecs.md](references/neuron-on-ecs).
+
+Do not synthesize per-chip specs — cite the ECS GPU/Neuron doc tables. Right accelerator = f(model family × latency × cost posture × team skill × timeline).
+
+### D3 — Capacity: the separate-ASG-per-GPU-type pattern (the ECS-specific crux)
+
+This is where ECS diverges hardest from EKS. **An ECS capacity-provider Auto Scaling group can't have instance weighting settings** ([ECS capacity providers for EC2](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)), and cluster auto scaling behaves predictably only when an ASG's instances are homogeneous. The consequence: **use one ASG (and one capacity provider) per GPU instance type**, and blend them with a **capacity-provider strategy** rather than stuffing mixed GPU types into a single mixed-instance ASG. There is no Karpenter equivalent on native ECS. Details: [capacity-and-scaling.md](references/capacity-and-scaling).
+
+For scarce accelerator capacity, use **EC2 Capacity Blocks for ML** (reserve P/Trn UltraCluster capacity for a future window); for cost, layer Spot only on interruption-tolerant work with checkpoint/resume. Managed Instances offers an AWS-managed alternative to hand-rolled ASGs.
+
+### D4 — Workload shape
+
+- **Single-container inference** — GPU task with `resourceRequirements` type `GPU`; model weights from S3/EFS. [inference-serving.md](references/inference-serving).
+- **Distributed multi-node training** — placement groups + EFA + NCCL; Ray Train / PyTorch on ECS. [distributed-training.md](references/distributed-training).
+- **GPU sharing for dev** — ECS pins whole GPUs by default; sharing is coarse (see the caveat below). [compute-hardware.md](references/compute-hardware).
+
+### D5 — Boundary check
+
+If the answer is "Kubernetes," "fully-managed training/hosting," or "no self-hosting at all," route out. [service-boundaries.md](references/service-boundaries).
+
+## GPU Sharing on ECS — State the Limit Precisely
+
+ECS, by default, **pins whole physical GPUs to containers** — the scheduler assigns the number of GPUs in `resourceRequirements` and sets `NVIDIA_VISIBLE_DEVICES` accordingly ([ECS GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)). Native ECS has **no MIG-partitioning or time-slicing-replica scheduler primitive** like the EKS NVIDIA device plugin. To share a GPU across ECS tasks you must **remove the GPU `resourceRequirements`** from the task definitions and make `nvidia` the **default Docker runtime** on the instance via user data, then set `NVIDIA_VISIBLE_DEVICES` per container — a manual, unisolated pattern suitable for dev/test only (no memory isolation between co-located containers). If the customer needs first-class fractional-GPU scheduling (MIG, time-slicing, DRA), that is an argument for **EKS (`eks-genai`)** or SageMaker. Details: [compute-hardware.md](references/compute-hardware).
+
+## Security Baseline (non-negotiable)
+
+Every GPU/ML-on-ECS recommendation MUST include: **task role + execution role least-privilege** (never static keys in the image/env); **secrets via Secrets Manager / SSM Parameter Store** injected into the task definition (never baked into the model image); **ECR image scanning** (DLC/CUDA/Neuron images carry huge CVE surfaces); **model-artifact provenance** (checksum/signing; pin exact model revisions); **private subnets + VPC endpoints** (S3 for weights, ECR, Secrets Manager, Bedrock-runtime if used) for GPU instances; **CloudTrail + Container Insights** audit; and **GuardDuty ECS Runtime Monitoring** on the EC2 hosts. Details: [security-and-compliance.md](references/security-and-compliance).
+
+## Cost Optimization
+
+Levers in priority order: (1) **Capacity Blocks for ML** for planned multi-day training (capacity assurance, not a fixed discount); (2) **Neuron over GPU** for supported Transformer models (compilation ramp, verify support first); (3) **Spot + checkpoint/resume** for fault-tolerant training only; (4) **right-size the GPU instance family** to the model (over-provisioning GPUs is a top cost mistake); (5) **cluster auto scaling / Managed Instances consolidation** for off-peak inference; (6) **share GPUs for dev** (dev/test only). Always give directional ranges with caveats — never point estimates. Details: [capacity-and-scaling.md](references/capacity-and-scaling).
+
+## Top Guardrails (the high-cost mistakes)
+
+- **Never design a GPU workload on Fargate** — it has no GPU; use ECS-on-EC2 / Managed Instances / Anywhere.
+- **Don't put mixed GPU instance types in one capacity-provider ASG** — one ASG per GPU type + capacity-provider strategy (no instance weighting allowed).
+- **Don't assume native ECS has MIG/time-slicing** — GPU sharing is coarse and dev/test only; fractional GPU → EKS/SageMaker.
+- **Don't compile Neuron models at task startup** — pre-compile offline, ship the artifact via S3/image.
+- **Don't run distributed multi-node training without EFA + placement groups** — bandwidth collapses to TCP.
+- **Don't use Spot for training without checkpoint/resume**, or for latency-SLA inference.
+- **Don't skip the security baseline** — task-role trust, secrets, private subnets, image scanning, provenance.
+- **Don't give point cost estimates** — directional ranges with caveats only.
+- **Don't synthesize accelerator specs** — cite the ECS GPU/Neuron doc tables.
+
+## How to Use the References
+
+Progressive disclosure — the essentials are above; load a reference only when the task needs that depth:
+
+| Reference | Load when the task is about… |
+|-----------|------------------------------|
+| [compute-hardware.md](references/compute-hardware) | GPU instance families, GPU-optimized AMI, NVIDIA runtime, GPU sharing limits, capacity planning |
+| [capacity-and-scaling.md](references/capacity-and-scaling) | Separate-ASG-per-GPU-type, capacity-provider strategy, cluster auto scaling, Managed Instances, Capacity Blocks, Spot |
+| [inference-serving.md](references/inference-serving) | Model inference containers on ECS, serving engines, model loading, autoscaling inference services |
+| [distributed-training.md](references/distributed-training) | Multi-node GPU/Neuron training, EFA + placement groups, NCCL, Ray Train on ECS, checkpointing |
+| [neuron-on-ecs.md](references/neuron-on-ecs) | Inferentia/Trainium on ECS, Neuron device allocation (managed vs manual), compilation, Inf/Trn selection |
+| [storage.md](references/storage) | Model artifact handling, S3, EFS, FSx for Lustre, checkpoints, container image size |
+| [observability.md](references/observability) | Container Insights enhanced (DCGM), GPU/EFA/Neuron metrics, CloudWatch, alerting |
+| [security-and-compliance.md](references/security-and-compliance) | Task/execution-role trust, secrets, private subnets, ECR scanning, provenance, GuardDuty, compliance |
+| [service-boundaries.md](references/service-boundaries) | Fargate-GPU exclusion evidence; when to use eks-genai / SageMaker / Bedrock / ecs-architect instead |
+| [use-cases.md](references/use-cases) | Worked end-to-end scenarios (inference, distributed training, Neuron migration, GPU dev-sharing) with build paths |
+
+## Sources
+
+- [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html) · [ECS task definitions for AWS Neuron ML workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html) · [Use GPUs with ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)
+- [ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html) · [ECS capacity providers for EC2 workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html) · [Automatically manage ECS capacity with cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-auto-scaling.html)
+- [EC2 Capacity Blocks for ML](https://aws.amazon.com/ec2/capacityblocks/) · [Capacity Blocks for ML (EC2 User Guide)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html) · [Amazon ECS Managed Instances](https://aws.amazon.com/ecs/managed-instances/)
+- [Amazon ECS Best Practices Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-best-practices.html) · [Monitoring ECS Managed Instances (GPU / DCGM)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/monitoring-managed-instances.html)
+- [Distributed machine learning with Amazon ECS](https://aws.amazon.com/blogs/containers/distributed-machine-learning-with-amazon-ecs/) · [Using Amazon ECS with NVIDIA GPUs to accelerate drug discovery](https://aws.amazon.com/blogs/containers/using-amazon-ecs-with-nvidia-gpus-to-accelerate-drug-discovery/) · [Running GPU-based container applications with ECS Anywhere](https://aws.amazon.com/blogs/containers/running-gpu-based-container-applications-with-amazon-ecs-anywhere/)

--- a/misc/website/docs/skills/ecs/ecs-genai/index.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/index.md
@@ -1,6 +1,6 @@
 ---
 title: "ecs-genai"
-description: "Use whenever someone is running a GPU / ML / GenAI / LLM workload on Amazon ECS — phrased as \"GPU on ECS\", \"ECS GPU-optimized AMI\", \"g4dn/g5/g6/p4/p5 on ECS\", \"which ECS launch type for GPU\", \"Inferentia/Trainium/Neuron on ECS\", \"distributed training on ECS\", \"model inference container on ECS\", \"Capacity Blocks for ECS\", \"GPU sharing on ECS\", or \"separate ASG per GPU type\". Covers GPU compute on ECS-on-EC2 (GPU-optimized AMIs, NVIDIA container runtime, instance families), the separate-ASG-per-GPU-type capacity-provider pattern (ECS capacity providers cannot use mixed-instance ASGs), EC2 Capacity Blocks for ML, container inference/serving, Neuron on ECS, distributed ML, GPU observability, and a security baseline. First-class constraint: AWS Fargate has NO GPU support — GPU is ECS-on-EC2 (or ECS Managed Instances / ECS Anywhere) only. Trigger even if \"GenAI\" is never said — any GPU, accelerator, inference-serving, or ML-training decision on ECS qualifies. Use eks-genai for Kubernetes/EKS; SageMaker for fully-managed ML training/hosting; Bedrock for managed foundation models with no self-hosting. For generic ECS launch-type/design with no accelerator or ML workload use ecs-architect."
+description: "Use whenever someone runs a GPU / ML / GenAI / LLM workload on Amazon ECS — GPU on ECS, ECS GPU-optimized AMI, g4dn/g5/g6/p4/p5 on ECS, which ECS launch type for GPU, Inferentia/Trainium/Neuron on ECS, distributed training on ECS, model inference on ECS, Capacity Blocks for ECS, GPU sharing, or ASG per GPU type. Covers GPU compute on ECS-on-EC2 and ECS Managed Instances (GPU-optimized AMIs, NVIDIA runtime, instance families); the capacity pattern where mixed-instance ASGs are supported but constrained (no weighting; managed scaling protects on the smallest type, so one homogeneous ASG per GPU type is best practice); Capacity Blocks; inference/serving; Neuron; distributed ML; GPU observability; a GPU/ML security slice. AWS Fargate has NO GPU — use ECS-on-EC2, Managed Instances, or ECS Anywhere. Trigger even if GenAI is unsaid. Use eks-genai for Kubernetes/EKS; SageMaker for fully-managed ML; Bedrock for managed foundation models; ecs-architect for non-accelerator ECS design; ecs-security for deep compliance."
 custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/SKILL.md
 format: md
 ---
@@ -10,9 +10,11 @@ This page is generated from [skills/ecs-genai/SKILL.md](https://github.com/aws-s
 :::
 
 
+<!-- Note: ecs-genai intentionally ships no `apex:ecs-genai` steering command (eks-genai has one). This is an omission, not by design — steering-command wiring is deferred repo-wide, so it is left unwired for now to match the rest of the ECS skills. Freshness: instance/spec claims verified against live AWS docs 2026-07-09. -->
+
 # GenAI / GPU / ML Workloads on Amazon ECS
 
-End-to-end opinionated guidance for running GPU-accelerated, ML-training, and GenAI inference workloads on **Amazon ECS-on-EC2**. This skill is scoped to the compute-and-capacity mechanics that are unique to ECS: the GPU-optimized AMI + NVIDIA container runtime, the **separate-ASG-per-GPU-type capacity-provider pattern** (ECS capacity providers cannot use mixed-instance-type Auto Scaling groups), EC2 Capacity Blocks for ML, AWS Neuron (Inferentia/Trainium) on ECS, container inference/serving, distributed ML, and accelerator observability.
+End-to-end opinionated guidance for running GPU-accelerated, ML-training, and GenAI inference workloads on **Amazon ECS-on-EC2**. This skill is scoped to the compute-and-capacity mechanics that are unique to ECS: the GPU-optimized AMI + NVIDIA container runtime, the **one-homogeneous-ASG-per-GPU-type capacity-provider pattern** — cluster auto scaling *supports* multiple instance types in one ASG, but managed scaling has no instance weighting and bin-packs and protects on the **smallest** instance type, so mixing GPU types (with different GPU counts / VRAM) breaks the scaling math; one homogeneous ASG per GPU type is therefore the best practice, not a hard limit — plus EC2 Capacity Blocks for ML, AWS Neuron (Inferentia/Trainium) on ECS, container inference/serving, distributed ML, and accelerator observability.
 
 **The single most important constraint, stated first: AWS Fargate has no GPU support.** GPUs and AWS accelerators (Inferentia/Trainium) are available only on **ECS-on-EC2**, **ECS Managed Instances**, and **ECS Anywhere/External** — never on Fargate. Every GPU/ML answer on ECS begins by ruling Fargate out for the accelerated container. See [service-boundaries.md](references/service-boundaries) for the exact evidence and the "use EKS / SageMaker / Bedrock instead" routing.
 
@@ -25,7 +27,7 @@ For "which ECS launch model should I use" with no accelerator or ML workload, us
 - Serve an LLM / model inference container on ECS, or run ML training/fine-tuning on ECS
 - Design GPU capacity on ECS at scale — the separate-ASG-per-GPU-type + capacity-provider-strategy pattern, Managed Instances, Spot, and Capacity Blocks for ML
 - Use AWS Neuron (Inferentia/Trainium) on ECS — device allocation, compilation, Inf/Trn instance selection
-- Wire GPU/accelerator observability (Container Insights enhanced / DCGM) on ECS
+- Wire GPU/accelerator observability on ECS — agentless DCGM metrics via Container Insights enhanced observability are **Managed-Instances-only**; the EC2 launch type needs the CloudWatch agent (`nvidia_smi`, host-level) or a DCGM exporter for per-task metrics
 - Decide **when NOT to use ECS** — when EKS (`eks-genai`), SageMaker, or Bedrock is the better home
 
 **Don't use this skill for:**
@@ -34,6 +36,7 @@ For "which ECS launch model should I use" with no accelerator or ML workload, us
 - **Managed foundation-model API with no self-hosting** (no GPU to manage) → **Amazon Bedrock**
 - **Generic ECS launch-type selection / cluster design** with no accelerator or ML workload → `ecs-architect`
 - **Deep Neuron kernel / NKI / model-porting** work → the Neuron-specific skills, not this one
+- **Deep ECS security / regulated-compliance baseline** (PCI/HIPAA/FedRAMP CDE design, org-wide guardrails, threat modeling) → `ecs-security`; this skill carries only the GPU/ML-specific security slice
 - Any assumption that **Fargate can run a GPU** — it cannot; do not design around it
 
 ## The ECS-GPU Decision Framework
@@ -53,7 +56,7 @@ D5  Boundary check    stay on ECS · or route to eks-genai / SageMaker / Bedrock
 **AWS Fargate cannot run GPU or AWS-accelerator workloads.** AWS lists the `gpu` parameter among the task-definition parameters that are **"not valid in Fargate tasks"** (alongside `devices` and `placementConstraints`), and the Fargate task-size model exposes only CPU and memory — valid task sizes run from 256 (.25 vCPU) up to 32768 (32 vCPU), with no GPU dimension at all ([ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)). The `resourceRequirements` `GPU` type and `NeuronDevice` allocation are container-instance (EC2) concepts only. GPU is supported on:
 
 - **ECS-on-EC2** — you own the Auto Scaling group and the GPU-optimized AMI; full control (custom AMI/kernel, EFA, multi-node). The default for training and demanding inference.
-- **ECS Managed Instances** — AWS provisions/patches the EC2 lifecycle for you; supports GPU (e.g. `g4dn`, `g5`, `p3`, `p4d`) with pre-installed NVIDIA drivers + CUDA, and the managed Neuron device-allocation path ([Use GPUs with ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)). GA Sept 2025, all commercial Regions Oct 2025.
+- **ECS Managed Instances** — AWS provisions/patches (~every 14 days) the EC2 lifecycle for you; supports GPU (e.g. `g4dn`, `g5`, `p3`, `p4d`) with pre-installed NVIDIA drivers + CUDA ([Use GPUs with ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)), and the managed `NeuronDevice` allocation path ([ECS task definitions for AWS Neuron ML workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html)). GA Sept 2025, all commercial Regions Oct 2025.
 - **ECS Anywhere / External** — on-prem/hybrid GPU hosts registered with `--enable-gpu`.
 
 Also note: **GPUs are not supported on Windows containers on ECS** ([ECS GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)). Details: [compute-hardware.md](references/compute-hardware).
@@ -65,11 +68,11 @@ Also note: **GPUs are not supported on Windows containers on ECS** ([ECS GPU wor
 
 Do not synthesize per-chip specs — cite the ECS GPU/Neuron doc tables. Right accelerator = f(model family × latency × cost posture × team skill × timeline).
 
-### D3 — Capacity: the separate-ASG-per-GPU-type pattern (the ECS-specific crux)
+### D3 — Capacity: one homogeneous ASG per GPU type (the ECS-specific crux)
 
-This is where ECS diverges hardest from EKS. **An ECS capacity-provider Auto Scaling group can't have instance weighting settings** ([ECS capacity providers for EC2](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)), and cluster auto scaling behaves predictably only when an ASG's instances are homogeneous. The consequence: **use one ASG (and one capacity provider) per GPU instance type**, and blend them with a **capacity-provider strategy** rather than stuffing mixed GPU types into a single mixed-instance ASG. There is no Karpenter equivalent on native ECS. Details: [capacity-and-scaling.md](references/capacity-and-scaling).
+This is where ECS diverges hardest from EKS. ECS cluster auto scaling **does support an Auto Scaling group with multiple instance types**, but the constraints make heterogeneous *GPU* ASGs a trap: **an ECS capacity-provider ASG can't have instance weighting settings** ([ECS capacity providers for EC2](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)), and managed scaling **bin-packs and protects on the smallest instance type in the ASG** — if a group of tasks needs more than the smallest type provides, that group can't run and the tasks stay `PROVISIONING` ([Amazon ECS managed scaling behavior](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-scaling-behavior.html)). Because `resourceRequirements` `GPU` counts GPUs but not VRAM, mixing GPU types (e.g. g5 24 GiB + p4d 40 GiB) also lets ECS place a large-VRAM task onto a small-VRAM instance and OOM at load. The best practice therefore: **use one homogeneous ASG (and one capacity provider) per GPU instance type**, and blend them with a **capacity-provider strategy**. There is no Karpenter equivalent on native ECS. Details: [capacity-and-scaling.md](references/capacity-and-scaling).
 
-For scarce accelerator capacity, use **EC2 Capacity Blocks for ML** (reserve P/Trn UltraCluster capacity for a future window); for cost, layer Spot only on interruption-tolerant work with checkpoint/resume. Managed Instances offers an AWS-managed alternative to hand-rolled ASGs.
+For scarce accelerator capacity, use **EC2 Capacity Blocks for ML** (reserve P/Trn UltraCluster capacity for a future window) — a Capacity Block is delivered in a **single Availability Zone**, so restrict the ASG to that AZ's subnet (and co-locate FSx in the same AZ). For assured non-block inference capacity use **On-Demand Capacity Reservations (ODCRs)** or, on Managed Instances, `capacityOptionType: Reserved` with a Capacity Reservation group. For cost, layer Spot only on interruption-tolerant work with checkpoint/resume. Managed Instances offers an AWS-managed alternative to hand-rolled ASGs.
 
 ### D4 — Workload shape
 
@@ -87,7 +90,7 @@ ECS, by default, **pins whole physical GPUs to containers** — the scheduler as
 
 ## Security Baseline (non-negotiable)
 
-Every GPU/ML-on-ECS recommendation MUST include: **task role + execution role least-privilege** (never static keys in the image/env); **secrets via Secrets Manager / SSM Parameter Store** injected into the task definition (never baked into the model image); **ECR image scanning** (DLC/CUDA/Neuron images carry huge CVE surfaces); **model-artifact provenance** (checksum/signing; pin exact model revisions); **private subnets + VPC endpoints** (S3 for weights, ECR, Secrets Manager, Bedrock-runtime if used) for GPU instances; **CloudTrail + Container Insights** audit; and **GuardDuty ECS Runtime Monitoring** on the EC2 hosts. Details: [security-and-compliance.md](references/security-and-compliance).
+Every GPU/ML-on-ECS recommendation MUST include: **task role + execution role least-privilege** (never static keys in the image/env); **secrets via Secrets Manager / SSM Parameter Store** injected into the task definition (never baked into the model image); **ECR image scanning** (DLC/CUDA/Neuron images carry huge CVE surfaces); **model-artifact provenance** (checksum/signing; pin exact model revisions); **private subnets + VPC endpoints** (S3 for weights, ECR, Secrets Manager, Bedrock-runtime if used) for GPU instances; **inference-endpoint authentication** (internal vs internet-facing ALB/NLB + auth in front of the model API — see [security-and-compliance.md](references/security-and-compliance)); and **CloudTrail + Container Insights** audit. Add **GuardDuty ECS Runtime Monitoring** on **ECS-on-EC2** hosts — but note it is **not supported on ECS Managed Instances, ECS Anywhere, or Windows** ([GuardDuty Runtime Monitoring considerations](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-guard-duty-integration.html)), so an MI-based fleet needs a different runtime-threat control. For the deep, general ECS security baseline and regulated-compliance design, route to **`ecs-security`**; this skill carries only the GPU/ML-specific slice. Details: [security-and-compliance.md](references/security-and-compliance).
 
 ## Cost Optimization
 
@@ -96,8 +99,8 @@ Levers in priority order: (1) **Capacity Blocks for ML** for planned multi-day t
 ## Top Guardrails (the high-cost mistakes)
 
 - **Never design a GPU workload on Fargate** — it has no GPU; use ECS-on-EC2 / Managed Instances / Anywhere.
-- **Don't put mixed GPU instance types in one capacity-provider ASG** — one ASG per GPU type + capacity-provider strategy (no instance weighting allowed).
-- **Don't assume native ECS has MIG/time-slicing** — GPU sharing is coarse and dev/test only; fractional GPU → EKS/SageMaker.
+- **Don't mix GPU instance types in one capacity-provider ASG** — it's *allowed* but managed scaling protects on the smallest type and can't weight, so use one homogeneous ASG per GPU type + a capacity-provider strategy.
+- **Don't assume native ECS has a MIG/time-slicing scheduler** — there is no fractional-GPU *scheduler* primitive; hardware-fractional L4 instances (G6f/Gr6f) exist on Managed Instances, but dynamic multi-model GPU packing (MIG/time-slicing/DRA) → EKS/SageMaker.
 - **Don't compile Neuron models at task startup** — pre-compile offline, ship the artifact via S3/image.
 - **Don't run distributed multi-node training without EFA + placement groups** — bandwidth collapses to TCP.
 - **Don't use Spot for training without checkpoint/resume**, or for latency-SLA inference.
@@ -117,7 +120,7 @@ Progressive disclosure — the essentials are above; load a reference only when 
 | [distributed-training.md](references/distributed-training) | Multi-node GPU/Neuron training, EFA + placement groups, NCCL, Ray Train on ECS, checkpointing |
 | [neuron-on-ecs.md](references/neuron-on-ecs) | Inferentia/Trainium on ECS, Neuron device allocation (managed vs manual), compilation, Inf/Trn selection |
 | [storage.md](references/storage) | Model artifact handling, S3, EFS, FSx for Lustre, checkpoints, container image size |
-| [observability.md](references/observability) | Container Insights enhanced (DCGM), GPU/EFA/Neuron metrics, CloudWatch, alerting |
+| [observability.md](references/observability) | GPU metrics (Container Insights enhanced = MI-only; CloudWatch agent / DCGM exporter on EC2), Neuron metrics, CloudWatch, alerting |
 | [security-and-compliance.md](references/security-and-compliance) | Task/execution-role trust, secrets, private subnets, ECR scanning, provenance, GuardDuty, compliance |
 | [service-boundaries.md](references/service-boundaries) | Fargate-GPU exclusion evidence; when to use eks-genai / SageMaker / Bedrock / ecs-architect instead |
 | [use-cases.md](references/use-cases) | Worked end-to-end scenarios (inference, distributed training, Neuron migration, GPU dev-sharing) with build paths |

--- a/misc/website/docs/skills/ecs/ecs-genai/references/capacity-and-scaling.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/capacity-and-scaling.md
@@ -1,0 +1,109 @@
+---
+title: "Capacity & Scaling — GPU at Scale on Amazon ECS"
+description: ""
+custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/capacity-and-scaling.md
+format: md
+---
+
+:::info[Source]
+This page is generated from [skills/ecs-genai/references/capacity-and-scaling.md](https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/capacity-and-scaling.md). Edit the source, not this page.
+:::
+
+# Capacity & Scaling — GPU at Scale on Amazon ECS
+
+The mechanics that make ECS-GPU capacity different from EKS. There is **no Karpenter on native ECS** — capacity is Auto Scaling groups + ECS capacity providers, with a hard structural constraint that dictates the whole pattern.
+
+## The Separate-ASG-Per-GPU-Type Pattern (the crux)
+
+**An ECS capacity-provider Auto Scaling group can't have instance weighting settings** ([ECS capacity providers for EC2 workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)). ECS cluster auto scaling drives the ASG via a single `CapacityProviderReservation` target-tracking metric that assumes the instances in that ASG are effectively **homogeneous** — the formula is `(instances needed) / (running instances) × 100` ([Automatically manage ECS capacity with cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-auto-scaling.html)). Mixing heterogeneous GPU types (e.g. g5 + p4d) in one ASG breaks the scaling math and makes task placement non-deterministic.
+
+There is a second, sharper failure mode: **ECS task placement has no native "GPU model / VRAM" attribute** — a `resourceRequirements` `GPU: 1` only counts GPUs, not their memory. If a g4dn (16 GiB, T4) and a g5 (24 GiB, A10G) share one ASG, ECS can place a task needing 24 GiB onto the 16 GiB T4, and the model OOMs at load time. Homogeneous per-type ASGs (pin `allowedInstanceTypes` in the launch template) are what keep placement correct; use a placement constraint on `ecs.instance-type` to steer within a mixed cluster.
+
+**Therefore, the pattern for GPU at scale on native ECS:**
+
+1. **One Auto Scaling group per GPU instance type** (one for g5, one for g6e, one for p4d, …), each homogeneous.
+2. **One ECS capacity provider per ASG**, with **managed scaling** and **managed termination protection** on.
+3. **Blend them with a capacity-provider strategy** on the service — `base`/`weight` to prefer one pool and spill to another, rather than one mixed ASG.
+
+```json
+// Service capacity-provider strategy: prefer g6e for inference, spill to g5
+{
+  "capacityProviderStrategy": [
+    { "capacityProvider": "cp-g6e", "base": 1, "weight": 3 },
+    { "capacityProvider": "cp-g5",  "base": 0, "weight": 1 }
+  ]
+}
+```
+
+Constraints to respect (from the capacity-providers doc):
+- A capacity-provider strategy can specify **at most 20 capacity providers**.
+- At least one capacity provider must have **weight > 0**; only one may set a **base**.
+- A strategy can contain **either** ASG capacity providers **or** Fargate capacity providers — **not both**. (And Fargate can't run GPU anyway.)
+- You **can't switch** a service between an ASG capacity provider and a Fargate capacity provider without recreating/redeploying; moving a service from `launchType` to a capacity-provider strategy requires a **forced new deployment**.
+- Create the empty ASG with **desired = 0**; ECS scales it out via managed scaling.
+
+### Karpenter equivalent? No.
+
+There is no Karpenter for native ECS. The closest "AWS picks the instance" experience is **ECS Managed Instances** (below), or, if the customer truly wants Karpenter-style provisioning, that is an argument for **EKS (`eks-genai`)**.
+
+## ECS Managed Instances — the AWS-managed alternative
+
+Instead of hand-rolling one ASG per GPU type, **ECS Managed Instances** lets AWS provision, configure, patch (every 14 days), scale, and place tasks on optimal EC2 instances, while you declare requirements ([Amazon ECS Managed Instances](https://aws.amazon.com/ecs/managed-instances/)). You still select GPU/accelerator families through the capacity provider's **`instanceRequirements`** launch template (see [compute-hardware.md](compute-hardware) and [neuron-on-ecs.md](neuron-on-ecs)). Trade-offs:
+
+- **Pro:** No ASG plumbing, no AMI/driver management, faster to stand up, per-type homogeneity handled by AWS.
+- **Con:** A management charge on top of EC2 cost; less control than self-managed EC2 (no custom kernel/AMI). For custom AMI/kernel or the most demanding multi-node EFA training, self-managed ECS-on-EC2 remains the choice.
+- GA Sept 2025; available in all commercial Regions since Oct 2025.
+
+## EC2 Capacity Blocks for ML — securing scarce GPU capacity
+
+GPU capacity is scarce. **EC2 Capacity Blocks for ML** let you reserve accelerated instances for a future window, colocated in EC2 UltraClusters with EFA ([EC2 Capacity Blocks for ML](https://aws.amazon.com/ec2/capacityblocks/)). Verified current facts:
+
+- **Supported instance types** (per the Capacity Blocks page): P6e-GB200, P6-B300, P6-B200, P5en, P5e, P5, and P4d (NVIDIA Blackwell / H200 / H100 / A100), plus **Trn2 and Trn1** (AWS Trainium).
+- **Reservation duration** is 1–14 days, or a multiple of 7 days up to **182 days** (e.g. 21, 28 days); reservable with a start time **up to 8 weeks in advance**. Each Capacity Block can have **up to 64 instances**, and **up to 256 instances across Capacity Blocks** ([How Capacity Blocks work](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-blocks-how.html)). Instance Capacity Blocks are shareable across accounts (UltraServer Capacity Blocks are not).
+- **Pricing = reservation fee + OS fee.** AWS publishes **no fixed discount vs on-demand** — the value is **guaranteed capacity assurance**, not a headline discount. Do not claim a percentage saving.
+- Best for: planned pre-training/fine-tuning runs, benchmark campaigns, guaranteed-capacity demos. Not for elastic inference (Capacity Blocks don't autoscale).
+
+Use with ECS by launching the reserved instances into a **self-managed GPU ASG capacity provider** for the reservation window: create the ASG's launch template to target the Capacity Block reservation, and — because managed scaling doesn't know the block's expiration — **schedule scale-up at the block start** (Auto Scaling scheduled scaling handles retries) and **drain/checkpoint before it ends** (the block begins terminating instances 30 minutes before end time; an EventBridge event fires 10 minutes before that). The reserved-capacity ASG path is the documented integration; wiring Capacity Blocks directly into an ECS Managed Instances capacity provider is not a documented pattern — fall back to the self-managed ASG for reserved-capacity use cases. Reference: [Capacity Blocks for ML (EC2 User Guide)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html), [How Capacity Blocks work](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-blocks-how.html).
+
+## Spot vs On-Demand for GPU on ECS
+
+| Workload | Capacity type | Condition |
+|---|---|---|
+| **Training** | Spot | ✅ Only with checkpoint/resume wired (see [distributed-training.md](distributed-training)) |
+| **Training** | On-Demand / Capacity Blocks | When the job can't tolerate interruption |
+| **Inference (production, SLA-bound)** | On-Demand | Always — Spot interruptions break per-request SLAs |
+| **Dev / experimentation** | Spot | ✅ Tolerable interruption profile |
+
+**Spot without checkpoint/resume is a guaranteed cost-burn** — every interruption restarts training. Use **managed instance draining** (on by default) for graceful task rebalancing when instances terminate ([ECS capacity providers for EC2](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)). Note: separate **Spot and On-Demand into different ASGs/capacity providers** (a single ASG mixing purchase options with per-type homogeneity is fine via a MixedInstancesPolicy for *sizes*, but keep GPU *types* separated per the crux above).
+
+## Cluster Auto Scaling Behavior & Latency
+
+ECS cluster auto scaling is a **CloudWatch-driven, latent** process ([Optimize ECS cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/capacity-cluster-speed-up-ec2.html)):
+
+- Scale-out/in reacts to the `CapacityProviderReservation` metric breaching alarms; there is inherent lag from metric publish + alarm evaluation + EC2 warm-up.
+- **Scale-in requires ~15 minutes of data points** before reducing capacity, then steps down gradually ([Faster Scaling-in for ECS Cluster Auto Scaling](https://aws.amazon.com/blogs/containers/faster-scaling-in-for-amazon-ecs-cluster-auto-scaling/)). This matters for expensive GPU nodes — idle GPU minutes are costly.
+- Speed levers: use **warm pools** of pre-initialized GPU instances (supported by ECS ASG capacity providers) to cut GPU-instance warm-up time; keep GPU AMIs lean; pre-cache large model images (see [storage.md](storage)).
+
+## Cost Levers (priority order)
+
+| Priority | Lever | Directional value | Caveat |
+|---|---|---|---|
+| 1 | **Capacity Blocks for ML** | Capacity *assurance* (not a fixed discount) | Reservation + OS fee; no autoscale; advance reservation |
+| 2 | **Neuron over GPU** | Cost-optimized for supported Transformer models | Compilation ramp; verify model support ([neuron-on-ecs.md](neuron-on-ecs)) |
+| 3 | **Spot + checkpoint/resume** | Large savings for fault-tolerant training | Requires checkpoint logic; not for SLA inference |
+| 4 | **Right-size GPU instance family** | Avoids paying for idle GPU memory/compute | Match model size to instance; measure first |
+| 5 | **Cluster auto scaling / Managed Instances consolidation** | Reclaims idle GPU nodes off-peak | Scale-in latency (~15 min); warm pools mitigate cold-start |
+| 6 | **GPU sharing (dev only)** | Density for dev/test | No isolation — dev/test only ([compute-hardware.md](compute-hardware)) |
+
+Always give **directional ranges with caveats** — never point estimates. Actual savings depend on model size, traffic pattern, batch size, sequence length, and configuration.
+
+## Sources
+
+- [Amazon ECS capacity providers for EC2 workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)
+- [Automatically manage Amazon ECS capacity with cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-auto-scaling.html)
+- [Optimize Amazon ECS cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/capacity-cluster-speed-up-ec2.html)
+- [Deep Dive on Amazon ECS Cluster Auto Scaling](https://aws.amazon.com/blogs/containers/deep-dive-on-amazon-ecs-cluster-auto-scaling/)
+- [Faster Scaling-in for Amazon ECS Cluster Auto Scaling](https://aws.amazon.com/blogs/containers/faster-scaling-in-for-amazon-ecs-cluster-auto-scaling/)
+- [Optimize cost for container workloads with ECS capacity providers and EC2 Spot Instances](https://aws.amazon.com/blogs/containers/optimize-cost-for-container-workloads-with-ecs-capacity-providers-and-ec2-spot-instances/)
+- [EC2 Capacity Blocks for ML](https://aws.amazon.com/ec2/capacityblocks/) · [Capacity Blocks for ML (EC2 User Guide)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html)
+- [Amazon ECS Managed Instances](https://aws.amazon.com/ecs/managed-instances/) · [Managed Instances now in all commercial Regions](https://aws.amazon.com/about-aws/whats-new/2025/10/amazon-ecs-managed-instances-commercial-regions/)

--- a/misc/website/docs/skills/ecs/ecs-genai/references/capacity-and-scaling.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/capacity-and-scaling.md
@@ -11,13 +11,17 @@ This page is generated from [skills/ecs-genai/references/capacity-and-scaling.md
 
 # Capacity & Scaling — GPU at Scale on Amazon ECS
 
-The mechanics that make ECS-GPU capacity different from EKS. There is **no Karpenter on native ECS** — capacity is Auto Scaling groups + ECS capacity providers, with a hard structural constraint that dictates the whole pattern.
+The mechanics that make ECS-GPU capacity different from EKS. There is **no Karpenter on native ECS** — capacity is Auto Scaling groups + ECS capacity providers, with a scaling behavior that dictates the whole GPU pattern. (Freshness: Capacity Blocks instance list + Managed Instances facts verified against live AWS docs **2026-07-09** — this is a fast-moving list; re-verify against the cited pages.)
 
-## The Separate-ASG-Per-GPU-Type Pattern (the crux)
+> **Scope note:** This file covers the GPU-specific capacity story. For the generic capacity-provider mechanics — the `CapacityProviderReservation` formula, strategy-shape constraints, managed instance draining — route to **`ecs-architect`** / [ECS capacity providers for EC2 workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html). What follows is only what changes because the instances carry GPUs.
 
-**An ECS capacity-provider Auto Scaling group can't have instance weighting settings** ([ECS capacity providers for EC2 workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)). ECS cluster auto scaling drives the ASG via a single `CapacityProviderReservation` target-tracking metric that assumes the instances in that ASG are effectively **homogeneous** — the formula is `(instances needed) / (running instances) × 100` ([Automatically manage ECS capacity with cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-auto-scaling.html)). Mixing heterogeneous GPU types (e.g. g5 + p4d) in one ASG breaks the scaling math and makes task placement non-deterministic.
+## One Homogeneous ASG Per GPU Type (the crux)
 
-There is a second, sharper failure mode: **ECS task placement has no native "GPU model / VRAM" attribute** — a `resourceRequirements` `GPU: 1` only counts GPUs, not their memory. If a g4dn (16 GiB, T4) and a g5 (24 GiB, A10G) share one ASG, ECS can place a task needing 24 GiB onto the 16 GiB T4, and the model OOMs at load time. Homogeneous per-type ASGs (pin `allowedInstanceTypes` in the launch template) are what keep placement correct; use a placement constraint on `ecs.instance-type` to steer within a mixed cluster.
+Cluster auto scaling **does support an Auto Scaling group with multiple instance types** ([ECS managed scaling behavior](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-scaling-behavior.html) explicitly lists this) — so this is **best practice, not a hard limit**. The reasons a heterogeneous *GPU* ASG is nonetheless a trap:
+
+1. **No instance weighting.** An ECS capacity-provider ASG **can't have instance weighting settings** ([ECS capacity providers for EC2 workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)), so the scaling math can't account for one GPU type being worth more than another.
+2. **Managed scaling bin-packs and protects on the *smallest* instance type.** When an ASG has multiple instance types, ECS sorts them by vCPU/memory/ENI/port/GPU parameters and uses the **smallest** type's values as *protection*: "If a group of tasks have resource requirements that are greater than the smallest instance type in the Auto Scaling group, then that group of tasks can't run with this capacity provider… The tasks remain in the `PROVISIONING` state." AWS's own recommendation is to "create separate Auto Scaling groups and capacity providers for different minimum resource requirements" ([ECS managed scaling behavior](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-scaling-behavior.html)).
+3. **No native "GPU model / VRAM" placement attribute.** A `resourceRequirements` `GPU: 1` only counts GPUs, not their memory. If a g4dn (16 GiB, T4) and a g5 (24 GiB, A10G) share one ASG, ECS can place a task needing 24 GiB onto the 16 GiB T4 and the model OOMs at load time. Homogeneous per-type ASGs (pin `allowedInstanceTypes` in the launch template) keep placement correct; use a placement constraint on `ecs.instance-type` to steer within a mixed cluster.
 
 **Therefore, the pattern for GPU at scale on native ECS:**
 
@@ -35,12 +39,9 @@ There is a second, sharper failure mode: **ECS task placement has no native "GPU
 }
 ```
 
-Constraints to respect (from the capacity-providers doc):
-- A capacity-provider strategy can specify **at most 20 capacity providers**.
-- At least one capacity provider must have **weight > 0**; only one may set a **base**.
-- A strategy can contain **either** ASG capacity providers **or** Fargate capacity providers — **not both**. (And Fargate can't run GPU anyway.)
-- You **can't switch** a service between an ASG capacity provider and a Fargate capacity provider without recreating/redeploying; moving a service from `launchType` to a capacity-provider strategy requires a **forced new deployment**.
-- Create the empty ASG with **desired = 0**; ECS scales it out via managed scaling.
+GPU-relevant reminders (the full strategy-shape rules — the ≤20-provider limit, base/weight semantics, ASG-vs-Fargate exclusivity, launchType migration — are generic capacity-provider mechanics; see `ecs-architect` / the capacity-providers doc):
+- Create the empty GPU ASG with **desired = 0**; ECS scales it out via managed scaling.
+- A strategy can't mix ASG and Fargate capacity providers — moot here, since Fargate can't run GPU anyway.
 
 ### Karpenter equivalent? No.
 
@@ -51,30 +52,42 @@ There is no Karpenter for native ECS. The closest "AWS picks the instance" exper
 Instead of hand-rolling one ASG per GPU type, **ECS Managed Instances** lets AWS provision, configure, patch (every 14 days), scale, and place tasks on optimal EC2 instances, while you declare requirements ([Amazon ECS Managed Instances](https://aws.amazon.com/ecs/managed-instances/)). You still select GPU/accelerator families through the capacity provider's **`instanceRequirements`** launch template (see [compute-hardware.md](compute-hardware) and [neuron-on-ecs.md](neuron-on-ecs)). Trade-offs:
 
 - **Pro:** No ASG plumbing, no AMI/driver management, faster to stand up, per-type homogeneity handled by AWS.
-- **Con:** A management charge on top of EC2 cost; less control than self-managed EC2 (no custom kernel/AMI). For custom AMI/kernel or the most demanding multi-node EFA training, self-managed ECS-on-EC2 remains the choice.
+- **Con:** A **management charge** on top of the EC2 instance price, billed per-second with a one-minute minimum ([ECS Managed Instances pricing](https://aws.amazon.com/ecs/managed-instances/pricing/)); less control than self-managed EC2 (no custom kernel/AMI). For custom AMI/kernel or the most demanding multi-node EFA training, self-managed ECS-on-EC2 remains the choice.
+- **Instance lifetime caveat for training:** Managed Instances initiates **security patching every 14 days** by replacing instances (drain-and-replace); you can use EC2 event windows to schedule it into weekly maintenance windows ([ECS Managed Instances FAQs](https://aws.amazon.com/ecs/managed-instances/faqs/), [Patching in ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-patching.html)). That is fine for inference, but a **multi-week training run can be interrupted mid-flight** — so multi-week runs need robust checkpoint/resume (see [distributed-training.md](distributed-training)), or should run on a self-managed ASG / Capacity Block instead.
 - GA Sept 2025; available in all commercial Regions since Oct 2025.
 
 ## EC2 Capacity Blocks for ML — securing scarce GPU capacity
 
-GPU capacity is scarce. **EC2 Capacity Blocks for ML** let you reserve accelerated instances for a future window, colocated in EC2 UltraClusters with EFA ([EC2 Capacity Blocks for ML](https://aws.amazon.com/ec2/capacityblocks/)). Verified current facts:
+GPU capacity is scarce. **EC2 Capacity Blocks for ML** let you reserve accelerated instances for a future window, colocated in EC2 UltraClusters with EFA ([EC2 Capacity Blocks for ML](https://aws.amazon.com/ec2/capacityblocks/)). Current facts (**verified against live AWS docs 2026-07-09 — the supported-type list moves fast, e.g. it already includes P6e-GB200; always re-check the cited pages**):
 
-- **Supported instance types** (per the Capacity Blocks page): P6e-GB200, P6-B300, P6-B200, P5en, P5e, P5, and P4d (NVIDIA Blackwell / H200 / H100 / A100), plus **Trn2 and Trn1** (AWS Trainium).
-- **Reservation duration** is 1–14 days, or a multiple of 7 days up to **182 days** (e.g. 21, 28 days); reservable with a start time **up to 8 weeks in advance**. Each Capacity Block can have **up to 64 instances**, and **up to 256 instances across Capacity Blocks** ([How Capacity Blocks work](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-blocks-how.html)). Instance Capacity Blocks are shareable across accounts (UltraServer Capacity Blocks are not).
+- **Single Availability Zone.** A Capacity Block is delivered as a **`targeted` Capacity Reservation in one AZ** ([Use Capacity Blocks for ML workloads (EC2 Auto Scaling)](https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-template-capacity-blocks.html)). This is not stated as a passing detail: it means you must **pin the ASG to that AZ's subnet** and **co-locate FSx for Lustre in the same AZ** ([storage.md](storage)) — a cross-AZ block/FSx layout silently underperforms or won't place.
+- **Supported instance types** (per the Capacity Blocks page, 2026-07-09): P6e-GB200, P6-B300, P6-B200, P5en, P5e, P5, and P4d (NVIDIA Blackwell / H200 / H100 / A100), plus **Trn2 and Trn1** (AWS Trainium). Capacity Blocks cover **P- and Trn-family only** — there is no g6e Capacity Block, so for assured g6e/inference capacity use **ODCRs** or Managed Instances Capacity Reservations instead (below).
+- **Reservation duration** is 1–14 days, or a multiple of 7 days up to **182 days**; reservable with a start time **up to 8 weeks in advance**. Each Capacity Block can have **up to 64 instances**, and **up to 256 instances across Capacity Blocks** ([How Capacity Blocks work](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-blocks-how.html)). Instance Capacity Blocks are shareable across accounts (UltraServer Capacity Blocks are not).
+- **Cancellations aren't allowed, but a block CAN be extended.** An `active` or `scheduled` block can be extended (subject to available capacity) in 1-day increments up to 14 days and 7-day increments up to 182 days total, from 1 hour to 57 days before it expires, with no limit on the number of extensions — the reservation ID stays the same ([Extend Capacity Blocks](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-blocks-extend.html)). Plan the initial window, but know you can extend a run rather than re-reserving.
 - **Pricing = reservation fee + OS fee.** AWS publishes **no fixed discount vs on-demand** — the value is **guaranteed capacity assurance**, not a headline discount. Do not claim a percentage saving.
 - Best for: planned pre-training/fine-tuning runs, benchmark campaigns, guaranteed-capacity demos. Not for elastic inference (Capacity Blocks don't autoscale).
 
-Use with ECS by launching the reserved instances into a **self-managed GPU ASG capacity provider** for the reservation window: create the ASG's launch template to target the Capacity Block reservation, and — because managed scaling doesn't know the block's expiration — **schedule scale-up at the block start** (Auto Scaling scheduled scaling handles retries) and **drain/checkpoint before it ends** (the block begins terminating instances 30 minutes before end time; an EventBridge event fires 10 minutes before that). The reserved-capacity ASG path is the documented integration; wiring Capacity Blocks directly into an ECS Managed Instances capacity provider is not a documented pattern — fall back to the self-managed ASG for reserved-capacity use cases. Reference: [Capacity Blocks for ML (EC2 User Guide)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html), [How Capacity Blocks work](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-blocks-how.html).
+Use with ECS by launching the reserved instances into a **self-managed GPU ASG capacity provider** for the reservation window: create the ASG's launch template to target the Capacity Block reservation, **restrict the ASG to the block's AZ subnet**, and — because managed scaling doesn't know the block's expiration — **schedule scale-up at the block start** (Auto Scaling scheduled scaling handles retries) and **drain/checkpoint before it ends** (the block begins terminating instances 30 minutes before end time; an EventBridge event fires 10 minutes before that). The reserved-capacity ASG path is the documented integration; wiring Capacity Blocks directly into an ECS Managed Instances capacity provider is not a documented pattern — fall back to the self-managed ASG for reserved-capacity use cases. Reference: [Capacity Blocks for ML (EC2 User Guide)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html), [How Capacity Blocks work](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-blocks-how.html).
+
+### Assured capacity without a Capacity Block (P/Trn only cover part of the story)
+
+For inference families that Capacity Blocks don't cover (e.g. g6e), get capacity assurance with:
+- **On-Demand Capacity Reservations (ODCRs)** in a specific AZ, consumed by a self-managed ASG launch template — the general-purpose assured-capacity lever for g-family inference.
+- **Managed Instances Capacity Reservations:** set `capacityOptionType: Reserved` on the capacity provider and supply a **Capacity Reservation group** ([ECS Managed Instances instance types — billing and purchase options](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-instance-types.html)); you can also set a reservation preference (`reservations-only`, `reservations-first`, `reservations-excluded`).
+> **Reservation-vs-support mismatch to flag:** Capacity Blocks / ODCRs can reserve instance types (P6, P5en, …) that the **ECS-on-EC2 GPU support table stops short of** (it currently ends at p5/g6e). Managed Instances' accelerated list is broader (see [compute-hardware.md](compute-hardware)). Before reserving, confirm the target instance type is actually consumable by the ECS launch model you intend to use, or you may reserve a block ECS-on-EC2 can't schedule onto.
 
 ## Spot vs On-Demand for GPU on ECS
 
 | Workload | Capacity type | Condition |
 |---|---|---|
-| **Training** | Spot | ✅ Only with checkpoint/resume wired (see [distributed-training.md](distributed-training)) |
+| **Training** | Spot | ✅ Only with checkpoint/resume wired (see [distributed-training.md](distributed-training)) — but see the P-family caveat below |
 | **Training** | On-Demand / Capacity Blocks | When the job can't tolerate interruption |
 | **Inference (production, SLA-bound)** | On-Demand | Always — Spot interruptions break per-request SLAs |
 | **Dev / experimentation** | Spot | ✅ Tolerable interruption profile |
 
-**Spot without checkpoint/resume is a guaranteed cost-burn** — every interruption restarts training. Use **managed instance draining** (on by default) for graceful task rebalancing when instances terminate ([ECS capacity providers for EC2](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)). Note: separate **Spot and On-Demand into different ASGs/capacity providers** (a single ASG mixing purchase options with per-type homogeneity is fine via a MixedInstancesPolicy for *sizes*, but keep GPU *types* separated per the crux above).
+**P-family Spot availability caveat:** the "Large savings" story for Spot training assumes the capacity exists. GPU capacity is scarce (the whole reason Capacity Blocks exist), and **large NVIDIA GPU instances — p4d/p5/p5en — are frequently unobtainable on Spot and carry high interruption rates**. Treat P-family Spot as opportunistic, not a capacity plan: for guaranteed multi-day training use **On-Demand or Capacity Blocks**; reserve Spot for smaller/interruption-tolerant phases with checkpoint/resume, and check the Spot placement score / interruption history for the type and AZ first.
+
+**Spot without checkpoint/resume is a guaranteed cost-burn** — every interruption restarts training. Use **managed instance draining** (on by default) for graceful task rebalancing when instances terminate ([ECS capacity providers for EC2](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)). Note: separate **Spot and On-Demand into different ASGs/capacity providers**, and keep GPU *types* separated per the crux above (one homogeneous GPU type per ASG).
 
 ## Cluster Auto Scaling Behavior & Latency
 
@@ -100,7 +113,10 @@ Always give **directional ranges with caveats** — never point estimates. Actua
 ## Sources
 
 - [Amazon ECS capacity providers for EC2 workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)
+- [Amazon ECS managed scaling behavior](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-scaling-behavior.html) (multiple instance types supported; bin-packs/protects on the smallest type)
 - [Automatically manage Amazon ECS capacity with cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-auto-scaling.html)
+- [Extend Capacity Blocks](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-blocks-extend.html) · [Use Capacity Blocks for ML workloads (single-AZ, EC2 Auto Scaling)](https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-template-capacity-blocks.html)
+- [ECS Managed Instances instance types (billing / Capacity Reservations)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-instance-types.html) · [Patching in ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-patching.html) · [ECS Managed Instances pricing](https://aws.amazon.com/ecs/managed-instances/pricing/)
 - [Optimize Amazon ECS cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/capacity-cluster-speed-up-ec2.html)
 - [Deep Dive on Amazon ECS Cluster Auto Scaling](https://aws.amazon.com/blogs/containers/deep-dive-on-amazon-ecs-cluster-auto-scaling/)
 - [Faster Scaling-in for Amazon ECS Cluster Auto Scaling](https://aws.amazon.com/blogs/containers/faster-scaling-in-for-amazon-ecs-cluster-auto-scaling/)

--- a/misc/website/docs/skills/ecs/ecs-genai/references/compute-hardware.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/compute-hardware.md
@@ -1,0 +1,164 @@
+---
+title: "Compute & Hardware — GPU on Amazon ECS"
+description: ""
+custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/compute-hardware.md
+format: md
+---
+
+:::info[Source]
+This page is generated from [skills/ecs-genai/references/compute-hardware.md](https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/compute-hardware.md). Edit the source, not this page.
+:::
+
+# Compute & Hardware — GPU on Amazon ECS
+
+The foundation of every GPU/ML-on-ECS architecture: **which host, which accelerator, which AMI, how GPUs are exposed to containers, and how (little) they can be shared.** Every claim here is cited to an AWS doc — do not synthesize accelerator specs.
+
+## First-Class Constraint — AWS Fargate Has No GPU
+
+GPUs (and AWS accelerators) are **not available on AWS Fargate**. AWS lists the `gpu` task-definition parameter among those that are **"not valid in Fargate tasks"** (with `devices`, `placementConstraints`, and `privileged`), and the Fargate task-size model exposes only CPU and memory — the valid combinations run from 256 (.25 vCPU) up to 32768 (32 vCPU), with no GPU dimension at all ([ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)). The `resourceRequirements` `GPU` type is a **container-instance (EC2)** concept only. GPU/ML on ECS therefore runs only on:
+
+| Host | GPU support | Who manages the EC2 lifecycle | Use when |
+|---|---|---|---|
+| **ECS-on-EC2** | ✅ Full (GPU-optimized AMI, custom AMI/kernel, EFA, multi-node) | You (Auto Scaling groups) | Training, demanding inference, full control |
+| **ECS Managed Instances** | ✅ GPU + Neuron (drivers pre-installed) | AWS (provision, patch every 14 days, refresh) | Lower ops overhead; GA Sept 2025, all commercial Regions Oct 2025 |
+| **ECS Anywhere / External** | ✅ On-prem GPU hosts (`--enable-gpu`) | You (on-prem) | Hybrid / data-residency |
+| **AWS Fargate** | ❌ **None** | AWS | Never — for GPU, rule Fargate out |
+
+Sources: [ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html), [Use GPUs with ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html).
+
+## NVIDIA GPU Instance Support on ECS
+
+Amazon ECS supports GPU workloads on container instances of the **p2, p3, p4d, p5, g3, g4, g5, g6, and g6e** families, which provide NVIDIA GPUs ([ECS GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)). The following table is the **verbatim supported-instance table from the ECS GPU documentation** (subset shown — see the doc for all sizes). Do not restate GPU counts from memory; cite this table.
+
+| Instance type | GPUs | GPU memory (GiB) | vCPUs | Memory (GiB) |
+|---|---|---|---|---|
+| p3.2xlarge | 1 | 16 | 8 | 61 |
+| p3.16xlarge | 8 | 128 | 64 | 488 |
+| p4d.24xlarge | 8 | 320 | 96 | 1152 |
+| p5.48xlarge | 8 | 640 | 192 | 2048 |
+| g4dn.xlarge | 1 | 16 | 4 | 16 |
+| g4dn.12xlarge | 4 | 64 | 48 | 192 |
+| g5.xlarge | 1 | 24 | 4 | 16 |
+| g5.48xlarge | 8 | 192 | 192 | 768 |
+| g6.xlarge | 1 | 24 | 4 | 16 |
+| g6.48xlarge | 8 | 192 | 192 | 768 |
+| g6e.2xlarge | 1 | 48 | 8 | 64 |
+| g6e.48xlarge | 8 | 384 | 192 | 1536 |
+
+Source: [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html).
+
+### Accelerator selection rule of thumb
+
+- **Inference (7B–70B, cost-sensitive):** g6 / g6e (L40S/L4-class) — broad ecosystem; or **Inf2** for supported Transformer models (see [neuron-on-ecs.md](neuron-on-ecs)).
+- **Training / fine-tuning at scale:** p4d / p5 (multi-node with EFA); or **Trn1/Trn2** for supported models.
+- **Multi-modal / novel architectures / custom CUDA:** NVIDIA GPU (Neuron support is model-specific).
+
+Right accelerator = f(model family × latency × cost posture × team skill × timeline) — never one dimension alone. AWS-published price-performance claims (e.g. Inferentia2/Trainium savings) belong to the EC2 instance pages; cite those pages rather than restating a number here.
+
+## The ECS GPU-Optimized AMI + NVIDIA Container Runtime
+
+Amazon ECS provides a **GPU-optimized AMI** that ships pre-configured NVIDIA kernel drivers and a Docker GPU (NVIDIA) runtime, so you never manage drivers by hand ([ECS GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)). Retrieve the current AMI ID from SSM Parameter Store rather than hard-coding it:
+
+```bash
+# Recommended ECS GPU-optimized AMI (Amazon Linux 2)
+aws ssm get-parameters \
+  --names /aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended \
+  --region us-east-1
+```
+
+Key operational facts (all from the ECS GPU doc):
+
+- Set **`ECS_ENABLE_GPU_SUPPORT=true`** in the container-agent config on GPU instances.
+- For each container with a GPU `resourceRequirements`, ECS sets the container runtime to the **NVIDIA container runtime** and sets **`NVIDIA_VISIBLE_DEVICES`** to the assigned GPU device IDs.
+- If your image is **not** built from an NVIDIA/CUDA base image, set **`NVIDIA_DRIVER_CAPABILITIES`** to `utility,compute` or `all`.
+- **Clusters can mix GPU and non-GPU container instances.**
+- **GPUs are not supported on Windows containers** on ECS.
+- Version notes: **p5** requires GPU-optimized AMI version `20230929`+; **g4** requires `20230913`+; **p2** is only supported on versions earlier than `20230912` (see the doc's "What to do if you need a P2 instance"); the **g2** family is deprecated. In-place NVIDIA/CUDA driver updates on p2/g2 can cause GPU workload failures.
+
+## Requesting a GPU in the Task Definition
+
+Request GPUs at the container level with `resourceRequirements` type `GPU`. ECS schedules the task onto a container instance with free GPUs and **pins the physical GPUs to the container** for optimal performance:
+
+```json
+{
+  "containerDefinitions": [
+    {
+      "name": "inference",
+      "image": "<account>.dkr.ecr.<region>.amazonaws.com/my-model:latest",
+      "resourceRequirements": [
+        { "type": "GPU", "value": "1" }
+      ],
+      "memory": 8192
+    }
+  ],
+  "family": "gpu-inference"
+}
+```
+
+The number of GPUs reserved across all containers in a task can't exceed the GPUs available on the instance ([CfnTaskDefinition ResourceRequirement](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.CfnTaskDefinition.ResourceRequirementProperty.html)). Use **task placement constraints** on `ecs.instance-type` to steer a task to a specific GPU instance type:
+
+```bash
+aws ecs run-task --cluster default --task-definition gpu-inference \
+  --placement-constraints type=memberOf,expression="attribute:ecs.instance-type == g4dn.xlarge"
+```
+
+## GPU Sharing on ECS — State the Limit Precisely
+
+**Native ECS has no MIG-partitioning, time-slicing-replica, or DRA scheduler primitive** (those are EKS device-plugin features). By default ECS pins **whole physical GPUs** to containers. The only supported sharing path documented for ECS is coarse and unisolated ([ECS GPU workloads — "Share GPUs"](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)):
+
+1. **Remove** the GPU `resourceRequirements` from the task definitions so ECS does not reserve GPUs.
+2. Add EC2 **user data** that makes `nvidia` the **default Docker runtime** on the instance (so all ECS containers can see the GPUs):
+
+```bash
+#!/bin/bash
+sudo rm /etc/sysconfig/docker
+echo 'OPTIONS="--default-ulimit nofile=32768:65536 --default-runtime nvidia"' | sudo tee -a /etc/sysconfig/docker
+sudo systemctl restart docker
+```
+
+3. Set **`NVIDIA_VISIBLE_DEVICES`** per container in the task definition to select which GPU(s) each container sees.
+
+> **Caution:** This provides **no memory or compute isolation** between co-located containers — one container can starve or OOM the others on the shared GPU. Use for **dev/test only.** If the customer needs first-class fractional-GPU scheduling (MIG, time-slicing with per-slice memory, DRA), that is a reason to prefer **EKS (`eks-genai`)** or **SageMaker**, not native ECS. See [service-boundaries.md](service-boundaries).
+
+## GPU on ECS Managed Instances
+
+ECS Managed Instances supports GPU-accelerated computing with **NVIDIA drivers and the CUDA toolkit pre-installed** on the instance ([Use GPUs with ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)). Documented GPU families include `g4dn` (NVIDIA T4), `g5` (A10G), `p3` (V100), and `p4d` (A100). You select GPU instances through the **`instanceRequirements`** object in the capacity provider's launch template:
+
+```json
+{
+  "instanceRequirements": {
+    "acceleratorTypes": "gpu",
+    "acceleratorCount": 1,
+    "acceleratorManufacturers": ["nvidia"]
+  }
+}
+```
+
+or pin exact types:
+
+```json
+{ "instanceRequirements": { "allowedInstanceTypes": ["g4dn.xlarge", "p4de.24xlarge"] } }
+```
+
+AWS handles instance configuration, capacity provisioning, workload placement, patching (every 14 days), scaling, and maintenance — trading some control for far lower operational overhead than a hand-rolled ASG.
+
+## Capacity Planning Guidance
+
+| Workload | Start with | Scale signal |
+|---|---|---|
+| Single-model inference (7B–13B) | 1× g6e.2xlarge (1 GPU, 48 GiB) or 1× inf2.8xlarge | Latency p99 > target → add tasks/instances |
+| Larger inference (30B–70B) | g6e.12xlarge / g6e.48xlarge or inf2.48xlarge | GPU memory > ~85% → upsize instance |
+| Distributed training | p4d/p5 or trn1/trn2 with EFA + placement group | All-reduce/EFA throughput, loss convergence |
+| GPU dev sharing | 1× g5/g6 with default-runtime sharing (dev only) | Contention/OOM between tenants → isolate on EKS/SageMaker |
+
+> **Rule:** Start small, measure, scale. Over-provisioning GPU instances is a top-two cost mistake (after choosing the wrong accelerator family). Always give directional ranges with caveats — never point cost estimates.
+
+## Sources
+
+- [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)
+- [ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)
+- [ECS task definition parameters for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html)
+- [Use GPUs with Amazon ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)
+- [Amazon ECS Managed Instances](https://aws.amazon.com/ecs/managed-instances/) · [Announcing Amazon ECS Managed Instances](https://aws.amazon.com/about-aws/whats-new/2025/09/amazon-ecs-managed-instances/)
+- [Amazon ECS-optimized Linux AMIs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)
+- [Using Amazon ECS with NVIDIA GPUs to accelerate drug discovery](https://aws.amazon.com/blogs/containers/using-amazon-ecs-with-nvidia-gpus-to-accelerate-drug-discovery/)

--- a/misc/website/docs/skills/ecs/ecs-genai/references/compute-hardware.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/compute-hardware.md
@@ -15,12 +15,12 @@ The foundation of every GPU/ML-on-ECS architecture: **which host, which accelera
 
 ## First-Class Constraint — AWS Fargate Has No GPU
 
-GPUs (and AWS accelerators) are **not available on AWS Fargate**. AWS lists the `gpu` task-definition parameter among those that are **"not valid in Fargate tasks"** (with `devices`, `placementConstraints`, and `privileged`), and the Fargate task-size model exposes only CPU and memory — the valid combinations run from 256 (.25 vCPU) up to 32768 (32 vCPU), with no GPU dimension at all ([ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)). The `resourceRequirements` `GPU` type is a **container-instance (EC2)** concept only. GPU/ML on ECS therefore runs only on:
+GPUs (and AWS accelerators) are **not available on AWS Fargate**. AWS lists the `gpu` task-definition parameter (with `placementConstraints`) among those **"not valid in Fargate tasks"**, and the Fargate task-size model exposes only CPU and memory — the valid combinations run from 256 (.25 vCPU) up to 32768 (32 vCPU), with no GPU dimension at all ([ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)). (Precise framing: on that same Fargate page, `devices` and `privileged` are listed under **`linuxParameters` limitations**, not on the "not valid" list — but the effect is the same, none are usable for a Fargate GPU task.) The `resourceRequirements` `GPU` type is a **container-instance (EC2)** concept only. GPU/ML on ECS therefore runs only on:
 
 | Host | GPU support | Who manages the EC2 lifecycle | Use when |
 |---|---|---|---|
 | **ECS-on-EC2** | ✅ Full (GPU-optimized AMI, custom AMI/kernel, EFA, multi-node) | You (Auto Scaling groups) | Training, demanding inference, full control |
-| **ECS Managed Instances** | ✅ GPU + Neuron (drivers pre-installed) | AWS (provision, patch every 14 days, refresh) | Lower ops overhead; GA Sept 2025, all commercial Regions Oct 2025 |
+| **ECS Managed Instances** | ✅ GPU + Neuron (drivers pre-installed) | AWS (provision; security patching initiated every 14 days by instance replacement — [ECS Managed Instances FAQs](https://aws.amazon.com/ecs/managed-instances/faqs/), [Patching in ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-patching.html)) | Lower ops overhead; GA Sept 2025, all commercial Regions Oct 2025 |
 | **ECS Anywhere / External** | ✅ On-prem GPU hosts (`--enable-gpu`) | You (on-prem) | Hybrid / data-residency |
 | **AWS Fargate** | ❌ **None** | AWS | Never — for GPU, rule Fargate out |
 
@@ -64,7 +64,14 @@ Amazon ECS provides a **GPU-optimized AMI** that ships pre-configured NVIDIA ker
 aws ssm get-parameters \
   --names /aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended \
   --region us-east-1
+
+# Amazon Linux 2023 GPU variant (AL2 is approaching end-of-life — prefer AL2023 for new builds)
+aws ssm get-parameters \
+  --names /aws/service/ecs/optimized-ami/amazon-linux-2023/gpu/recommended \
+  --region us-east-1
 ```
+
+**AMI options:** AWS publishes GPU-optimized variants for both **Amazon Linux 2** and **Amazon Linux 2023** ([ECS-optimized Linux AMIs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)); AL2 is approaching end-of-life, so prefer **AL2023** for new builds. There is also a **Bottlerocket ECS NVIDIA variant** (`aws-ecs-2-nvidia`, and the older `aws-ecs-1-nvidia`) for a minimal, image-based, security-oriented GPU host — exposed in CDK as `BottlerocketEcsVariant.AWS_ECS_2_NVIDIA` ([CDK BottlerocketEcsVariant](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.BottlerocketEcsVariant.html)).
 
 Key operational facts (all from the ECS GPU doc):
 
@@ -122,7 +129,11 @@ sudo systemctl restart docker
 
 ## GPU on ECS Managed Instances
 
-ECS Managed Instances supports GPU-accelerated computing with **NVIDIA drivers and the CUDA toolkit pre-installed** on the instance ([Use GPUs with ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)). Documented GPU families include `g4dn` (NVIDIA T4), `g5` (A10G), `p3` (V100), and `p4d` (A100). You select GPU instances through the **`instanceRequirements`** object in the capacity provider's launch template:
+ECS Managed Instances supports GPU-accelerated computing with **NVIDIA drivers and the CUDA toolkit pre-installed** on the instance ([Use GPUs with ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)). That page calls out `g4dn` (T4), `g5` (A10G), `p3` (V100), and `p4d` (A100) as a **subset** — the actual Managed Instances **accelerated-computing support list is far broader** than the EC2-launch-type GPU table above. Per [ECS Managed Instances instance types](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-instance-types.html) (verified 2026-07-09) it includes: **DL1, G4ad, G4dn, G5, G5g, G6, G6e, G6f, G7e, Gr6, Gr6f, Inf1, Inf2, P3dn, P4d, P4de, P5, P5en, P6-B200, P6-B300, Trn1** (plus HPC families). Re-check the live page — this list moves fast.
+
+**Hardware-fractional L4 (G6f / Gr6f) — MI-only, no scheduler needed.** `G6f` (and Graviton `Gr6f`) are **fractional-GPU** instances that expose a **1/8, 1/4, or 1/2 slice of an NVIDIA L4** as the hardware unit ([EC2 accelerated computing — Fractional-GPU G6 instances](https://aws.amazon.com/ec2/instance-types/accelerated-computing/)): the fractioning is done by the *instance shape*, not by a MIG/time-slicing scheduler, so it fits native ECS's whole-GPU pinning model. **G6f appears on the Managed Instances list but not on the EC2-launch-type GPU table** — treat it as a Managed-Instances lever for small/cost-sensitive L4 inference. This is distinct from *dynamic multi-model GPU packing* (MIG/time-slicing/DRA), which still has no native-ECS scheduler and routes to EKS/SageMaker (see GPU-sharing section and [service-boundaries.md](service-boundaries)).
+
+You select GPU instances through the **`instanceRequirements`** object in the capacity provider's launch template:
 
 ```json
 {
@@ -140,7 +151,7 @@ or pin exact types:
 { "instanceRequirements": { "allowedInstanceTypes": ["g4dn.xlarge", "p4de.24xlarge"] } }
 ```
 
-AWS handles instance configuration, capacity provisioning, workload placement, patching (every 14 days), scaling, and maintenance — trading some control for far lower operational overhead than a hand-rolled ASG.
+AWS handles instance configuration, capacity provisioning, workload placement, security patching (initiated every 14 days by instance replacement — [Patching in ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-patching.html)), scaling, and maintenance — trading some control for far lower operational overhead than a hand-rolled ASG. Note: the 14-day drain-and-replace cadence interrupts multi-week training runs — see [capacity-and-scaling.md](capacity-and-scaling).
 
 ## Capacity Planning Guidance
 
@@ -158,7 +169,8 @@ AWS handles instance configuration, capacity provisioning, workload placement, p
 - [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)
 - [ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)
 - [ECS task definition parameters for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html)
-- [Use GPUs with Amazon ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)
+- [Use GPUs with Amazon ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html) · [Amazon ECS Managed Instances instance types (full accelerated list, incl. G6f/Gr6f/G7e)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-instance-types.html)
 - [Amazon ECS Managed Instances](https://aws.amazon.com/ecs/managed-instances/) · [Announcing Amazon ECS Managed Instances](https://aws.amazon.com/about-aws/whats-new/2025/09/amazon-ecs-managed-instances/)
-- [Amazon ECS-optimized Linux AMIs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)
+- [Amazon ECS-optimized Linux AMIs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html) · [CDK BottlerocketEcsVariant (aws-ecs-2-nvidia)](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.BottlerocketEcsVariant.html)
+- [EC2 accelerated computing instances (Fractional-GPU G6f / Gr6f)](https://aws.amazon.com/ec2/instance-types/accelerated-computing/)
 - [Using Amazon ECS with NVIDIA GPUs to accelerate drug discovery](https://aws.amazon.com/blogs/containers/using-amazon-ecs-with-nvidia-gpus-to-accelerate-drug-discovery/)

--- a/misc/website/docs/skills/ecs/ecs-genai/references/distributed-training.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/distributed-training.md
@@ -1,0 +1,84 @@
+---
+title: "Distributed ML Training on Amazon ECS"
+description: ""
+custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/distributed-training.md
+format: md
+---
+
+:::info[Source]
+This page is generated from [skills/ecs-genai/references/distributed-training.md](https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/distributed-training.md). Edit the source, not this page.
+:::
+
+# Distributed ML Training on Amazon ECS
+
+Running multi-GPU and multi-node training / fine-tuning on ECS-on-EC2. ECS is a viable orchestrator for distributed ML — AWS documents an end-to-end pattern using **PyTorch + Ray Train** with distributed data parallel on ECS ([Distributed machine learning with Amazon ECS](https://aws.amazon.com/blogs/containers/distributed-machine-learning-with-amazon-ecs/)). Training runs on ECS-on-EC2 (or Managed Instances); **not Fargate** (no GPU/accelerator).
+
+## When ECS Fits Distributed Training — and When It Doesn't
+
+- **ECS fits** when the team wants a simple control plane (no Kubernetes to operate), IAM-native auth, and transparent control-plane upgrades, and the job is **single-node multi-GPU** (all GPUs on one instance; PyTorch DDP/FSDP inside one task with `GPU: ALL`) or a moderate multi-node data-parallel run driven by Ray. AWS's reference shows distributed data parallel (DDP) with Ray Train on ECS.
+- **Know the hard gap:** ECS has **no native multi-node distributed-training job primitive** — there is no equivalent to the Kubeflow `PyTorchJob`/`MPIJob`, the KubeRay operator, or `torchrun` auto peer-discovery across nodes. On ECS you wire rendezvous yourself (Ray head/worker tasks, or Cloud Map service discovery + `MASTER_ADDR`/`MASTER_PORT`), and you own job-level restart/checkpoint-resume on node failure. Multi-node scale beyond a Ray-managed run is where teams feel the absence most.
+- **Prefer EKS (`eks-genai`)** for large or multi-tenant training platforms needing gang scheduling (Volcano/Kueue), KubeRay operators, distributed-job CRDs, and Karpenter-driven elastic GPU provisioning.
+- **Prefer SageMaker** (training jobs / HyperPod) for fully-managed large-scale training where you don't want to own capacity or the training harness — including managed Spot with automatic checkpoint/resume.
+
+## Parallelism Techniques (choose by model size)
+
+Per the AWS ECS distributed-training reference:
+- **Distributed Data Parallel (DDP)** — a full copy of the model on each GPU; data split across GPUs. Simplest; use when the model fits in a single GPU's memory.
+- **Pipeline parallelism** — different model layers on different GPUs. For models too large for one GPU.
+- **Tensor parallelism** — a single layer split across GPUs. For very large layers.
+
+Frameworks run inside the container: **PyTorch (DDP/FSDP)**, **Ray Train** (wraps PyTorch with fault tolerance + orchestration), DeepSpeed, or Megatron. For Neuron training, use `neuronx-distributed` on Trn1/Trn2 ([neuron-on-ecs.md](neuron-on-ecs)).
+
+## Multi-Node Networking — EFA + Placement Groups
+
+Multi-node training is bottlenecked by inter-node collective communication (NCCL all-reduce). Without a high-bandwidth fabric, throughput collapses to standard TCP.
+
+- **Elastic Fabric Adapter (EFA):** attach EFA interfaces to the GPU instances (p4d/p5/trn) for low-latency, high-throughput RDMA. EFA is optimized for **NCCL** on AWS ([EFA for ML](https://aws.amazon.com/hpc/efa/)). The container image must include NCCL + the EFA/libfabric stack (use AWS Deep Learning Containers or build with `aws-ofi-nccl`).
+- **Cluster placement group:** launch the training ASG's instances into a **cluster placement group** so they are physically close for lowest latency ([Get started with EFA and NCCL for ML on EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start-nccl.html)).
+- **Capacity Blocks for ML** colocate reserved P/Trn instances in EC2 UltraClusters with EFA already — the simplest way to get a well-connected multi-node training cluster ([capacity-and-scaling.md](capacity-and-scaling)).
+
+Typical NCCL/EFA container environment:
+
+```bash
+FI_PROVIDER=efa
+FI_EFA_USE_DEVICE_RDMA=1
+NCCL_PROTO=simple
+NCCL_DEBUG=WARN
+```
+
+Expose EFA to the task via the instance (EFA interfaces are configured on the ENI/launch template); the training task uses host networking or `awsvpc` with the EFA-enabled ENI. Because ECS capacity-provider ASGs must be homogeneous ([capacity-and-scaling.md](capacity-and-scaling)), a multi-node training job uses **one ASG of one GPU type** sized to the job.
+
+## Orchestrating the Job on ECS
+
+Two common patterns:
+
+1. **Ray on ECS** — run a Ray head task + Ray worker tasks (each a GPU task) as ECS services/tasks; Ray Train handles worker placement, checkpointing, and fault-tolerant resume. This is the AWS-documented ECS distributed-training approach.
+2. **Rank-addressed tasks** — launch N training tasks (one per node) with a shared rendezvous (torchrun/`c10d` or an MPI launcher); each task pins its GPUs via `resourceRequirements`. Use a placement constraint to spread one task per instance.
+
+Keep the **whole job on one homogeneous GPU ASG** and size the ASG to the node count; ECS cluster auto scaling reacts with latency, so pre-provision (or use Capacity Blocks) for large runs rather than relying on reactive scale-out.
+
+## Checkpoint / Resume — Mandatory for Spot
+
+**Never run distributed training on Spot without checkpoint/resume.** Every interruption otherwise restarts from epoch 0 — a guaranteed cost-burn.
+
+```text
+Training task → checkpoint to FSx for Lustre (fast, same-AZ)  ── or ──  directly to S3
+FSx for Lustre → S3 Data Repository Association (async durable offload)
+On interruption → replacement task launches → loads latest checkpoint from S3/FSx → resumes
+```
+
+- Checkpoint every **15–30 min** on Spot (Spot gives a 2-minute warning; managed instance draining helps drain gracefully).
+- Keep checkpoint storage **same-AZ** as the GPU instances — cross-AZ latency dwarfs FSx's native performance ([storage.md](storage)).
+- Set the training tasks to **not be disrupted** by scale-in during an active run (schedule on On-Demand/Capacity Blocks, or isolate Spot to interruption-tolerant phases).
+
+## Train → Register → Serve Handoff
+
+The trained artifact (e.g. SafeTensors weights) is written to **S3**; the inference service reads from the same S3 path ([inference-serving.md](inference-serving), [storage.md](storage)). Version with an S3 key path (`s3://models/llama-7b-ft/v3/`); promote by updating the inference task definition to the new version and forcing a rolling service deployment. For richer pipelines, orchestrate `data-prep → train → eval → register → deploy` with Step Functions or an external workflow engine (Argo/Airflow) — ECS itself has no built-in ML-pipeline DAG.
+
+## Sources
+
+- [Distributed machine learning with Amazon ECS](https://aws.amazon.com/blogs/containers/distributed-machine-learning-with-amazon-ecs/)
+- [Elastic Fabric Adapter (EFA) for ML](https://aws.amazon.com/hpc/efa/) · [Get started with EFA and NCCL for ML workloads on Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start-nccl.html)
+- [EC2 Capacity Blocks for ML](https://aws.amazon.com/ec2/capacityblocks/)
+- [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html) · [ECS task definitions for AWS Neuron ML workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html)
+- [Amazon FSx for Lustre](https://docs.aws.amazon.com/fsx/latest/LustreGuide/what-is.html)

--- a/misc/website/docs/skills/ecs/ecs-genai/references/distributed-training.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/distributed-training.md
@@ -13,6 +13,8 @@ This page is generated from [skills/ecs-genai/references/distributed-training.md
 
 Running multi-GPU and multi-node training / fine-tuning on ECS-on-EC2. ECS is a viable orchestrator for distributed ML — AWS documents an end-to-end pattern using **PyTorch + Ray Train** with distributed data parallel on ECS ([Distributed machine learning with Amazon ECS](https://aws.amazon.com/blogs/containers/distributed-machine-learning-with-amazon-ecs/)). Training runs on ECS-on-EC2 (or Managed Instances); **not Fargate** (no GPU/accelerator).
 
+> **Managed Instances caveat for long training runs:** Managed Instances is convenient, but it **initiates security patching every ~14 days by replacing (drain-and-replace) the instance** ([capacity-and-scaling.md](capacity-and-scaling)). A multi-week pre-training/fine-tuning run **will be interrupted** by this cadence — so on MI you must have robust checkpoint/resume, schedule patching into a maintenance window, or prefer a **self-managed ASG / Capacity Block** for uninterrupted multi-week jobs.
+
 ## When ECS Fits Distributed Training — and When It Doesn't
 
 - **ECS fits** when the team wants a simple control plane (no Kubernetes to operate), IAM-native auth, and transparent control-plane upgrades, and the job is **single-node multi-GPU** (all GPUs on one instance; PyTorch DDP/FSDP inside one task with `GPU: ALL`) or a moderate multi-node data-parallel run driven by Ray. AWS's reference shows distributed data parallel (DDP) with Ray Train on ECS.
@@ -42,11 +44,12 @@ Typical NCCL/EFA container environment:
 ```bash
 FI_PROVIDER=efa
 FI_EFA_USE_DEVICE_RDMA=1
-NCCL_PROTO=simple
 NCCL_DEBUG=WARN
 ```
 
-Expose EFA to the task via the instance (EFA interfaces are configured on the ENI/launch template); the training task uses host networking or `awsvpc` with the EFA-enabled ENI. Because ECS capacity-provider ASGs must be homogeneous ([capacity-and-scaling.md](capacity-and-scaling)), a multi-node training job uses **one ASG of one GPU type** sized to the job.
+(Don't set `NCCL_PROTO=simple` — it's a legacy workaround that disables faster NCCL protocols and is not needed on recent `aws-ofi-nccl`; leave NCCL to auto-select.)
+
+**Exposing EFA to the container — the mechanism (get this right):** EFA attaches to the **instance at launch** via the launch template (an EFA-enabled ENI plus the EFA/libfabric driver baked into the AMI). To let the container use it you must **map the EFA device into the container with `linuxParameters.devices`** — `hostPath` (and, if set, `containerPath`) `/dev/infiniband/uverbs0`, with `permissions` `READ | WRITE | MKNOD` (multi-EFA instances such as p4d expose `uverbs0..uverbs3`). This is the documented device-mapping mechanism ([EFA on AWS Batch](https://docs.aws.amazon.com/batch/latest/userguide/efa.html)); also set the `memlock` ulimit to unlimited, and place all instances in the **same cluster placement group and AZ** (EFA OS-bypass traffic is limited to one AZ). Important: an `awsvpc` task ENI is a **plain interface ENI — it is never the EFA device**, so choosing `awsvpc` networking does not by itself grant EFA access; the `devices` mapping is what does (host networking is the other documented option). Because a heterogeneous GPU ASG breaks managed scaling ([capacity-and-scaling.md](capacity-and-scaling)), a multi-node training job uses **one homogeneous ASG of one GPU type** sized to the job.
 
 ## Orchestrating the Job on ECS
 
@@ -78,7 +81,7 @@ The trained artifact (e.g. SafeTensors weights) is written to **S3**; the infere
 ## Sources
 
 - [Distributed machine learning with Amazon ECS](https://aws.amazon.com/blogs/containers/distributed-machine-learning-with-amazon-ecs/)
-- [Elastic Fabric Adapter (EFA) for ML](https://aws.amazon.com/hpc/efa/) · [Get started with EFA and NCCL for ML workloads on Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start-nccl.html)
+- [Elastic Fabric Adapter (EFA) for ML](https://aws.amazon.com/hpc/efa/) · [Get started with EFA and NCCL for ML workloads on Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start-nccl.html) · [EFA device mapping into containers (AWS Batch)](https://docs.aws.amazon.com/batch/latest/userguide/efa.html)
 - [EC2 Capacity Blocks for ML](https://aws.amazon.com/ec2/capacityblocks/)
 - [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html) · [ECS task definitions for AWS Neuron ML workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html)
 - [Amazon FSx for Lustre](https://docs.aws.amazon.com/fsx/latest/LustreGuide/what-is.html)

--- a/misc/website/docs/skills/ecs/ecs-genai/references/inference-serving.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/inference-serving.md
@@ -1,0 +1,105 @@
+---
+title: "Model Inference & Serving on Amazon ECS"
+description: ""
+custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/inference-serving.md
+format: md
+---
+
+:::info[Source]
+This page is generated from [skills/ecs-genai/references/inference-serving.md](https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/inference-serving.md). Edit the source, not this page.
+:::
+
+# Model Inference & Serving on Amazon ECS
+
+Patterns for serving ML / LLM inference from containers on ECS-on-EC2 (or Managed Instances) GPU/Neuron capacity. ECS gives you the container primitives — task definition, service, load balancer, autoscaling — and you bring the serving engine inside the container.
+
+## The Inference Service Shape on ECS
+
+A production inference service on ECS is a standard **ECS Service** with GPU/Neuron tasks behind a load balancer:
+
+```text
+ALB / NLB
+   │  target group (health check → /health or /v1/models)
+   ▼
+ECS Service  (desired count N, capacity-provider strategy → GPU ASG)
+   │
+   ├── Task: [ serving-engine container ]  resourceRequirements GPU:1
+   │        weights loaded from S3 / EFS (see storage.md)
+   └── Task: …  (Service Auto Scaling on request/latency metric)
+```
+
+Key choices:
+- **Launch host:** ECS-on-EC2 or Managed Instances (never Fargate — no GPU). CPU-only pre/post-processing sidecars can share the task.
+- **Capacity:** route the service to the right GPU pool with a **capacity-provider strategy** (one ASG per GPU type — see [capacity-and-scaling.md](capacity-and-scaling)).
+- **Load balancer:** ALB for HTTP/gRPC inference APIs; NLB for raw TCP / ultra-low-overhead. Tune the **health-check grace period** generously — model load + warmup can take minutes, and a too-short grace period kills tasks mid-warmup.
+- **Networking:** `awsvpc` mode (task ENI) is the default for services behind a load balancer.
+
+## Serving Engine — Bring Your Own Container
+
+ECS is engine-agnostic; the engine runs inside your image. Common choices (all deployable as an ECS task):
+
+| Engine | Fit | Notes on ECS |
+|---|---|---|
+| **vLLM** | High-throughput LLM inference (GPU or Neuron via `neuronx-distributed-inference`) | OpenAI-compatible API; PagedAttention; run as a single GPU task or scale via ECS Service Auto Scaling |
+| **NVIDIA Triton Inference Server** | Multi-framework / ensembles / TensorRT | One server, multiple model formats; model repo on S3 |
+| **TorchServe / TensorFlow Serving** | Framework-native serving | Straightforward container; good for classic models |
+| **Text Generation Inference (TGI)** | HF-ecosystem LLM serving | Container image + weights from S3/HF |
+| **Custom (FastAPI + framework)** | Bespoke pre/post-processing | Full control; you own batching/metrics |
+
+Note: **KubeRay / Ray Serve, KServe, and the JARK stack are Kubernetes constructs** — they belong to `eks-genai`, not ECS. On ECS you can still run **Ray** inside a task (see [distributed-training.md](distributed-training)), but the K8s-operator serving stacks do not apply.
+
+## Model Loading — Get Weights to the Task
+
+Choose based on model size and cold-start tolerance (full matrix in [storage.md](storage)):
+
+| Pattern | Model size | Cold-start | Best for |
+|---|---|---|---|
+| **Bake into image** | < ~5 GB | Zero (in image layers) | Small/classic models; air-gapped |
+| **Pull from S3 at start** | 5–200+ GB | Seconds–minutes | LLMs; decoupled model/image release |
+| **Mount EFS** | Any (shared) | Low | Multiple tasks/nodes sharing weights (ReadWriteMany) |
+| **FSx for Lustre** | Very large | Zero if pre-warmed | High-throughput weight/checkpoint I/O |
+
+Rules: **pre-cache large model images** (SOCI/parallel pull helps GPU-pod start; huge CUDA/DLC images dominate task launch time); **never pull weights from Hugging Face at every task start** (egress cost, rate limits, cold-start) — stage in S3/ECR first. For Neuron, **pre-compile and ship the compiled artifact** — never compile at task startup ([neuron-on-ecs.md](neuron-on-ecs)).
+
+## Autoscaling the Inference Service
+
+Use **ECS Service Auto Scaling** (Application Auto Scaling) — target-tracking on a meaningful signal:
+
+- **ALB request count per target** (`ALBRequestCountPerTarget`) — simplest proxy for load.
+- **Custom CloudWatch metric** — publish queue depth / in-flight requests / TTFT from the serving engine for a truer signal; GPU utilization from Container Insights enhanced observability (see [observability.md](observability)).
+- Cluster-level: ECS **cluster auto scaling** grows the GPU ASG when tasks can't place (`PROVISIONING`). Remember the **~15-minute scale-in latency** — factor it into GPU cost. Use warm pools to cut GPU-instance warm-up.
+
+```json
+// Application Auto Scaling target tracking on ALB requests per target
+{
+  "TargetValue": 30.0,
+  "PredefinedMetricSpecification": { "PredefinedMetricType": "ALBRequestCountPerTarget" },
+  "ScaleInCooldown": 300,
+  "ScaleOutCooldown": 60
+}
+```
+
+Set `scale-out` faster than `scale-in` for GPU services — losing a warm GPU task is expensive to re-warm; adding one late hurts latency.
+
+## Serving Availability & Deployment Safety
+
+- **Min-healthy-% / max-%** tuned for GPU scarcity: a rolling deploy that briefly needs 2× GPU capacity may not place if the ASG can't scale. Confirm headroom or use a slower rollout.
+- **Deployment circuit breaker** with rollback protects against a bad model image.
+- **Health-check grace period** long enough for model load + warmup, or ECS will kill healthy-but-warming tasks.
+- **Connection draining** so in-flight inference requests complete before task stop.
+
+## When to Route Off ECS for Serving
+
+- Need **scale-to-zero**, **fractional-GPU (MIG/time-slicing) multi-model packing**, or a **Kubernetes-native serving mesh (KServe/Ray Serve/JARK)** → **`eks-genai`**.
+- Want a **fully-managed inference endpoint** (autoscaling, multi-model endpoints, no cluster to run) → **Amazon SageMaker** real-time/serverless/async inference.
+- Just need a **managed foundation-model API** with no self-hosting → **Amazon Bedrock**.
+
+See [service-boundaries.md](service-boundaries).
+
+## Sources
+
+- [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)
+- [Amazon ECS Best Practices Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-best-practices.html) (tasks & services, health checks, autoscaling)
+- [Target tracking scaling for Amazon ECS Service Auto Scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-auto-scaling.html)
+- [Automatically manage Amazon ECS capacity with cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-auto-scaling.html)
+- [Using Amazon ECS with NVIDIA GPUs to accelerate drug discovery](https://aws.amazon.com/blogs/containers/using-amazon-ecs-with-nvidia-gpus-to-accelerate-drug-discovery/)

--- a/misc/website/docs/skills/ecs/ecs-genai/references/inference-serving.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/inference-serving.md
@@ -33,6 +33,11 @@ Key choices:
 - **Capacity:** route the service to the right GPU pool with a **capacity-provider strategy** (one ASG per GPU type — see [capacity-and-scaling.md](capacity-and-scaling)).
 - **Load balancer:** ALB for HTTP/gRPC inference APIs; NLB for raw TCP / ultra-low-overhead. Tune the **health-check grace period** generously — model load + warmup can take minutes, and a too-short grace period kills tasks mid-warmup.
 - **Networking:** `awsvpc` mode (task ENI) is the default for services behind a load balancer.
+- **Endpoint authentication + exposure:** decide **internal (internal ALB/NLB in private subnets, reached over VPC/PrivateLink)** vs **internet-facing** up front. A self-hosted model endpoint has **no built-in auth** — put authentication in front of it: Cognito/OIDC on the ALB, an API Gateway or a mutual-TLS/JWT-validating reverse-proxy sidecar, or WAF + an authorizer. Never expose a raw model API to the internet unauthenticated. Deep endpoint-security / compliance design → route to **`ecs-security`**.
+
+### Token streaming vs ALB idle timeout (the canonical self-hosted-LLM gotcha)
+
+Streaming LLM responses (SSE / chunked `text/event-stream`) that keep a single HTTP connection open longer than the **ALB idle timeout (default 60s)** get **severed mid-generation** — the client sees a truncated stream on long completions. Fix by **raising the ALB idle timeout** to exceed the longest expected generation (e.g. several minutes), ensuring the serving engine **emits tokens/keep-alive frequently** (regular SSE chunks reset the idle timer), and setting client and target-group timeouts consistently. This is the most common "streaming works in dev, breaks in prod" failure for self-hosted LLMs on ECS behind an ALB.
 
 ## Serving Engine — Bring Your Own Container
 
@@ -59,14 +64,23 @@ Choose based on model size and cold-start tolerance (full matrix in [storage.md]
 | **Mount EFS** | Any (shared) | Low | Multiple tasks/nodes sharing weights (ReadWriteMany) |
 | **FSx for Lustre** | Very large | Zero if pre-warmed | High-throughput weight/checkpoint I/O |
 
-Rules: **pre-cache large model images** (SOCI/parallel pull helps GPU-pod start; huge CUDA/DLC images dominate task launch time); **never pull weights from Hugging Face at every task start** (egress cost, rate limits, cold-start) — stage in S3/ECR first. For Neuron, **pre-compile and ship the compiled artifact** — never compile at task startup ([neuron-on-ecs.md](neuron-on-ecs)).
+Rules: **on the EC2 launch type the container image downloads fully before the task starts** — SOCI lazy loading is a **Fargate-PV1.4-only** feature, and Fargate has no GPU, so SOCI is unavailable on every host this skill covers ([storage.md](storage)). Mitigate the multi-GB CUDA/DLC image tax with **warm pools of pre-pulled instances, image caching on the instance NVMe, and lean/baked AMI layers** — not SOCI. **Never pull weights from Hugging Face at every task start** (egress cost, rate limits, cold-start) — stage in S3/ECR first. For Neuron, **pre-compile and ship the compiled artifact** — never compile at task startup ([neuron-on-ecs.md](neuron-on-ecs)).
+
+## Sizing the GPU to the Model — VRAM Method (not just size buckets)
+
+The coarse "7B–13B → g6e" buckets are a starting point; size VRAM explicitly before choosing an instance:
+
+- **Weights:** `params × bytes-per-param` — FP16/BF16 = 2 bytes (a 7B model ≈ 14 GB; 70B ≈ 140 GB), INT8 ≈ 1 byte, INT4/AWQ/GPTQ ≈ 0.5 byte.
+- **KV cache (often the silent OOM):** grows with `batch × sequence_length × 2 (K+V) × num_layers × hidden_dim × bytes` — at long context and high concurrency this can rival or exceed the weights. Size for peak concurrent context, not just the model.
+- **Overhead:** add headroom for activations, CUDA context, and fragmentation (rule of thumb ~10–20%).
+- Sum the three, then pick a GPU whose memory (from the [compute-hardware.md](compute-hardware) table) fits with margin — or shard across GPUs (tensor parallel) when it doesn't. This is why a 70B model at long context needs multi-GPU (e.g. g6e.48xlarge / p4d) even though the weights alone might "fit."
 
 ## Autoscaling the Inference Service
 
 Use **ECS Service Auto Scaling** (Application Auto Scaling) — target-tracking on a meaningful signal:
 
 - **ALB request count per target** (`ALBRequestCountPerTarget`) — simplest proxy for load.
-- **Custom CloudWatch metric** — publish queue depth / in-flight requests / TTFT from the serving engine for a truer signal; GPU utilization from Container Insights enhanced observability (see [observability.md](observability)).
+- **Custom CloudWatch metric** — publish queue depth / in-flight requests / TTFT from the serving engine for a truer signal. GPU utilization as an autoscaling signal is **agentless only on Managed Instances**; on the **EC2 launch type** you must publish it via the CloudWatch agent (`nvidia_smi`, host-level) or a DCGM exporter (per-task) — the agentless MI metrics won't exist (see [observability.md](observability)).
 - Cluster-level: ECS **cluster auto scaling** grows the GPU ASG when tasks can't place (`PROVISIONING`). Remember the **~15-minute scale-in latency** — factor it into GPU cost. Use warm pools to cut GPU-instance warm-up.
 
 ```json
@@ -95,6 +109,11 @@ Set `scale-out` faster than `scale-in` for GPU services — losing a warm GPU ta
 - Just need a **managed foundation-model API** with no self-hosting → **Amazon Bedrock**.
 
 See [service-boundaries.md](service-boundaries).
+
+## AI Gateway / Agentic & RAG on ECS
+
+- **AI gateway:** a self-hosted model-routing/observability/rate-limiting gateway such as **LiteLLM** runs well as a CPU-only ECS service in front of both your ECS-hosted models and Bedrock — this is a documented `ai-gateway` target. Use it to give clients one OpenAI-compatible endpoint, centralize auth/keys, and do cost attribution across self-hosted + managed models.
+- **Agentic / RAG orchestrators:** a CPU-only orchestrator/RAG retriever (calling your GPU inference service and/or Bedrock) fits fine on ECS — including on Fargate for the non-accelerated part ([service-boundaries.md](service-boundaries)). Boundary to name: for a **fully-managed agent runtime with memory/tools/identity**, route to **Amazon Bedrock AgentCore**; **self-host on ECS** when you need to own the framework/serving stack. Agentic workloads with autonomous tool/code execution raise sandbox-escape risk → loop in **`ecs-security`**.
 
 ## Sources
 

--- a/misc/website/docs/skills/ecs/ecs-genai/references/neuron-on-ecs.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/neuron-on-ecs.md
@@ -47,7 +47,7 @@ aws ssm get-parameters \
   --names /aws/service/ecs/optimized-ami/amazon-linux-2023/neuron/recommended
 ```
 
-(The AWS CDK exposes the same via `EcsOptimizedImage.amazonLinux2(AmiHardwareType.NEURON)` for Inf1/Trn1/Inf2 launches.)
+> **CDK caveat (AL2 vs AL2023 mismatch):** `EcsOptimizedImage.amazonLinux2(AmiHardwareType.NEURON)` returns the **Amazon Linux 2 (Neuron)** AMI — *not* the AL2023 Neuron AMI recommended above ([CDK aws-ecs — Amazon Linux 2 (Neuron) Instances](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs-readme.html)). To launch the **AL2023** Neuron AMI in CDK, don't rely on `amazonLinux2(...NEURON)`; use the **SSM parameter above directly** (e.g. `MachineImage.fromSsmParameter(...)`) so the launch template actually gets AL2023.
 
 ## Two Ways to Give a Container Neuron Devices
 
@@ -123,5 +123,5 @@ AWS-published price-performance claims for Inferentia2/Trainium live on the EC2 
 - [Amazon ECS task definitions for AWS Neuron machine learning workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html)
 - [Example Neuron task definitions for Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference-task-def.html)
 - [AWS Neuron](https://aws.amazon.com/ai/machine-learning/neuron/) · [AWS Inferentia](https://aws.amazon.com/ai/machine-learning/inferentia/) · [AWS Trainium](https://aws.amazon.com/ai/machine-learning/trainium/)
-- [Use GPUs with Amazon ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html) (Neuron selection via instanceRequirements)
+- [Amazon ECS task definitions for AWS Neuron ML workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html) — the authoritative source for the managed `NeuronDevice` allocation path and `instanceRequirements` Neuron selection (the NVIDIA-only [managed-instances-gpu.html](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html) does *not* cover Neuron device allocation)
 - [aws-cdk-lib.aws_ecs — Amazon Linux 2 (Neuron) Instances](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs-readme.html)

--- a/misc/website/docs/skills/ecs/ecs-genai/references/neuron-on-ecs.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/neuron-on-ecs.md
@@ -1,0 +1,127 @@
+---
+title: "AWS Neuron (Inferentia / Trainium) on Amazon ECS"
+description: ""
+custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/neuron-on-ecs.md
+format: md
+---
+
+:::info[Source]
+This page is generated from [skills/ecs-genai/references/neuron-on-ecs.md](https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/neuron-on-ecs.md). Edit the source, not this page.
+:::
+
+# AWS Neuron (Inferentia / Trainium) on Amazon ECS
+
+Running AWS purpose-built ML accelerators — **AWS Inferentia (Inf1, Inf2)** and **AWS Trainium (Trn1, Trn2)** — as ECS workloads. Neuron is the cost-optimized alternative to NVIDIA GPU for **supported Transformer-family models**, at the cost of an ahead-of-time compilation step. Like GPU, **Neuron is not available on Fargate** — it runs on ECS-on-EC2 and ECS Managed Instances (Inf1 is EC2-launch-type only).
+
+## Supported Instances & What Each Is For
+
+Per [ECS task definitions for AWS Neuron ML workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html):
+
+| Family | Chip | Role | ECS support |
+|---|---|---|---|
+| **Trn1, Trn2** | AWS Trainium | High-performance, low-cost **training** (also large-model inference) | EC2 launch type + Managed Instances |
+| **Inf2** | AWS Inferentia2 | High-performance, low-cost **inference** | EC2 launch type + Managed Instances |
+| **Inf1** | AWS Inferentia | Inference (first-gen) | **EC2 launch type only** |
+
+Verbatim device mapping from the ECS Neuron doc (subset — chips per instance, used for manual device specification):
+
+| Instance | vCPUs | RAM (GiB) | Neuron chips | Device paths |
+|---|---|---|---|---|
+| trn1.2xlarge | 8 | 32 | 1 | /dev/neuron0 |
+| trn1.32xlarge | 128 | 512 | 16 | /dev/neuron0 … /dev/neuron15 |
+| trn2.48xlarge | 192 | 2048 | 16 | /dev/neuron0 … /dev/neuron15 |
+| inf1.xlarge | 4 | 8 | 1 | /dev/neuron0 |
+| inf1.24xlarge | 96 | 192 | 16 | /dev/neuron0 … /dev/neuron15 |
+| inf2.xlarge | 4 | 16 | 1 | /dev/neuron0 |
+| inf2.24xlarge | 96 | 384 | 6 | /dev/neuron0 … /dev/neuron5 |
+| inf2.48xlarge | 192 | 768 | 12 | /dev/neuron0 … /dev/neuron11 |
+
+Clusters can mix Trn1, Trn2, Inf1, Inf2, and other instances (subject to the per-type-ASG capacity rule in [capacity-and-scaling.md](capacity-and-scaling)). The workload must be a **Linux** container using a framework with Neuron support (PyTorch, TensorFlow) via the **AWS Neuron SDK** (compiler + runtime + profiling tools). Non-Neuron frameworks won't get accelerated performance on these instances.
+
+## The ECS Neuron-Optimized AMI
+
+ECS provides a **Neuron-optimized Amazon Linux 2023 AMI** with the AWS Neuron drivers and Docker runtime pre-installed — recommended for launching Trn1, Inf1, and Inf2 instances ([ECS Neuron ML workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html)):
+
+```bash
+aws ssm get-parameters \
+  --names /aws/service/ecs/optimized-ami/amazon-linux-2023/neuron/recommended
+```
+
+(The AWS CDK exposes the same via `EcsOptimizedImage.amazonLinux2(AmiHardwareType.NEURON)` for Inf1/Trn1/Inf2 launches.)
+
+## Two Ways to Give a Container Neuron Devices
+
+ECS supports **two approaches** for Neuron device access — use one consistently to avoid conflicts:
+
+### 1. Managed Neuron device allocation (Managed Instances only)
+
+Use `resourceRequirements` type **`NeuronDevice`** with value `ALL`. ECS discovers Neuron devices on the instance, assigns them, and gives the container access to **all** Neuron devices — so **only one Neuron task runs per instance** (exclusive access).
+
+```json
+{
+  "containerDefinitions": [
+    {
+      "name": "neuron-inference",
+      "image": "<account>.dkr.ecr.<region>.amazonaws.com/vllm-neuron:latest",
+      "resourceRequirements": [
+        { "type": "NeuronDevice", "value": "ALL" }
+      ]
+    }
+  ]
+}
+```
+
+Constraints: at most one container definition may specify `NeuronDevice`; you can't combine `NeuronDevice` `resourceRequirements` with `linuxParameters.devices` for Neuron in the same task definition. After launch, verify via `DescribeTasks` (`neuronDeviceIds` per container) or `DescribeContainerInstances` (`NEURON_DEVICES` in registered/remaining resources). Select Neuron instances in the Managed Instances launch template with `instanceRequirements`:
+
+```json
+{
+  "instanceRequirements": {
+    "acceleratorManufacturers": ["amazon-web-services"],
+    "acceleratorNames": ["inferentia2", "trainium", "trainium2"],
+    "allowedInstanceTypes": ["inf*", "trn*"]
+  }
+}
+```
+
+### 2. Manual Neuron device specification (EC2 launch type + Managed Instances)
+
+Explicitly map device paths with `linuxParameters.devices`. **Only one inference/training task can run per Trainium/Inferentia chip**; you can run as many tasks as there are chips by assigning different devices to each. The **task definition must be specific to a single instance type** (device paths differ per instance — see the table above). Use task placement constraints on `ecs.instance-type` to land the task on the right family.
+
+```json
+{
+  "containerDefinitions": [
+    {
+      "name": "neuron-inference",
+      "image": "…/vllm-neuron:latest",
+      "linuxParameters": {
+        "devices": [
+          { "hostPath": "/dev/neuron0", "containerPath": "/dev/neuron0", "permissions": ["read","write"] }
+        ]
+      }
+    }
+  ]
+}
+```
+
+## Compilation — The Ramp Cost
+
+Neuron requires **ahead-of-time compilation** of the model (via `torch-neuronx` / `neuronx-distributed-inference` for Inf2/Trn; `torch-neuron` for Inf1). This is the primary adoption friction vs NVIDIA GPU:
+
+- Budget **1–2 weeks** for the first model (SDK learning, graph-break debugging, tensor/pipeline-parallel tuning). Subsequent versions are much faster (reuse compilation cache).
+- **Pre-compile offline** in CI and ship the compiled artifact via S3 or bake it into the container image. **Never compile at task startup** in production — it puts a multi-minute step on the critical path.
+- **Verify the specific model architecture is Neuron-supported before committing budget** — not all Hugging Face models have Neuron support; verify against the [AWS Neuron](https://aws.amazon.com/ai/machine-learning/neuron/) supported-models list, and run an eval suite comparing GPU vs Neuron output quality before shifting production traffic.
+
+## When Neuron Wins (and When It Doesn't)
+
+- **Recommend Neuron when:** the model is Transformer-family (Llama, Mistral, Qwen, etc.), framework is PyTorch/TensorFlow with Neuron support, the workload is steady-state production (inference on Inf2) or cost-sensitive training (Trn1/Trn2), and the team can absorb the compilation ramp.
+- **Stay on NVIDIA GPU when:** fastest time-to-first-success matters, there are CUDA-only dependencies, the architecture is novel/non-Transformer or multi-modal, or Neuron support for the model is unverified.
+
+AWS-published price-performance claims for Inferentia2/Trainium live on the EC2 instance-type pages — cite those pages rather than restating a percentage here. Give directional ranges with caveats.
+
+## Sources
+
+- [Amazon ECS task definitions for AWS Neuron machine learning workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html)
+- [Example Neuron task definitions for Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference-task-def.html)
+- [AWS Neuron](https://aws.amazon.com/ai/machine-learning/neuron/) · [AWS Inferentia](https://aws.amazon.com/ai/machine-learning/inferentia/) · [AWS Trainium](https://aws.amazon.com/ai/machine-learning/trainium/)
+- [Use GPUs with Amazon ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html) (Neuron selection via instanceRequirements)
+- [aws-cdk-lib.aws_ecs — Amazon Linux 2 (Neuron) Instances](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs-readme.html)

--- a/misc/website/docs/skills/ecs/ecs-genai/references/observability.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/observability.md
@@ -1,0 +1,72 @@
+---
+title: "Observability for GPU / ML Workloads on Amazon ECS"
+description: ""
+custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/observability.md
+format: md
+---
+
+:::info[Source]
+This page is generated from [skills/ecs-genai/references/observability.md](https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/observability.md). Edit the source, not this page.
+:::
+
+# Observability for GPU / ML Workloads on Amazon ECS
+
+GPU/ML observability on ECS adds three concerns over standard container monitoring: **accelerator utilization/memory**, **per-request/inference latency**, and **cost attribution** for expensive GPU/Neuron capacity. The primary AWS-native path is **CloudWatch Container Insights with enhanced observability**.
+
+## GPU Metrics — Container Insights Enhanced Observability
+
+For ECS running **NVIDIA GPU** instances, **Container Insights with enhanced observability collects GPU metrics from NVIDIA DCGM (Data Center GPU Manager) at the container, task, and instance levels** — with **no additional agent installation** required. GPU metrics are collected automatically on supported instance types once enhanced observability is enabled on the cluster ([Monitoring ECS Managed Instances — GPU monitoring](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/monitoring-managed-instances.html)).
+
+- **GPU metrics are NOT collected with basic Container Insights** — you must **enable enhanced observability** to get GPU telemetry.
+- Metrics land in CloudWatch (the `ECS/ContainerInsights` enhanced namespace); build dashboards and alarms there.
+- Typical DCGM-sourced signals: GPU compute utilization, GPU memory utilization, GPU temperature, at node/task/container granularity (analogous to the EKS Container Insights GPU metric set — e.g. `*_gpu_utilization`, `*_gpu_memory_utilization`, `*_gpu_temperature`).
+
+Enable on the cluster:
+
+```bash
+aws ecs update-cluster-settings \
+  --cluster my-gpu-cluster \
+  --settings name=containerInsights,value=enhanced
+```
+
+## What to Watch (and rough thresholds)
+
+| Signal | Why it matters | Guidance |
+|---|---|---|
+| **GPU utilization** | Are you paying for idle GPUs? | <50% sustained → consolidate/right-size; >90% sustained → capacity risk |
+| **GPU memory utilization** | KV-cache / model headroom | >~90% → OOM risk; upsize instance or reduce batch/context |
+| **GPU temperature** | Thermal throttling | Alert high temps; correlate with throughput drops |
+| **Inference latency (TTFT / p99)** | User-perceived quality | Publish from the serving engine as a custom CloudWatch metric |
+| **In-flight / queued requests** | Saturation signal for autoscaling | Drive ECS Service Auto Scaling ([inference-serving.md](inference-serving)) |
+| **EFA traffic (multi-node training)** | Inter-node fabric health | Packet drops / throughput dips precede training stalls |
+
+## Neuron (Inferentia / Trainium) Metrics
+
+For Neuron workloads, use the **AWS Neuron Monitor** tooling / `neuron-monitor` (part of the Neuron SDK on the ECS Neuron-optimized AMI) to expose NeuronCore utilization, HBM usage, and EFA interface health. Publish to CloudWatch (Container Insights) or a Prometheus scrape. Key categories: per-NeuronCore compute/memory %, HBM used/free per device, EFA Tx/Rx and drops, and compilation-cache hit/miss (a miss ratio > 0 in steady state signals models aren't pre-compiled — see [neuron-on-ecs.md](neuron-on-ecs)).
+
+## Standard ECS Telemetry (still applies)
+
+- **CloudWatch metrics** — CPU, memory, network at cluster/service/task level (free, 2-week retention); Container Insights adds task/instance-level and diagnostics.
+- **Logs** — `awslogs` driver to CloudWatch Logs, or **FireLens** (Fluent Bit) to route to OpenSearch/S3/third-party. Keep log routing off the GPU's critical path.
+- **CloudTrail** — API audit (task launches, S3 model-bucket data events).
+- **Third-party** — Datadog/Dynatrace/New Relic as agent sidecars; they can scrape DCGM/Neuron and the serving-engine `/metrics` endpoint.
+
+## Cost Attribution
+
+GPU/Neuron capacity is the dominant cost. Attribute it with:
+- **AWS Split Cost Allocation Data (SCAD)** for per-task ECS cost allocation in Cost Explorer.
+- **Cost allocation tags** on services/task definitions (team, model, environment).
+- **Custom per-request accounting** from the serving engine (tokens/requests per tenant) when you need per-tenant chargeback.
+
+## Keep Observability Off the GPU's Back
+
+DCGM collection is agentless via Container Insights (no scheduling concern), but any **heavy log-processing or metrics sidecars** should be sized carefully — GPU-instance memory is precious. Don't co-locate memory-hungry aggregation with large model tasks; prefer routing to managed backends (CloudWatch, AMP, third-party SaaS).
+
+## Sources
+
+- [Monitoring Amazon ECS Managed Instances (GPU / DCGM via Container Insights enhanced)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/monitoring-managed-instances.html)
+- [Amazon ECS CloudWatch Container Insights](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-container-insights.html)
+- [Gain operational insights for NVIDIA GPU workloads using CloudWatch Container Insights](https://aws.amazon.com/blogs/mt/gain-operational-insights-for-nvidia-gpu-workloads-using-amazon-cloudwatch-container-insights/)
+- [AWS Neuron Monitor](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/tools/neuron-sys-tools/neuron-monitor-user-guide.html)
+- [Send Amazon ECS logs to CloudWatch / FireLens](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html)
+- [AWS Split Cost Allocation Data](https://docs.aws.amazon.com/cur/latest/userguide/split-cost-allocation-data.html)

--- a/misc/website/docs/skills/ecs/ecs-genai/references/observability.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/observability.md
@@ -13,13 +13,16 @@ This page is generated from [skills/ecs-genai/references/observability.md](https
 
 GPU/ML observability on ECS adds three concerns over standard container monitoring: **accelerator utilization/memory**, **per-request/inference latency**, and **cost attribution** for expensive GPU/Neuron capacity. The primary AWS-native path is **CloudWatch Container Insights with enhanced observability**.
 
-## GPU Metrics — Container Insights Enhanced Observability
+## GPU Metrics — Two Different Paths (MI vs EC2 launch type)
 
-For ECS running **NVIDIA GPU** instances, **Container Insights with enhanced observability collects GPU metrics from NVIDIA DCGM (Data Center GPU Manager) at the container, task, and instance levels** — with **no additional agent installation** required. GPU metrics are collected automatically on supported instance types once enhanced observability is enabled on the cluster ([Monitoring ECS Managed Instances — GPU monitoring](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/monitoring-managed-instances.html)).
+This is the single most-often-wrong claim about GPU observability on ECS: the **agentless DCGM path is Managed-Instances-only**, not "all ECS NVIDIA instances." Get the path right for the launch model.
 
-- **GPU metrics are NOT collected with basic Container Insights** — you must **enable enhanced observability** to get GPU telemetry.
-- Metrics land in CloudWatch (the `ECS/ContainerInsights` enhanced namespace); build dashboards and alarms there.
-- Typical DCGM-sourced signals: GPU compute utilization, GPU memory utilization, GPU temperature, at node/task/container granularity (analogous to the EKS Container Insights GPU metric set — e.g. `*_gpu_utilization`, `*_gpu_memory_utilization`, `*_gpu_temperature`).
+### Managed Instances — agentless DCGM via Container Insights enhanced observability
+
+For **ECS Managed Instances running NVIDIA GPU-enabled EC2 types**, Container Insights with enhanced observability collects GPU metrics from NVIDIA DCGM at the container, task, and instance levels, with **no additional agent installation** ([Monitoring ECS Managed Instances — GPU monitoring](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/monitoring-managed-instances.html)). Every one of these GPU metrics is documented as **"Available only for Amazon ECS Managed Instances running NVIDIA GPU-enabled Amazon EC2 instance types"** ([Container Insights enhanced observability metrics for ECS](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-enhanced-observability-metrics-ECS.html)).
+
+- **GPU metrics are NOT collected with basic Container Insights** — you must **enable enhanced observability**.
+- Metrics land in the `ECS/ContainerInsights` namespace. The **actual metric names** are `TaskGPUUtilization`, `TaskGPUMemoryUtilization`, `TaskGPUMemoryUsed`/`TaskGPUMemoryTotal`, `TaskGPUPowerDraw`, `TaskGPUTemperature`, `TaskGPURestartAppXidCount` (and the `ContainerGPU*` and `InstanceGPULimit`/`InstanceGPUUsageTotal` families) — **not** the EKS-style `*_gpu_utilization` names. Cite these exact names.
 
 Enable on the cluster:
 
@@ -28,6 +31,14 @@ aws ecs update-cluster-settings \
   --cluster my-gpu-cluster \
   --settings name=containerInsights,value=enhanced
 ```
+
+### ECS-on-EC2 launch type — no agentless DCGM path
+
+On the **EC2 launch type there is no agentless DCGM collection**. To get GPU telemetry you deploy an agent:
+- **CloudWatch agent with `nvidia_smi`** — the CloudWatch-agent collects host-level NVIDIA GPU metrics (utilization, memory, temperature, power) per **instance**. Simplest, but **host-level only — no per-task attribution**.
+- **DCGM exporter (or the Neuron/DCGM exporter sidecar) → CloudWatch/AMP/Prometheus** — deploy the exporter as a container to get **per-task / per-GPU** granularity, at the cost of running and sizing the exporter yourself.
+
+So if an inference service on the **EC2 launch type** wants GPU utilization as an autoscaling signal (see [inference-serving.md](inference-serving)), it must publish it via one of these agents — the agentless MI metrics won't exist.
 
 ## What to Watch (and rough thresholds)
 
@@ -42,11 +53,13 @@ aws ecs update-cluster-settings \
 
 ## Neuron (Inferentia / Trainium) Metrics
 
-For Neuron workloads, use the **AWS Neuron Monitor** tooling / `neuron-monitor` (part of the Neuron SDK on the ECS Neuron-optimized AMI) to expose NeuronCore utilization, HBM usage, and EFA interface health. Publish to CloudWatch (Container Insights) or a Prometheus scrape. Key categories: per-NeuronCore compute/memory %, HBM used/free per device, EFA Tx/Rx and drops, and compilation-cache hit/miss (a miss ratio > 0 in steady state signals models aren't pre-compiled — see [neuron-on-ecs.md](neuron-on-ecs)).
+For Neuron workloads, use the **AWS Neuron Monitor** tooling / `neuron-monitor` (part of the Neuron SDK on the ECS Neuron-optimized AMI) and publish to CloudWatch (via `neuron-monitor-cloudwatch.py`) or a Prometheus scrape. Its **documented metric groups** are: `neuroncore_counters` (per-NeuronCore utilization), `memory_used`, `neuron_runtime_vcpu_usage`, `execution_stats` (error count + latency), and the system groups `vcpu_usage`, `memory_info`, and `neuron_hw_counters` — where `neuron_hw_counters` is **ECC event counters only** (corrected/uncorrected DRAM and SRAM ECC), *not* general hardware telemetry ([neuron-monitor User Guide](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/tools/neuron-sys-tools/neuron-monitor-user-guide.html)).
+
+Two corrections to a common mis-statement: **neuron-monitor has no EFA metric group** — get EFA Tx/Rx and drops from `ethtool` / `/sys/class/infiniband/*/ports/*/counters` or the CloudWatch agent, not neuron-monitor. And **neuron-monitor exposes no compilation-cache hit/miss metric** — don't monitor for it; instead enforce pre-compilation at the pipeline level (ship the compiled artifact — see [neuron-on-ecs.md](neuron-on-ecs)).
 
 ## Standard ECS Telemetry (still applies)
 
-- **CloudWatch metrics** — CPU, memory, network at cluster/service/task level (free, 2-week retention); Container Insights adds task/instance-level and diagnostics.
+- **CloudWatch metrics** — CPU, memory, network at cluster/service/task level; Container Insights adds task/instance-level and diagnostics. **Retention:** 1-minute datapoints are kept **15 days**, but metrics persist up to **15 months** at coarser resolution (5-min to 63 days, 1-hour to 455 days) — data is aggregated, not deleted ([CloudWatch metrics retention](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html)). Note Container Insights metrics are billed as custom metrics.
 - **Logs** — `awslogs` driver to CloudWatch Logs, or **FireLens** (Fluent Bit) to route to OpenSearch/S3/third-party. Keep log routing off the GPU's critical path.
 - **CloudTrail** — API audit (task launches, S3 model-bucket data events).
 - **Third-party** — Datadog/Dynatrace/New Relic as agent sidecars; they can scrape DCGM/Neuron and the serving-engine `/metrics` endpoint.
@@ -60,12 +73,13 @@ GPU/Neuron capacity is the dominant cost. Attribute it with:
 
 ## Keep Observability Off the GPU's Back
 
-DCGM collection is agentless via Container Insights (no scheduling concern), but any **heavy log-processing or metrics sidecars** should be sized carefully — GPU-instance memory is precious. Don't co-locate memory-hungry aggregation with large model tasks; prefer routing to managed backends (CloudWatch, AMP, third-party SaaS).
+DCGM collection is agentless **only on Managed Instances** (no scheduling concern there), but on the EC2 launch type the CloudWatch-agent / DCGM-exporter and any **heavy log-processing or metrics sidecars** should be sized carefully — GPU-instance memory is precious. Don't co-locate memory-hungry aggregation with large model tasks; prefer routing to managed backends (CloudWatch, AMP, third-party SaaS).
 
 ## Sources
 
 - [Monitoring Amazon ECS Managed Instances (GPU / DCGM via Container Insights enhanced)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/monitoring-managed-instances.html)
-- [Amazon ECS CloudWatch Container Insights](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-container-insights.html)
+- [Amazon ECS Container Insights with enhanced observability metrics (GPU metric names; MI-only)](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-enhanced-observability-metrics-ECS.html)
+- [Amazon ECS CloudWatch Container Insights](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-container-insights.html) · [CloudWatch metrics retention](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html)
 - [Gain operational insights for NVIDIA GPU workloads using CloudWatch Container Insights](https://aws.amazon.com/blogs/mt/gain-operational-insights-for-nvidia-gpu-workloads-using-amazon-cloudwatch-container-insights/)
 - [AWS Neuron Monitor](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/tools/neuron-sys-tools/neuron-monitor-user-guide.html)
 - [Send Amazon ECS logs to CloudWatch / FireLens](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html)

--- a/misc/website/docs/skills/ecs/ecs-genai/references/security-and-compliance.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/security-and-compliance.md
@@ -11,72 +11,42 @@ This page is generated from [skills/ecs-genai/references/security-and-compliance
 
 # Security & Compliance for GPU / ML Workloads on Amazon ECS
 
-Non-negotiable security baseline for every GPU/ML-on-ECS deployment. GenAI workloads add supply-chain (model artifacts, huge dependency images) and data-processing (prompts, outputs, embeddings) risk on top of standard ECS hardening. For deep, general ECS security use the `ecs-security` skill; this file is the GPU/ML-specific slice.
+This file is the **GPU/ML-specific security slice only.** The generic ECS security baseline — task/execution-role least-privilege and the `ecs-tasks.amazonaws.com` trust policy, secrets via Secrets Manager/SSM, ECR enhanced scanning, private subnets + VPC endpoints, `awsvpc` security-group-per-task, non-root/read-only-rootfs container hardening, CloudTrail + Container Insights audit — is **owned by the `ecs-security` skill; route deep compliance and CDE design there** and don't restate it in full here. What follows is only what changes because the workload is GPU/ML/GenAI.
 
-## The Non-Negotiable Baseline
+## Baseline pointer (apply via `ecs-security`)
 
-Include every item in every GPU/ML-on-ECS response.
+Every GPU/ML-on-ECS response still MUST include the standard baseline (roles, secrets, ECR scanning, private subnets + endpoints, hardening, audit) — see **`ecs-security`** for the how. Two baseline items have GPU/ML-specific twists worth stating inline:
 
-### 1. Task role + execution role — least-privilege, no static keys
+- **Task role** grants the model server/trainer its S3 (weights/checkpoints), Secrets Manager, and — if the app calls Bedrock as a model target — **`bedrock-runtime`** permissions; scope to exact buckets/prefixes/secrets, never static keys.
+- **Container hardening exception:** the GPU-sharing pattern (making `nvidia` the default Docker runtime) **loosens isolation** — reserve it for dev/test ([compute-hardware.md](compute-hardware)).
 
-- **Task role** grants the *application* (model server / trainer) its AWS permissions — S3 for weights/checkpoints, Bedrock-runtime if used as a gateway target, Secrets Manager. Scope to specific buckets/prefixes/secrets; **never** put `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` in env vars, the task definition, or the image.
-- **Execution role** grants the *ECS agent* rights to pull the ECR image and inject secrets/logs — keep it separate and minimal.
-- The recurring hard failure on ECS is the **task-role trust-relationship error** ("ECS was unable to assume the role"): the role's trust policy must allow `ecs-tasks.amazonaws.com` to `sts:AssumeRole`, and `iam:PassRole` must be granted to whoever registers/runs the task. Get the trust policy right first.
+## GPU/ML-Specific Controls (the reason this file exists)
 
-```json
-// Task role trust policy
-{ "Version": "2012-10-17", "Statement": [{
-  "Effect": "Allow",
-  "Principal": { "Service": "ecs-tasks.amazonaws.com" },
-  "Action": "sts:AssumeRole"
-}]}
-```
+### Model-artifact provenance (the top GenAI supply-chain risk)
 
-### 2. Secrets — Secrets Manager / SSM Parameter Store injection
+A poisoned model artifact executes arbitrary inference on customer data — treat weights like application binaries. Verify integrity before serving: pin **exact model revisions** (not floating tags/branches); verify **SHA256 checksums** for downloaded weights; use **image signing** (AWS Signer / Sigstore) for baked-in models; enable **S3 Object Lock** for production artifact buckets. Never pull weights from Hugging Face at task start in prod — stage in S3/ECR first ([storage.md](storage)).
 
-Store model-registry tokens, API keys, and gateway keys in **AWS Secrets Manager** or **SSM Parameter Store**; inject via the task definition `secrets` block (resolved by the execution role) — never bake secrets into the (often cached, widely-pulled) model image or a ConfigMap-style env.
+### GPU/ML-specific supply chain
 
-```json
-"secrets": [
-  { "name": "HF_TOKEN", "valueFrom": "arn:aws:secretsmanager:REGION:ACCT:secret:hf-token" }
-]
-```
+GPU/ML images (CUDA, cuDNN, PyTorch, Neuron SDK, DLC) carry **far larger dependency trees** than typical microservices — ECR enhanced scanning matters more here; scan on push and periodically for base-image drift, and block critical/high CVEs.
 
-### 3. ECR image scanning
+### `bedrock-runtime` VPC endpoint
 
-Enable **ECR enhanced scanning (Amazon Inspector)** and block deployment of critical/high CVEs. GPU/ML images (CUDA, cuDNN, PyTorch, Neuron SDK, DLC) carry **far larger dependency trees** than typical microservices — scan on push and periodically for base-image drift.
+If the ECS app calls Bedrock as a downstream model target, add the **`bedrock-runtime` interface endpoint** so that traffic stays private — this is the one VPC endpoint beyond the standard S3/ECR/Secrets/logs set that GenAI-on-ECS specifically adds.
 
-### 4. Model-artifact provenance
+### Inference-endpoint authentication
 
-A poisoned model artifact executes arbitrary inference on customer data — treat weights like application binaries. Verify integrity before serving: pin **exact model revisions** (not floating tags/branches); verify **SHA256 checksums** for downloaded weights; use **image signing** (AWS Signer / Sigstore) for baked-in models; enable **S3 Object Lock** for production artifact buckets.
+A self-hosted model endpoint has **no built-in auth**. Decide **internal vs internet-facing** (internal ALB/NLB in private subnets reached via VPC/PrivateLink is the default for internal consumers), and always put an authN/authZ layer in front — Cognito/OIDC on the ALB, API Gateway, or a JWT/mTLS-validating reverse proxy — plus WAF for internet-facing. Deep endpoint-security design → **`ecs-security`**. See [inference-serving.md](inference-serving) for the streaming/idle-timeout interaction.
 
-### 5. Network isolation
+### GuardDuty Runtime Monitoring — MI carve-out
 
-Place GPU/Neuron container instances in **private subnets** with no direct inbound internet. Route AWS API calls through **VPC endpoints**:
+Enable **GuardDuty ECS Runtime Monitoring** on **ECS-on-EC2** container instances for runtime threat detection. **Critical caveat given how heavily this skill promotes Managed Instances:** Runtime Monitoring is **not supported on ECS Managed Instances**, and also **not on ECS Anywhere or the Windows OS** ([Runtime Monitoring considerations](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-guard-duty-integration.html)). An MI-based GPU fleet therefore cannot rely on GuardDuty RM for the host — plan a different runtime-threat control (or keep sensitive runtime-monitored workloads on ECS-on-EC2). Pair with CloudTrail (management + S3 model-bucket data events).
 
-| Endpoint | Why |
-|---|---|
-| `s3` (Gateway) | Model weights, checkpoints, training data |
-| `ecr.api` + `ecr.dkr` | Image pull |
-| `secretsmanager` | Secrets injection |
-| `logs` / `monitoring` | CloudWatch Logs / metrics |
-| `bedrock-runtime` (Interface) | Only if the app calls Bedrock as a model target |
+## Compliance-Regime Notes (GPU/ML angle; full regime design → `ecs-security`)
 
-Egress for any unavoidable downloads via a NAT gateway with restrictive SGs — or eliminate by pre-caching all artifacts to S3/ECR. Use **security-group-per-task** (`awsvpc` mode) to scope task-to-task traffic.
-
-### 6. Container hardening
-
-Run containers **non-root**, with **read-only root filesystem** where the framework allows, and drop unneeded Linux capabilities. Note the GPU-sharing exception: making `nvidia` the default Docker runtime for GPU sharing loosens isolation — reserve that pattern for dev/test ([compute-hardware.md](compute-hardware)).
-
-### 7. GuardDuty ECS Runtime Monitoring + audit logging
-
-Enable **GuardDuty ECS Runtime Monitoring** on the EC2 container instances for runtime threat detection. Enable **CloudTrail** (management + S3 model-bucket data events) and **Container Insights** for audit and forensics. Retain per compliance requirement.
-
-## Compliance-Regime Notes
-
-- **HIPAA:** GPU tasks processing PHI on a HIPAA-eligible account (BAA in place); KMS-CMK encryption for EBS/S3/EFS; audit all access; verify Bedrock/other targets' HIPAA status at deployment.
-- **PCI-DSS:** isolate GPU/ML workloads in a dedicated cluster or node group + namespace + SG boundary within the CDE; encrypt task-to-task traffic; quarterly image scans retained.
-- **FedRAMP:** GovCloud or FedRAMP-authorized Regions; FIPS-validated modules; images only from an approved ECR in-boundary (no Docker Hub / HF pulls in prod).
+- **HIPAA:** GPU tasks processing PHI on a HIPAA-eligible account (BAA in place); KMS-CMK encryption for EBS/S3/EFS; verify Bedrock/other model targets' HIPAA status at deployment.
+- **PCI-DSS:** isolate GPU/ML workloads within the CDE using **ECS-native** boundaries — a **dedicated cluster** *or* a **dedicated capacity provider / ASG** + **security-group-per-task** (`awsvpc`) + **separate task/execution roles (and ideally separate accounts)**. (Node groups and namespaces are **Kubernetes** constructs that **don't exist in ECS** — don't prescribe them here; that's an `eks-genai` pattern.) Encrypt task-to-task traffic; retain quarterly image scans.
+- **FedRAMP:** GovCloud or FedRAMP-authorized Regions; FIPS-validated modules; images only from an approved in-boundary ECR (no Docker Hub / HF pulls in prod).
 - **GDPR:** EU-region deployment for EU personal data; design right-to-erasure so deleting source documents cascades to derived embeddings; treat stored prompts/outputs as personal data.
 
 ## When to Escalate to a Specialist Review
@@ -88,13 +58,18 @@ Enable **GuardDuty ECS Runtime Monitoring** on the EC2 container instances for r
 
 ## Quick-Reference Checklist
 
-- [ ] Task role + execution role least-privilege; trust policy allows `ecs-tasks.amazonaws.com`; `iam:PassRole` scoped
+Baseline items (details in **`ecs-security`**):
+- [ ] Task + execution role least-privilege; trust policy allows `ecs-tasks.amazonaws.com`; `iam:PassRole` scoped
 - [ ] Secrets via Secrets Manager / SSM — never in image/env
 - [ ] ECR enhanced scanning — critical/high blocked
-- [ ] Model provenance — pinned revision + checksum/signing
-- [ ] Private subnets + VPC endpoints (S3, ECR, Secrets Manager, logs; Bedrock if used)
-- [ ] Non-root, read-only rootfs, dropped capabilities
-- [ ] GuardDuty ECS Runtime Monitoring + CloudTrail + Container Insights
+- [ ] Private subnets + VPC endpoints (S3, ECR, Secrets Manager, logs); non-root, read-only rootfs, dropped capabilities
+- [ ] CloudTrail + Container Insights audit
+
+GPU/ML-specific (this file):
+- [ ] Model provenance — pinned revision + SHA256 checksum / signing; S3 Object Lock on prod artifact buckets
+- [ ] `bedrock-runtime` VPC endpoint if the app calls Bedrock
+- [ ] Inference-endpoint authN/authZ + internal-vs-internet-facing decision
+- [ ] GuardDuty ECS Runtime Monitoring on **ECS-on-EC2** hosts — **not available on Managed Instances / Anywhere / Windows** (plan an alternative for MI fleets)
 
 ## Sources
 
@@ -102,5 +77,6 @@ Enable **GuardDuty ECS Runtime Monitoring** on the EC2 container instances for r
 - [Amazon ECS task IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) · [Task execution IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html)
 - [Passing sensitive data to a container (Secrets Manager / SSM)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html)
 - [Amazon ECR image scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html)
-- [GuardDuty Runtime Monitoring for Amazon ECS](https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring.html)
+- [GuardDuty Runtime Monitoring for Amazon ECS — considerations (not supported on Managed Instances / Anywhere / Windows)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-guard-duty-integration.html)
 - [Interface VPC endpoints for Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/vpc-endpoints.html)
+- For the full ECS security baseline and regulated-compliance design: the **`ecs-security`** skill

--- a/misc/website/docs/skills/ecs/ecs-genai/references/security-and-compliance.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/security-and-compliance.md
@@ -1,0 +1,106 @@
+---
+title: "Security & Compliance for GPU / ML Workloads on Amazon ECS"
+description: ""
+custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/security-and-compliance.md
+format: md
+---
+
+:::info[Source]
+This page is generated from [skills/ecs-genai/references/security-and-compliance.md](https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/security-and-compliance.md). Edit the source, not this page.
+:::
+
+# Security & Compliance for GPU / ML Workloads on Amazon ECS
+
+Non-negotiable security baseline for every GPU/ML-on-ECS deployment. GenAI workloads add supply-chain (model artifacts, huge dependency images) and data-processing (prompts, outputs, embeddings) risk on top of standard ECS hardening. For deep, general ECS security use the `ecs-security` skill; this file is the GPU/ML-specific slice.
+
+## The Non-Negotiable Baseline
+
+Include every item in every GPU/ML-on-ECS response.
+
+### 1. Task role + execution role — least-privilege, no static keys
+
+- **Task role** grants the *application* (model server / trainer) its AWS permissions — S3 for weights/checkpoints, Bedrock-runtime if used as a gateway target, Secrets Manager. Scope to specific buckets/prefixes/secrets; **never** put `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` in env vars, the task definition, or the image.
+- **Execution role** grants the *ECS agent* rights to pull the ECR image and inject secrets/logs — keep it separate and minimal.
+- The recurring hard failure on ECS is the **task-role trust-relationship error** ("ECS was unable to assume the role"): the role's trust policy must allow `ecs-tasks.amazonaws.com` to `sts:AssumeRole`, and `iam:PassRole` must be granted to whoever registers/runs the task. Get the trust policy right first.
+
+```json
+// Task role trust policy
+{ "Version": "2012-10-17", "Statement": [{
+  "Effect": "Allow",
+  "Principal": { "Service": "ecs-tasks.amazonaws.com" },
+  "Action": "sts:AssumeRole"
+}]}
+```
+
+### 2. Secrets — Secrets Manager / SSM Parameter Store injection
+
+Store model-registry tokens, API keys, and gateway keys in **AWS Secrets Manager** or **SSM Parameter Store**; inject via the task definition `secrets` block (resolved by the execution role) — never bake secrets into the (often cached, widely-pulled) model image or a ConfigMap-style env.
+
+```json
+"secrets": [
+  { "name": "HF_TOKEN", "valueFrom": "arn:aws:secretsmanager:REGION:ACCT:secret:hf-token" }
+]
+```
+
+### 3. ECR image scanning
+
+Enable **ECR enhanced scanning (Amazon Inspector)** and block deployment of critical/high CVEs. GPU/ML images (CUDA, cuDNN, PyTorch, Neuron SDK, DLC) carry **far larger dependency trees** than typical microservices — scan on push and periodically for base-image drift.
+
+### 4. Model-artifact provenance
+
+A poisoned model artifact executes arbitrary inference on customer data — treat weights like application binaries. Verify integrity before serving: pin **exact model revisions** (not floating tags/branches); verify **SHA256 checksums** for downloaded weights; use **image signing** (AWS Signer / Sigstore) for baked-in models; enable **S3 Object Lock** for production artifact buckets.
+
+### 5. Network isolation
+
+Place GPU/Neuron container instances in **private subnets** with no direct inbound internet. Route AWS API calls through **VPC endpoints**:
+
+| Endpoint | Why |
+|---|---|
+| `s3` (Gateway) | Model weights, checkpoints, training data |
+| `ecr.api` + `ecr.dkr` | Image pull |
+| `secretsmanager` | Secrets injection |
+| `logs` / `monitoring` | CloudWatch Logs / metrics |
+| `bedrock-runtime` (Interface) | Only if the app calls Bedrock as a model target |
+
+Egress for any unavoidable downloads via a NAT gateway with restrictive SGs — or eliminate by pre-caching all artifacts to S3/ECR. Use **security-group-per-task** (`awsvpc` mode) to scope task-to-task traffic.
+
+### 6. Container hardening
+
+Run containers **non-root**, with **read-only root filesystem** where the framework allows, and drop unneeded Linux capabilities. Note the GPU-sharing exception: making `nvidia` the default Docker runtime for GPU sharing loosens isolation — reserve that pattern for dev/test ([compute-hardware.md](compute-hardware)).
+
+### 7. GuardDuty ECS Runtime Monitoring + audit logging
+
+Enable **GuardDuty ECS Runtime Monitoring** on the EC2 container instances for runtime threat detection. Enable **CloudTrail** (management + S3 model-bucket data events) and **Container Insights** for audit and forensics. Retain per compliance requirement.
+
+## Compliance-Regime Notes
+
+- **HIPAA:** GPU tasks processing PHI on a HIPAA-eligible account (BAA in place); KMS-CMK encryption for EBS/S3/EFS; audit all access; verify Bedrock/other targets' HIPAA status at deployment.
+- **PCI-DSS:** isolate GPU/ML workloads in a dedicated cluster or node group + namespace + SG boundary within the CDE; encrypt task-to-task traffic; quarterly image scans retained.
+- **FedRAMP:** GovCloud or FedRAMP-authorized Regions; FIPS-validated modules; images only from an approved ECR in-boundary (no Docker Hub / HF pulls in prod).
+- **GDPR:** EU-region deployment for EU personal data; design right-to-erasure so deleting source documents cascades to derived embeddings; treat stored prompts/outputs as personal data.
+
+## When to Escalate to a Specialist Review
+
+1. Regulated data (HIPAA/PCI/FedRAMP/GDPR) processed by the GenAI workload — GenAI compliance is materially harder (prompts, outputs, embeddings are all data-processing).
+2. Multi-tenant SaaS needing cross-tenant isolation of models/data on shared GPU capacity.
+3. Agentic workloads with autonomous code/tool execution — sandbox-escape risk.
+4. Air-gapped environments with no VPC-endpoint path — custom supply-chain design.
+
+## Quick-Reference Checklist
+
+- [ ] Task role + execution role least-privilege; trust policy allows `ecs-tasks.amazonaws.com`; `iam:PassRole` scoped
+- [ ] Secrets via Secrets Manager / SSM — never in image/env
+- [ ] ECR enhanced scanning — critical/high blocked
+- [ ] Model provenance — pinned revision + checksum/signing
+- [ ] Private subnets + VPC endpoints (S3, ECR, Secrets Manager, logs; Bedrock if used)
+- [ ] Non-root, read-only rootfs, dropped capabilities
+- [ ] GuardDuty ECS Runtime Monitoring + CloudTrail + Container Insights
+
+## Sources
+
+- [Amazon ECS security best practices](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/security.html) · [Amazon ECS Best Practices Guide — security](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-best-practices.html)
+- [Amazon ECS task IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) · [Task execution IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html)
+- [Passing sensitive data to a container (Secrets Manager / SSM)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html)
+- [Amazon ECR image scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html)
+- [GuardDuty Runtime Monitoring for Amazon ECS](https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring.html)
+- [Interface VPC endpoints for Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/vpc-endpoints.html)

--- a/misc/website/docs/skills/ecs/ecs-genai/references/service-boundaries.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/service-boundaries.md
@@ -1,0 +1,66 @@
+---
+title: "Service Boundaries — Fargate-GPU Exclusion & When to Leave ECS"
+description: ""
+custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/service-boundaries.md
+format: md
+---
+
+:::info[Source]
+This page is generated from [skills/ecs-genai/references/service-boundaries.md](https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/service-boundaries.md). Edit the source, not this page.
+:::
+
+# Service Boundaries — Fargate-GPU Exclusion & When to Leave ECS
+
+This skill's most important job is to keep GPU/ML workloads on the *right* AWS service. Two questions: (1) is Fargate viable? (never, for GPU) and (2) is ECS-on-EC2 the right home, or should this be EKS / SageMaker / Bedrock?
+
+## 1. AWS Fargate Has No GPU — the Evidence
+
+State this as fact, not opinion. GPU is a **container-instance (EC2)** capability on ECS; Fargate exposes only CPU + memory.
+
+- AWS lists the **`gpu` task-definition parameter among those "not valid in Fargate tasks"** — alongside `devices`, `placementConstraints`, and `privileged` ([ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)).
+- The **Fargate task-size model** enumerates valid CPU/memory combinations only — 256 (.25 vCPU) through 32768 (32 vCPU), with matching memory ranges — and **no GPU dimension**.
+- AWS documents the GPU `resourceRequirements` type as the number of physical GPUs the **ECS container agent** reserves on the **container instance**. The ECS GPU documentation is entirely about **EC2 GPU-based container instances** and the GPU-optimized AMI — there is no Fargate GPU path ([ECS GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)).
+
+**Consequence:** any GPU/accelerator container must run on **ECS-on-EC2**, **ECS Managed Instances**, or **ECS Anywhere/External**. Fargate can still host **CPU-only** parts of a GenAI app (an API front-end, an orchestrator, a RAG retriever calling Bedrock) — just not the accelerated container.
+
+## 2. Stay on ECS vs Route Elsewhere
+
+| Signal | Right home | Why |
+|---|---|---|
+| Team wants a **simple control plane**, IAM-native, no Kubernetes to operate; GPU/Neuron container inference or moderate training | **ECS-on-EC2 (this skill)** | ECS gives container + capacity primitives without K8s operational surface |
+| Needs **Karpenter-style GPU provisioning**, **KubeRay/Ray Serve/JARK**, **KServe scale-to-zero**, **fractional-GPU (MIG/time-slicing/DRA)**, or a **Kubernetes serving mesh** | **EKS (`eks-genai`)** | These are Kubernetes-native constructs with no native-ECS equivalent |
+| Wants **fully-managed training** (no capacity/harness to own) or a **managed inference endpoint** (real-time/serverless/async, multi-model, autoscaling) | **Amazon SageMaker** | SageMaker manages the training/hosting plane end-to-end; HyperPod for large clusters |
+| Wants a **managed foundation-model API** with **no self-hosting** (no GPU at all) | **Amazon Bedrock** | Zero infrastructure; pay-per-use FMs, Knowledge Bases, Agents, Guardrails |
+| Generic **ECS launch-type / cluster design** with **no accelerator or ML workload** | **`ecs-architect`** | Model selection/design without the GPU/ML specialization |
+
+### Sharper EKS boundary (vs `eks-genai`)
+
+Route to **`eks-genai`** the moment the requirement names a Kubernetes primitive: Karpenter, node pools, device plugins, KubeRay, Ray Serve on K8s, KServe, JARK, Kubeflow, gang scheduling (Volcano/Kueue), MIG/time-slicing/DRA fractional-GPU, or an existing EKS estate the team wants to extend. ECS deliberately has **no** Karpenter and **no** fractional-GPU scheduler — if those are hard requirements, ECS is the wrong tool.
+
+### Sharper SageMaker boundary
+
+Route to **SageMaker** when the customer does **not want to own container orchestration or GPU capacity** at all: managed training jobs, managed endpoints, built-in model registry/pipelines, HyperPod for very large training. If they *want* to own the container/service (custom serving stack, existing ECS estate, tight infra control), ECS-on-EC2 is the fit.
+
+### Sharper Bedrock boundary
+
+Route to **Bedrock** when there is **no self-hosting** — the customer just wants to call managed FMs. This skill covers Bedrock only as a *downstream target* a self-hosted ECS app might also call (hybrid: self-host cost-sensitive models on ECS-GPU, call Bedrock for best-of-breed).
+
+## 3. Quick Router
+
+```text
+GPU / accelerator container?
+  ├─ No GPU, just "which ECS model"      → ecs-architect
+  ├─ Fargate?                            → NO (no GPU) — use ECS-on-EC2 / Managed Instances / Anywhere
+  ├─ Kubernetes primitive named / EKS    → eks-genai
+  ├─ Fully-managed train/host, no infra  → SageMaker
+  ├─ Managed FM API, no self-hosting     → Bedrock
+  └─ Self-hosted GPU/Neuron on ECS       → THIS SKILL (ecs-genai)
+```
+
+## Sources
+
+- [Amazon ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)
+- [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)
+- [Use GPUs with Amazon ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)
+- [Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html) · [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html)
+- [Best Practices for AI/ML Workloads on Amazon EKS](https://docs.aws.amazon.com/eks/latest/best-practices/aiml.html) (the eks-genai counterpart)

--- a/misc/website/docs/skills/ecs/ecs-genai/references/service-boundaries.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/service-boundaries.md
@@ -17,11 +17,13 @@ This skill's most important job is to keep GPU/ML workloads on the *right* AWS s
 
 State this as fact, not opinion. GPU is a **container-instance (EC2)** capability on ECS; Fargate exposes only CPU + memory.
 
-- AWS lists the **`gpu` task-definition parameter among those "not valid in Fargate tasks"** — alongside `devices`, `placementConstraints`, and `privileged` ([ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)).
+- AWS lists the **`gpu` task-definition parameter among those "not valid in Fargate tasks"** (alongside `placementConstraints`); `devices` and `privileged` appear separately under **`linuxParameters` limitations** on the same page — either way none work for a Fargate GPU task ([ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)).
 - The **Fargate task-size model** enumerates valid CPU/memory combinations only — 256 (.25 vCPU) through 32768 (32 vCPU), with matching memory ranges — and **no GPU dimension**.
 - AWS documents the GPU `resourceRequirements` type as the number of physical GPUs the **ECS container agent** reserves on the **container instance**. The ECS GPU documentation is entirely about **EC2 GPU-based container instances** and the GPU-optimized AMI — there is no Fargate GPU path ([ECS GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)).
 
 **Consequence:** any GPU/accelerator container must run on **ECS-on-EC2**, **ECS Managed Instances**, or **ECS Anywhere/External**. Fargate can still host **CPU-only** parts of a GenAI app (an API front-end, an orchestrator, a RAG retriever calling Bedrock) — just not the accelerated container.
+
+**Guidance for the CPU-only orchestrator/RAG/gateway pieces** (so this isn't a dead-end blessing): a **RAG retriever or agent orchestrator** that calls a model runs fine on Fargate — the boundary to name is **Amazon Bedrock AgentCore** for a fully-managed agent runtime (memory/tools/identity) vs **self-hosting the framework on ECS** when you want to own it. A self-hosted **AI gateway (e.g. LiteLLM)** — model routing, key management, cost attribution across your ECS-hosted models and Bedrock — is a documented `ai-gateway` target and also runs as a CPU-only ECS/Fargate service. See [inference-serving.md](inference-serving) for the gateway/agentic patterns; agentic workloads with autonomous tool/code execution → also loop in `ecs-security`.
 
 ## 2. Stay on ECS vs Route Elsewhere
 

--- a/misc/website/docs/skills/ecs/ecs-genai/references/storage.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/storage.md
@@ -1,0 +1,71 @@
+---
+title: "Storage for GPU / ML Workloads on Amazon ECS"
+description: ""
+custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/storage.md
+format: md
+---
+
+:::info[Source]
+This page is generated from [skills/ecs-genai/references/storage.md](https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/storage.md). Edit the source, not this page.
+:::
+
+# Storage for GPU / ML Workloads on Amazon ECS
+
+Where model weights, training data, and checkpoints live — and how to get them to GPU/Neuron tasks fast enough that expensive accelerators aren't idle waiting on I/O.
+
+## Decision Table — Workload Pattern → Storage
+
+| Workload pattern | Recommended storage | Why |
+|---|---|---|
+| **Inference weights (single task)** | S3 (pull at start) or bake into image (<5 GB) | Decoupled model/image release; lazy availability |
+| **Inference weights shared across many tasks/nodes** | Amazon EFS (ReadWriteMany) | Concurrent read from multiple tasks; simple, elastic |
+| **Distributed training data + checkpoints** | FSx for Lustre (same-AZ) + S3 DRA | Sub-ms latency, high aggregate throughput, durable offload |
+| **Training checkpoints (durable)** | FSx for Lustre → S3 Data Repository Association | Fast local write; async durable copy to S3 |
+| **Very large weights, I/O-bound cold start** | FSx for Lustre (pre-warmed) | Eliminates S3 cold-start when bandwidth-bound |
+
+## Model Artifact Handling — Getting Weights to the Task
+
+| Strategy | Model size | Cold-start | Coupling | Best for |
+|---|---|---|---|---|
+| **Bake into container image** | < ~5 GB | Zero (in layers) | Model release = image release | Small/classic models; air-gapped |
+| **Pull from S3 at task start** | 5 GB – 200+ GB | Seconds–minutes | Decoupled | LLMs; frequent model updates |
+| **Mount EFS** | Any (shared) | Low | Decoupled | Many tasks/nodes sharing the same weights |
+| **Pre-cache on FSx for Lustre** | Any | Zero if pre-warmed | FSx lifecycle to manage | Training; very large weights where S3 is the bottleneck |
+
+Rules:
+- **Never pull weights from Hugging Face at every task start** — egress cost, rate limits, and cold-start. Stage in **S3** (or ECR for baked images) first.
+- **Pre-compile Neuron models offline** and ship the compiled artifact via S3/image — never compile at task startup ([neuron-on-ecs.md](neuron-on-ecs)).
+- **Access S3 via the task role** (least-privilege, per-bucket/prefix) — never static keys ([security-and-compliance.md](security-and-compliance)).
+
+## Container Image Size — the Cold-Start Tax
+
+CUDA / Deep Learning Container / Neuron images are large (often 5–15+ GB). On GPU/Neuron instances with local NVMe, ECS benefits from **parallel image pull/unpack (SOCI-style)** to speed multi-GB image starts; keep images lean (multi-stage builds, drop build toolchains) and pre-pull onto warm-pool instances so a scale-out event isn't dominated by image download. Decouple weights from the image (pull from S3) so a model update doesn't force a full image re-pull.
+
+## FSx for Lustre — Training I/O
+
+For distributed training and checkpoint-heavy workloads, FSx for Lustre delivers high aggregate throughput and low latency, with an **S3 Data Repository Association (DRA)** for import (training data) and async export (checkpoints):
+
+- **Same-AZ rule (critical):** deploy FSx in the **same Availability Zone** as the GPU/Neuron instances. Cross-AZ round-trip latency dwarfs FSx's native performance — a top silent-bad-architecture decision.
+- **Pre-warm** FSx with training data (via an admin task) **before** launching Spot GPU capacity, so you don't burn expensive accelerator minutes waiting on data ingest.
+- **Checkpoint flow:** training task writes to FSx → DRA async-exports to S3 → on interruption a replacement task lazy-loads the latest checkpoint from S3 into a fresh FSx volume. See [distributed-training.md](distributed-training).
+
+## Amazon EFS — Shared Weights
+
+Use EFS when multiple inference tasks (possibly across instances) must read the same weights concurrently (ReadWriteMany) and FSx's throughput/complexity isn't warranted. EFS is elastic (no sizing), mounts in each AZ, and is simple to attach as an ECS volume — moderate throughput, low-single-digit-ms latency. Good for 5–20 model variants shared across an inference fleet.
+
+## Amazon S3 — the Backbone
+
+S3 is the durable source of truth for weights, checkpoints, and the train→serve handoff artifact. Access via the **task role**; reach it privately from GPU instances in private subnets via an **S3 VPC endpoint** ([security-and-compliance.md](security-and-compliance)). Version models by key path (`s3://models/<name>/v3/`) to make promotion a task-definition update.
+
+## Storage + Capacity Notes
+
+- **FSx same-AZ:** pin the training ASG to the FSx AZ; accept reduced Spot diversity in exchange for correct latency.
+- **EFS / S3:** regional/multi-AZ — no zone pinning needed for tasks.
+- **Checkpoint safety:** ensure training tasks aren't scaled-in mid-write — schedule long runs on On-Demand/Capacity Blocks, or checkpoint frequently on Spot.
+
+## Sources
+
+- [Amazon FSx for Lustre](https://docs.aws.amazon.com/fsx/latest/LustreGuide/what-is.html) · [FSx for Lustre and Amazon S3](https://docs.aws.amazon.com/fsx/latest/LustreGuide/fsx-data-repositories.html)
+- [Amazon EFS volumes for Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/efs-volumes.html)
+- [Amazon ECS Best Practices Guide — task definitions (volumes, images)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-best-practices.html)
+- [Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)

--- a/misc/website/docs/skills/ecs/ecs-genai/references/storage.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/storage.md
@@ -39,7 +39,7 @@ Rules:
 
 ## Container Image Size — the Cold-Start Tax
 
-CUDA / Deep Learning Container / Neuron images are large (often 5–15+ GB). On GPU/Neuron instances with local NVMe, ECS benefits from **parallel image pull/unpack (SOCI-style)** to speed multi-GB image starts; keep images lean (multi-stage builds, drop build toolchains) and pre-pull onto warm-pool instances so a scale-out event isn't dominated by image download. Decouple weights from the image (pull from S3) so a model update doesn't force a full image re-pull.
+CUDA / Deep Learning Container / Neuron images are large (often 5–15+ GB). **On the ECS-on-EC2 launch type the container image downloads completely before the container starts** — the same behavior as all non-1.4.0 Fargate platform versions ([ECS task definition differences for Fargate — SOCI lazy loading](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)). **SOCI lazy loading is Fargate-PV1.4-only, and Fargate has no GPU**, so SOCI is **unavailable on every host this skill covers** — do not plan around it for GPU/Neuron cold-start. Real EC2 mitigations: **pre-pull the image onto warm-pool instances**, **cache images on the instance NVMe**, **bake heavy layers into the AMI**, and keep images lean (multi-stage builds, drop build toolchains). Decouple weights from the image (pull from S3) so a model update doesn't force a full image re-pull.
 
 ## FSx for Lustre — Training I/O
 

--- a/misc/website/docs/skills/ecs/ecs-genai/references/use-cases.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/use-cases.md
@@ -25,15 +25,15 @@ Four condensed scenarios. Each gives: customer profile, the ECS-specific decisio
 |---|---|---|
 | D1 Host | ECS-on-EC2 (or Managed Instances) | Fargate has no GPU |
 | D2 Accelerator | g6e (NVIDIA L40S) for 7B–13B; evaluate Inf2 as phase-2 cost play | Broad ecosystem first; Neuron savings later |
-| D3 Capacity | One capacity-provider ASG for the g6e type + service capacity-provider strategy | ASGs must be homogeneous (no instance weighting) |
-| D4 Shape | Single GPU task behind an ALB; Service Auto Scaling on requests/latency | Standard inference service |
-| Storage | Weights in S3, pulled at task start | Decoupled model/image release ([storage.md](storage)) |
-| Observability | Container Insights **enhanced** (DCGM GPU metrics) + serving-engine latency metric | Enable enhanced — basic has no GPU metrics ([observability.md](observability)) |
+| D3 Capacity | One homogeneous g6e capacity-provider ASG + service capacity-provider strategy | Mixed-GPU ASGs are allowed but managed scaling protects on the smallest type — keep one type per ASG ([capacity-and-scaling.md](capacity-and-scaling)) |
+| D4 Shape | Single GPU task behind an ALB; Service Auto Scaling on requests/latency; raise ALB idle timeout for token streaming | Standard inference service ([inference-serving.md](inference-serving)) |
+| Storage | Weights in S3, pulled at task start | Decoupled model/image release; on EC2 the image downloads fully first (no SOCI) ([storage.md](storage)) |
+| Observability | **On g6e MI:** agentless DCGM via Container Insights **enhanced**. **On g6e ECS-on-EC2:** CloudWatch agent (`nvidia_smi`) or DCGM exporter — the agentless MI metrics don't exist there. Plus serving-engine latency metric | Pick the path by launch model ([observability.md](observability)) |
 | Security | Task role → S3 (prefix-scoped); private subnet + S3/ECR VPC endpoints; ECR scanning | Baseline ([security-and-compliance.md](security-and-compliance)) |
 
 **Build path:** stand up the g6e capacity provider + service; validate the model + a generous health-check grace period; wire enhanced Container Insights + latency-based Service Auto Scaling; harden (task role, secrets, private subnets, image scanning); then run a g6e-vs-inf2 cost comparison and migrate to Neuron if the savings justify the compilation ramp.
 
-**Route out if:** the team wants scale-to-zero or fractional-GPU multi-model packing → `eks-genai`; or a fully-managed endpoint → SageMaker.
+**Route out if:** the team wants scale-to-zero or **scheduler-driven** fractional-GPU multi-model packing (MIG/time-slicing/DRA) → `eks-genai`; or a fully-managed endpoint → SageMaker. (Hardware-fractional L4 via G6f/Gr6f on Managed Instances stays on ECS — see [compute-hardware.md](compute-hardware).)
 
 ---
 
@@ -90,7 +90,7 @@ Four condensed scenarios. Each gives: customer profile, the ECS-specific decisio
 
 **Build path:** launch a small g5/g6 ASG with the default-runtime user data; publish task-definition templates with `NVIDIA_VISIBLE_DEVICES` set; document the no-isolation caveat.
 
-**Route out if:** the team needs isolated fractional GPUs (MIG / time-slicing with per-slice memory / DRA) → `eks-genai`; or managed notebooks/experiments → SageMaker Studio.
+**Route out if:** the team needs **dynamic multi-model GPU packing** — a MIG / time-slicing / DRA *scheduler* — → `eks-genai`; or managed notebooks/experiments → SageMaker Studio. (But note: **hardware-fractional L4 instances (G6f/Gr6f)** are supported on ECS **Managed Instances** for small/cost-sensitive inference — the slice is the instance shape, no scheduler needed; see [compute-hardware.md](compute-hardware). Route to EKS only when the requirement is a *scheduler-driven* fractional-GPU platform.)
 
 ---
 

--- a/misc/website/docs/skills/ecs/ecs-genai/references/use-cases.md
+++ b/misc/website/docs/skills/ecs/ecs-genai/references/use-cases.md
@@ -1,0 +1,112 @@
+---
+title: "Worked Use Cases — GPU / ML on Amazon ECS"
+description: ""
+custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/use-cases.md
+format: md
+---
+
+:::info[Source]
+This page is generated from [skills/ecs-genai/references/use-cases.md](https://github.com/aws-samples/sample-apex-skills/blob/main/skills/ecs-genai/references/use-cases.md). Edit the source, not this page.
+:::
+
+# Worked Use Cases — GPU / ML on Amazon ECS
+
+Four condensed scenarios. Each gives: customer profile, the ECS-specific decisions, and a build path. All keep the first-class constraint in view — **GPU is never on Fargate**.
+
+---
+
+## Use Case 1 — Single-Model LLM Inference on ECS-on-EC2
+
+**Profile:** Team already runs services on ECS (non-AI). Wants to self-host an open Transformer LLM (Llama/Mistral/Qwen) for a product feature. Balanced cost, no strong hardware preference, no Kubernetes appetite.
+
+**ECS-specific decisions:**
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| D1 Host | ECS-on-EC2 (or Managed Instances) | Fargate has no GPU |
+| D2 Accelerator | g6e (NVIDIA L40S) for 7B–13B; evaluate Inf2 as phase-2 cost play | Broad ecosystem first; Neuron savings later |
+| D3 Capacity | One capacity-provider ASG for the g6e type + service capacity-provider strategy | ASGs must be homogeneous (no instance weighting) |
+| D4 Shape | Single GPU task behind an ALB; Service Auto Scaling on requests/latency | Standard inference service |
+| Storage | Weights in S3, pulled at task start | Decoupled model/image release ([storage.md](storage)) |
+| Observability | Container Insights **enhanced** (DCGM GPU metrics) + serving-engine latency metric | Enable enhanced — basic has no GPU metrics ([observability.md](observability)) |
+| Security | Task role → S3 (prefix-scoped); private subnet + S3/ECR VPC endpoints; ECR scanning | Baseline ([security-and-compliance.md](security-and-compliance)) |
+
+**Build path:** stand up the g6e capacity provider + service; validate the model + a generous health-check grace period; wire enhanced Container Insights + latency-based Service Auto Scaling; harden (task role, secrets, private subnets, image scanning); then run a g6e-vs-inf2 cost comparison and migrate to Neuron if the savings justify the compilation ramp.
+
+**Route out if:** the team wants scale-to-zero or fractional-GPU multi-model packing → `eks-genai`; or a fully-managed endpoint → SageMaker.
+
+---
+
+## Use Case 2 — Distributed Multi-Node Training on ECS
+
+**Profile:** Team fine-tuning / pre-training a 7B–70B Transformer across multiple GPU nodes. Cost-conscious. PyTorch + Ray. No Kubernetes platform team.
+
+**ECS-specific decisions:**
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| D1 Host | ECS-on-EC2 | Custom AMI/kernel + EFA control; not Fargate |
+| D2 Accelerator | p4d/p5 (GPU) or trn1/trn2 (Neuron) | Model-family + cost dependent |
+| D3 Capacity | One homogeneous ASG of the chosen type in a **cluster placement group**; **Capacity Blocks for ML** for guaranteed multi-day capacity | UltraCluster + EFA; capacity assurance ([capacity-and-scaling.md](capacity-and-scaling)) |
+| D4 Shape | Ray head + worker tasks (DDP/FSDP); EFA + NCCL in the image | AWS-documented ECS distributed-training pattern |
+| Storage | FSx for Lustre same-AZ + S3 DRA for checkpoints | Fast I/O; durable offload ([distributed-training.md](distributed-training)) |
+
+**Build path:** reserve capacity (Capacity Blocks) into a placement-group ASG; validate single-node training + Neuron compilation (if Trn); wire checkpoint→FSx→S3 every 15–30 min; scale to multi-node and confirm EFA/NCCL throughput; run with Spot only on interruption-tolerant phases with checkpoint/resume.
+
+**Route out if:** the team needs gang scheduling / a multi-tenant training platform → `eks-genai`; or fully-managed large-scale training → SageMaker HyperPod.
+
+---
+
+## Use Case 3 — Cost-Optimized Inference via Neuron Migration on ECS
+
+**Profile:** Production inference on ECS using g5/g6 GPUs, steady high-volume traffic, cost-first. Models are Transformer-family. Considering Inf2.
+
+**ECS-specific decisions:**
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| D2 Accelerator | Add Inf2 alongside existing GPU | Cost-optimized for supported models |
+| D3 Capacity | New Inf2 capacity provider/ASG beside the GPU one; blend via capacity-provider strategy during canary | Separate homogeneous ASGs; shift weight gradually |
+| Neuron | Managed device allocation (`NeuronDevice: ALL`) on Managed Instances, or manual `linuxParameters.devices` on EC2 | ([neuron-on-ecs.md](neuron-on-ecs)) |
+| Compilation | Pre-compile offline, ship artifact via S3 | Never compile at task start |
+
+**Build path:** verify the model architecture is Neuron-supported; compile offline (budget 1–2 weeks for the first model); deploy an Inf2 service; run an eval suite comparing GPU vs Neuron output quality; canary traffic 5%→100% by shifting the capacity-provider-strategy weights; decommission the GPU pool; document the compilation pipeline for future model versions.
+
+**Risk callouts:** compilation ramp adds lead time to each new model version; not all HF models are Neuron-supported; validate output parity before shifting production traffic.
+
+---
+
+## Use Case 4 — Shared GPU Dev Cluster on ECS
+
+**Profile:** A data-science team wants several people to share a couple of GPU instances for experimentation. Cost-sensitive; isolation not critical.
+
+**ECS-specific decisions:**
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| D1 Host | ECS-on-EC2, g5/g6 | Not Fargate |
+| Sharing | Remove GPU `resourceRequirements`; set `nvidia` as default Docker runtime via user data; set `NVIDIA_VISIBLE_DEVICES` per container | The only ECS GPU-sharing path ([compute-hardware.md](compute-hardware)) |
+| Guardrail | **Dev/test only — no memory/compute isolation** | One container can starve/OOM others |
+
+**Build path:** launch a small g5/g6 ASG with the default-runtime user data; publish task-definition templates with `NVIDIA_VISIBLE_DEVICES` set; document the no-isolation caveat.
+
+**Route out if:** the team needs isolated fractional GPUs (MIG / time-slicing with per-slice memory / DRA) → `eks-genai`; or managed notebooks/experiments → SageMaker Studio.
+
+---
+
+## Pattern Summary
+
+| Scenario | Primary lever | Key ECS-specific gotcha |
+|---|---|---|
+| Single-model inference | Right-size GPU family; enhanced Container Insights | Health-check grace period for model warmup |
+| Distributed training | Capacity Blocks + EFA + placement group | One homogeneous ASG; checkpoint or lose Spot progress |
+| Neuron migration | Neuron over GPU for supported models | Pre-compile offline; verify model support + output parity |
+| Shared GPU dev | GPU sharing via default runtime | No isolation — dev/test only |
+
+## Sources
+
+- [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html) · [ECS Neuron ML workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html)
+- [Distributed machine learning with Amazon ECS](https://aws.amazon.com/blogs/containers/distributed-machine-learning-with-amazon-ecs/)
+- [EC2 Capacity Blocks for ML](https://aws.amazon.com/ec2/capacityblocks/)
+- [Amazon ECS capacity providers for EC2 workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)
+- [Monitoring Amazon ECS Managed Instances (GPU / DCGM)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/monitoring-managed-instances.html)

--- a/misc/website/docs/skills/index.md
+++ b/misc/website/docs/skills/index.md
@@ -19,7 +19,7 @@ description: "Browse all APEX skills for AWS platform engineering — EKS archit
 ## ECS Skills
 
 <table>
-<tr><td><a href="./ecs/ecs-architect/"><b>ecs-architect</b></a></td><td><a href="./ecs/ecs-operation-review/"><b>ecs-operation-review</b></a></td><td><a href="./ecs/ecs-security/"><b>ecs-security</b></a></td></tr>
+<tr><td><a href="./ecs/ecs-architect/"><b>ecs-architect</b></a></td><td><a href="./ecs/ecs-genai/"><b>ecs-genai</b></a></td><td><a href="./ecs/ecs-operation-review/"><b>ecs-operation-review</b></a></td><td><a href="./ecs/ecs-security/"><b>ecs-security</b></a></td></tr>
 </table>
 
 ## General

--- a/misc/website/static/manifests/skills.json
+++ b/misc/website/static/manifests/skills.json
@@ -6,6 +6,12 @@
     "group": "ecs"
   },
   {
+    "name": "ecs-genai",
+    "description": "Use whenever someone runs a GPU / ML / GenAI / LLM workload on Amazon ECS — GPU on ECS, ECS GPU-optimized AMI, g4dn/g5/g6/p4/p5 on ECS, which ECS launch type for GPU, Inferentia/Trainium/Neuron on ECS, distributed training on ECS, model inference on ECS, Capacity Blocks for ECS, GPU sharing, or ASG per GPU type. Covers GPU compute on ECS-on-EC2 and ECS Managed Instances (GPU-optimized AMIs, NVIDIA runtime, instance families); the capacity pattern where mixed-instance ASGs are supported but constrained (no weighting; managed scaling protects on the smallest type, so one homogeneous ASG per GPU type is best practice); Capacity Blocks; inference/serving; Neuron; distributed ML; GPU observability; a GPU/ML security slice. AWS Fargate has NO GPU — use ECS-on-EC2, Managed Instances, or ECS Anywhere. Trigger even if GenAI is unsaid. Use eks-genai for Kubernetes/EKS; SageMaker for fully-managed ML; Bedrock for managed foundation models; ecs-architect for non-accelerator ECS design; ecs-security for deep compliance.",
+    "path": "/docs/skills/ecs/ecs-genai",
+    "group": "ecs"
+  },
+  {
     "name": "ecs-operation-review",
     "description": "Run a structured Amazon ECS operational-excellence assessment against a live estate and score it GREEN/AMBER/RED. Skip for EKS/Kubernetes (use eks-operation-review). Covers 8 domains — clusters & capacity, networking, task definitions, services & deployment safety (circuit breaker, blue/green, canary), service health & autoscaling (grace period, draining, AZ rebalancing), observability, security posture, and operational processes — producing a rated report with prioritized actions. Activate for \"audit my ECS estate\", \"ECS health check\", \"score my ECS posture\", \"review my ECS services\", \"GREEN/AMBER/RED my ECS clusters\", including section-scoped reviews of a single domain. For Day-0 design/selection use ecs-architect; for deep security hardening use ecs-security; for cost/TCO use ecs-cost-intelligence; for observability design use ecs-observability; for CI/CD engineering use ecs-devops; for replatform/refactor use ecs-modernize; for read-only inventory/discovery use ecs-recon (siblings once available).",
     "path": "/docs/skills/ecs/ecs-operation-review",

--- a/skills/README.md
+++ b/skills/README.md
@@ -335,6 +335,27 @@ Use when choosing and architecting an Amazon ECS deployment model for a NEW work
 
 ---
 
+### [ecs-genai](./ecs-genai/)
+
+Use whenever someone runs a GPU / ML / GenAI / LLM workload on Amazon ECS — GPU on ECS, ECS GPU-optimized AMI, g4dn/g5/g6/p4/p5 on ECS, which ECS launch type for GPU, Inferentia/Trainium/Neuron on ECS, distributed training on ECS, model inference on ECS, Capacity Blocks for ECS, GPU sharing, or ASG per GPU type. Covers GPU compute on ECS-on-EC2 and ECS Managed Instances (GPU-optimized AMIs, NVIDIA runtime, instance families); the capacity pattern where mixed-instance ASGs are supported but constrained (no weighting; managed scaling protects on the smallest type, so one homogeneous ASG per GPU type is best practice); Capacity Blocks; inference/serving; Neuron; distributed ML; GPU observability; a GPU/ML security slice. AWS Fargate has NO GPU — use ECS-on-EC2, Managed Instances, or ECS Anywhere. Trigger even if GenAI is unsaid. Use eks-genai for Kubernetes/EKS; SageMaker for fully-managed ML; Bedrock for managed foundation models; ecs-architect for non-accelerator ECS design; ecs-security for deep compliance.
+
+**References** (loaded on demand):
+
+| Reference | Description |
+|-----------|-------------|
+| [capacity-and-scaling.md](./ecs-genai/references/capacity-and-scaling.md) | Capacity and scaling |
+| [compute-hardware.md](./ecs-genai/references/compute-hardware.md) | Compute hardware |
+| [distributed-training.md](./ecs-genai/references/distributed-training.md) | Distributed training |
+| [inference-serving.md](./ecs-genai/references/inference-serving.md) | Inference serving |
+| [neuron-on-ecs.md](./ecs-genai/references/neuron-on-ecs.md) | Neuron on ecs |
+| [observability.md](./ecs-genai/references/observability.md) | Observability |
+| [security-and-compliance.md](./ecs-genai/references/security-and-compliance.md) | Security and compliance |
+| [service-boundaries.md](./ecs-genai/references/service-boundaries.md) | Service boundaries |
+| [storage.md](./ecs-genai/references/storage.md) | Storage |
+| [use-cases.md](./ecs-genai/references/use-cases.md) | Use cases |
+
+---
+
 ### [ecs-operation-review](./ecs-operation-review/)
 
 Run a structured Amazon ECS operational-excellence assessment against a live estate and score it GREEN/AMBER/RED. Skip for EKS/Kubernetes (use eks-operation-review). Covers 8 domains — clusters & capacity, networking, task definitions, services & deployment safety (circuit breaker, blue/green, canary), service health & autoscaling (grace period, draining, AZ rebalancing), observability, security posture, and operational processes — producing a rated report with prioritized actions. Activate for "audit my ECS estate", "ECS health check", "score my ECS posture", "review my ECS services", "GREEN/AMBER/RED my ECS clusters", including section-scoped reviews of a single domain. For Day-0 design/selection use ecs-architect; for deep security hardening use ecs-security; for cost/TCO use ecs-cost-intelligence; for observability design use ecs-observability; for CI/CD engineering use ecs-devops; for replatform/refactor use ecs-modernize; for read-only inventory/discovery use ecs-recon (siblings once available).

--- a/skills/ecs-genai/SKILL.md
+++ b/skills/ecs-genai/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: ecs-genai
+description: Use whenever someone is running a GPU / ML / GenAI / LLM workload on Amazon ECS — phrased as "GPU on ECS", "ECS GPU-optimized AMI", "g4dn/g5/g6/p4/p5 on ECS", "which ECS launch type for GPU", "Inferentia/Trainium/Neuron on ECS", "distributed training on ECS", "model inference container on ECS", "Capacity Blocks for ECS", "GPU sharing on ECS", or "separate ASG per GPU type". Covers GPU compute on ECS-on-EC2 (GPU-optimized AMIs, NVIDIA container runtime, instance families), the separate-ASG-per-GPU-type capacity-provider pattern (ECS capacity providers cannot use mixed-instance ASGs), EC2 Capacity Blocks for ML, container inference/serving, Neuron on ECS, distributed ML, GPU observability, and a security baseline. First-class constraint: AWS Fargate has NO GPU support — GPU is ECS-on-EC2 (or ECS Managed Instances / ECS Anywhere) only. Trigger even if "GenAI" is never said — any GPU, accelerator, inference-serving, or ML-training decision on ECS qualifies. Use eks-genai for Kubernetes/EKS; SageMaker for fully-managed ML training/hosting; Bedrock for managed foundation models with no self-hosting. For generic ECS launch-type/design with no accelerator or ML workload use ecs-architect.
+---
+
+# GenAI / GPU / ML Workloads on Amazon ECS
+
+End-to-end opinionated guidance for running GPU-accelerated, ML-training, and GenAI inference workloads on **Amazon ECS-on-EC2**. This skill is scoped to the compute-and-capacity mechanics that are unique to ECS: the GPU-optimized AMI + NVIDIA container runtime, the **separate-ASG-per-GPU-type capacity-provider pattern** (ECS capacity providers cannot use mixed-instance-type Auto Scaling groups), EC2 Capacity Blocks for ML, AWS Neuron (Inferentia/Trainium) on ECS, container inference/serving, distributed ML, and accelerator observability.
+
+**The single most important constraint, stated first: AWS Fargate has no GPU support.** GPUs and AWS accelerators (Inferentia/Trainium) are available only on **ECS-on-EC2**, **ECS Managed Instances**, and **ECS Anywhere/External** — never on Fargate. Every GPU/ML answer on ECS begins by ruling Fargate out for the accelerated container. See [service-boundaries.md](references/service-boundaries.md) for the exact evidence and the "use EKS / SageMaker / Bedrock instead" routing.
+
+For "which ECS launch model should I use" with no accelerator or ML workload, use `ecs-architect`. For Kubernetes-based GenAI, use `eks-genai`. This skill is the GPU/ML *workload* layer on ECS specifically.
+
+## When to Use This Skill
+
+**Activate when the user wants to:**
+- Run a GPU workload on ECS — choose an instance family (g4dn/g5/g6/g6e/p3/p4d/p5), the ECS GPU-optimized AMI, and the NVIDIA container runtime
+- Serve an LLM / model inference container on ECS, or run ML training/fine-tuning on ECS
+- Design GPU capacity on ECS at scale — the separate-ASG-per-GPU-type + capacity-provider-strategy pattern, Managed Instances, Spot, and Capacity Blocks for ML
+- Use AWS Neuron (Inferentia/Trainium) on ECS — device allocation, compilation, Inf/Trn instance selection
+- Wire GPU/accelerator observability (Container Insights enhanced / DCGM) on ECS
+- Decide **when NOT to use ECS** — when EKS (`eks-genai`), SageMaker, or Bedrock is the better home
+
+**Don't use this skill for:**
+- **Kubernetes / EKS GenAI** (Karpenter, KubeRay, JARK, device plugins, vLLM-on-EKS) → `eks-genai`
+- **Fully-managed ML training or model hosting** with no container orchestration to own → **Amazon SageMaker** (training jobs, endpoints, HyperPod)
+- **Managed foundation-model API with no self-hosting** (no GPU to manage) → **Amazon Bedrock**
+- **Generic ECS launch-type selection / cluster design** with no accelerator or ML workload → `ecs-architect`
+- **Deep Neuron kernel / NKI / model-porting** work → the Neuron-specific skills, not this one
+- Any assumption that **Fargate can run a GPU** — it cannot; do not design around it
+
+## The ECS-GPU Decision Framework
+
+Walk the customer through five decisions, top to bottom. Depth for each is in the references.
+
+```text
+D1  Compute host      ECS-on-EC2 · ECS Managed Instances · ECS Anywhere   (NEVER Fargate for GPU)
+D2  Accelerator       NVIDIA GPU (g4dn/g5/g6/g6e/p3/p4d/p5) · AWS Neuron (Inf2/Trn1/Trn2)
+D3  Capacity model    separate ASG per GPU type + capacity-provider strategy · Managed Instances · Capacity Blocks · Spot
+D4  Workload shape    single-container inference · distributed multi-node training · GPU-shared dev
+D5  Boundary check    stay on ECS · or route to eks-genai / SageMaker / Bedrock
+```
+
+### D1 — Compute host: Fargate is out for GPU (first-class caveat)
+
+**AWS Fargate cannot run GPU or AWS-accelerator workloads.** AWS lists the `gpu` parameter among the task-definition parameters that are **"not valid in Fargate tasks"** (alongside `devices` and `placementConstraints`), and the Fargate task-size model exposes only CPU and memory — valid task sizes run from 256 (.25 vCPU) up to 32768 (32 vCPU), with no GPU dimension at all ([ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)). The `resourceRequirements` `GPU` type and `NeuronDevice` allocation are container-instance (EC2) concepts only. GPU is supported on:
+
+- **ECS-on-EC2** — you own the Auto Scaling group and the GPU-optimized AMI; full control (custom AMI/kernel, EFA, multi-node). The default for training and demanding inference.
+- **ECS Managed Instances** — AWS provisions/patches the EC2 lifecycle for you; supports GPU (e.g. `g4dn`, `g5`, `p3`, `p4d`) with pre-installed NVIDIA drivers + CUDA, and the managed Neuron device-allocation path ([Use GPUs with ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)). GA Sept 2025, all commercial Regions Oct 2025.
+- **ECS Anywhere / External** — on-prem/hybrid GPU hosts registered with `--enable-gpu`.
+
+Also note: **GPUs are not supported on Windows containers on ECS** ([ECS GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)). Details: [compute-hardware.md](references/compute-hardware.md).
+
+### D2 — Accelerator: NVIDIA GPU vs AWS Neuron
+
+- **NVIDIA GPU** (g4dn/g5/g6/g6e inference; p3/p4d/p5 training) — broadest ecosystem, CUDA, fastest time-to-first-success, multi-modal/novel architectures. The ECS GPU-optimized AMI ships NVIDIA kernel drivers + the NVIDIA Docker runtime pre-installed.
+- **AWS Neuron** (Inf2 inference; Trn1/Trn2 training; Inf1 legacy, EC2 launch type only) — cost-optimized for supported Transformer-family models on the ECS Neuron-optimized AL2023 AMI, at the price of a compilation ramp. Details: [compute-hardware.md](references/compute-hardware.md), [neuron-on-ecs.md](references/neuron-on-ecs.md).
+
+Do not synthesize per-chip specs — cite the ECS GPU/Neuron doc tables. Right accelerator = f(model family × latency × cost posture × team skill × timeline).
+
+### D3 — Capacity: the separate-ASG-per-GPU-type pattern (the ECS-specific crux)
+
+This is where ECS diverges hardest from EKS. **An ECS capacity-provider Auto Scaling group can't have instance weighting settings** ([ECS capacity providers for EC2](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)), and cluster auto scaling behaves predictably only when an ASG's instances are homogeneous. The consequence: **use one ASG (and one capacity provider) per GPU instance type**, and blend them with a **capacity-provider strategy** rather than stuffing mixed GPU types into a single mixed-instance ASG. There is no Karpenter equivalent on native ECS. Details: [capacity-and-scaling.md](references/capacity-and-scaling.md).
+
+For scarce accelerator capacity, use **EC2 Capacity Blocks for ML** (reserve P/Trn UltraCluster capacity for a future window); for cost, layer Spot only on interruption-tolerant work with checkpoint/resume. Managed Instances offers an AWS-managed alternative to hand-rolled ASGs.
+
+### D4 — Workload shape
+
+- **Single-container inference** — GPU task with `resourceRequirements` type `GPU`; model weights from S3/EFS. [inference-serving.md](references/inference-serving.md).
+- **Distributed multi-node training** — placement groups + EFA + NCCL; Ray Train / PyTorch on ECS. [distributed-training.md](references/distributed-training.md).
+- **GPU sharing for dev** — ECS pins whole GPUs by default; sharing is coarse (see the caveat below). [compute-hardware.md](references/compute-hardware.md).
+
+### D5 — Boundary check
+
+If the answer is "Kubernetes," "fully-managed training/hosting," or "no self-hosting at all," route out. [service-boundaries.md](references/service-boundaries.md).
+
+## GPU Sharing on ECS — State the Limit Precisely
+
+ECS, by default, **pins whole physical GPUs to containers** — the scheduler assigns the number of GPUs in `resourceRequirements` and sets `NVIDIA_VISIBLE_DEVICES` accordingly ([ECS GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)). Native ECS has **no MIG-partitioning or time-slicing-replica scheduler primitive** like the EKS NVIDIA device plugin. To share a GPU across ECS tasks you must **remove the GPU `resourceRequirements`** from the task definitions and make `nvidia` the **default Docker runtime** on the instance via user data, then set `NVIDIA_VISIBLE_DEVICES` per container — a manual, unisolated pattern suitable for dev/test only (no memory isolation between co-located containers). If the customer needs first-class fractional-GPU scheduling (MIG, time-slicing, DRA), that is an argument for **EKS (`eks-genai`)** or SageMaker. Details: [compute-hardware.md](references/compute-hardware.md).
+
+## Security Baseline (non-negotiable)
+
+Every GPU/ML-on-ECS recommendation MUST include: **task role + execution role least-privilege** (never static keys in the image/env); **secrets via Secrets Manager / SSM Parameter Store** injected into the task definition (never baked into the model image); **ECR image scanning** (DLC/CUDA/Neuron images carry huge CVE surfaces); **model-artifact provenance** (checksum/signing; pin exact model revisions); **private subnets + VPC endpoints** (S3 for weights, ECR, Secrets Manager, Bedrock-runtime if used) for GPU instances; **CloudTrail + Container Insights** audit; and **GuardDuty ECS Runtime Monitoring** on the EC2 hosts. Details: [security-and-compliance.md](references/security-and-compliance.md).
+
+## Cost Optimization
+
+Levers in priority order: (1) **Capacity Blocks for ML** for planned multi-day training (capacity assurance, not a fixed discount); (2) **Neuron over GPU** for supported Transformer models (compilation ramp, verify support first); (3) **Spot + checkpoint/resume** for fault-tolerant training only; (4) **right-size the GPU instance family** to the model (over-provisioning GPUs is a top cost mistake); (5) **cluster auto scaling / Managed Instances consolidation** for off-peak inference; (6) **share GPUs for dev** (dev/test only). Always give directional ranges with caveats — never point estimates. Details: [capacity-and-scaling.md](references/capacity-and-scaling.md).
+
+## Top Guardrails (the high-cost mistakes)
+
+- **Never design a GPU workload on Fargate** — it has no GPU; use ECS-on-EC2 / Managed Instances / Anywhere.
+- **Don't put mixed GPU instance types in one capacity-provider ASG** — one ASG per GPU type + capacity-provider strategy (no instance weighting allowed).
+- **Don't assume native ECS has MIG/time-slicing** — GPU sharing is coarse and dev/test only; fractional GPU → EKS/SageMaker.
+- **Don't compile Neuron models at task startup** — pre-compile offline, ship the artifact via S3/image.
+- **Don't run distributed multi-node training without EFA + placement groups** — bandwidth collapses to TCP.
+- **Don't use Spot for training without checkpoint/resume**, or for latency-SLA inference.
+- **Don't skip the security baseline** — task-role trust, secrets, private subnets, image scanning, provenance.
+- **Don't give point cost estimates** — directional ranges with caveats only.
+- **Don't synthesize accelerator specs** — cite the ECS GPU/Neuron doc tables.
+
+## How to Use the References
+
+Progressive disclosure — the essentials are above; load a reference only when the task needs that depth:
+
+| Reference | Load when the task is about… |
+|-----------|------------------------------|
+| [compute-hardware.md](references/compute-hardware.md) | GPU instance families, GPU-optimized AMI, NVIDIA runtime, GPU sharing limits, capacity planning |
+| [capacity-and-scaling.md](references/capacity-and-scaling.md) | Separate-ASG-per-GPU-type, capacity-provider strategy, cluster auto scaling, Managed Instances, Capacity Blocks, Spot |
+| [inference-serving.md](references/inference-serving.md) | Model inference containers on ECS, serving engines, model loading, autoscaling inference services |
+| [distributed-training.md](references/distributed-training.md) | Multi-node GPU/Neuron training, EFA + placement groups, NCCL, Ray Train on ECS, checkpointing |
+| [neuron-on-ecs.md](references/neuron-on-ecs.md) | Inferentia/Trainium on ECS, Neuron device allocation (managed vs manual), compilation, Inf/Trn selection |
+| [storage.md](references/storage.md) | Model artifact handling, S3, EFS, FSx for Lustre, checkpoints, container image size |
+| [observability.md](references/observability.md) | Container Insights enhanced (DCGM), GPU/EFA/Neuron metrics, CloudWatch, alerting |
+| [security-and-compliance.md](references/security-and-compliance.md) | Task/execution-role trust, secrets, private subnets, ECR scanning, provenance, GuardDuty, compliance |
+| [service-boundaries.md](references/service-boundaries.md) | Fargate-GPU exclusion evidence; when to use eks-genai / SageMaker / Bedrock / ecs-architect instead |
+| [use-cases.md](references/use-cases.md) | Worked end-to-end scenarios (inference, distributed training, Neuron migration, GPU dev-sharing) with build paths |
+
+## Sources
+
+- [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html) · [ECS task definitions for AWS Neuron ML workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html) · [Use GPUs with ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)
+- [ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html) · [ECS capacity providers for EC2 workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html) · [Automatically manage ECS capacity with cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-auto-scaling.html)
+- [EC2 Capacity Blocks for ML](https://aws.amazon.com/ec2/capacityblocks/) · [Capacity Blocks for ML (EC2 User Guide)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html) · [Amazon ECS Managed Instances](https://aws.amazon.com/ecs/managed-instances/)
+- [Amazon ECS Best Practices Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-best-practices.html) · [Monitoring ECS Managed Instances (GPU / DCGM)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/monitoring-managed-instances.html)
+- [Distributed machine learning with Amazon ECS](https://aws.amazon.com/blogs/containers/distributed-machine-learning-with-amazon-ecs/) · [Using Amazon ECS with NVIDIA GPUs to accelerate drug discovery](https://aws.amazon.com/blogs/containers/using-amazon-ecs-with-nvidia-gpus-to-accelerate-drug-discovery/) · [Running GPU-based container applications with ECS Anywhere](https://aws.amazon.com/blogs/containers/running-gpu-based-container-applications-with-amazon-ecs-anywhere/)

--- a/skills/ecs-genai/SKILL.md
+++ b/skills/ecs-genai/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: ecs-genai
-description: Use whenever someone is running a GPU / ML / GenAI / LLM workload on Amazon ECS — phrased as "GPU on ECS", "ECS GPU-optimized AMI", "g4dn/g5/g6/p4/p5 on ECS", "which ECS launch type for GPU", "Inferentia/Trainium/Neuron on ECS", "distributed training on ECS", "model inference container on ECS", "Capacity Blocks for ECS", "GPU sharing on ECS", or "separate ASG per GPU type". Covers GPU compute on ECS-on-EC2 (GPU-optimized AMIs, NVIDIA container runtime, instance families), the separate-ASG-per-GPU-type capacity-provider pattern (ECS capacity providers cannot use mixed-instance ASGs), EC2 Capacity Blocks for ML, container inference/serving, Neuron on ECS, distributed ML, GPU observability, and a security baseline. First-class constraint: AWS Fargate has NO GPU support — GPU is ECS-on-EC2 (or ECS Managed Instances / ECS Anywhere) only. Trigger even if "GenAI" is never said — any GPU, accelerator, inference-serving, or ML-training decision on ECS qualifies. Use eks-genai for Kubernetes/EKS; SageMaker for fully-managed ML training/hosting; Bedrock for managed foundation models with no self-hosting. For generic ECS launch-type/design with no accelerator or ML workload use ecs-architect.
+description: "Use whenever someone runs a GPU / ML / GenAI / LLM workload on Amazon ECS — GPU on ECS, ECS GPU-optimized AMI, g4dn/g5/g6/p4/p5 on ECS, which ECS launch type for GPU, Inferentia/Trainium/Neuron on ECS, distributed training on ECS, model inference on ECS, Capacity Blocks for ECS, GPU sharing, or ASG per GPU type. Covers GPU compute on ECS-on-EC2 and ECS Managed Instances (GPU-optimized AMIs, NVIDIA runtime, instance families); the capacity pattern where mixed-instance ASGs are supported but constrained (no weighting; managed scaling protects on the smallest type, so one homogeneous ASG per GPU type is best practice); Capacity Blocks; inference/serving; Neuron; distributed ML; GPU observability; a GPU/ML security slice. AWS Fargate has NO GPU — use ECS-on-EC2, Managed Instances, or ECS Anywhere. Trigger even if GenAI is unsaid. Use eks-genai for Kubernetes/EKS; SageMaker for fully-managed ML; Bedrock for managed foundation models; ecs-architect for non-accelerator ECS design; ecs-security for deep compliance."
 ---
+
+<!-- Note: ecs-genai intentionally ships no `apex:ecs-genai` steering command (eks-genai has one). This is an omission, not by design — steering-command wiring is deferred repo-wide, so it is left unwired for now to match the rest of the ECS skills. Freshness: instance/spec claims verified against live AWS docs 2026-07-09. -->
 
 # GenAI / GPU / ML Workloads on Amazon ECS
 
-End-to-end opinionated guidance for running GPU-accelerated, ML-training, and GenAI inference workloads on **Amazon ECS-on-EC2**. This skill is scoped to the compute-and-capacity mechanics that are unique to ECS: the GPU-optimized AMI + NVIDIA container runtime, the **separate-ASG-per-GPU-type capacity-provider pattern** (ECS capacity providers cannot use mixed-instance-type Auto Scaling groups), EC2 Capacity Blocks for ML, AWS Neuron (Inferentia/Trainium) on ECS, container inference/serving, distributed ML, and accelerator observability.
+End-to-end opinionated guidance for running GPU-accelerated, ML-training, and GenAI inference workloads on **Amazon ECS-on-EC2**. This skill is scoped to the compute-and-capacity mechanics that are unique to ECS: the GPU-optimized AMI + NVIDIA container runtime, the **one-homogeneous-ASG-per-GPU-type capacity-provider pattern** — cluster auto scaling *supports* multiple instance types in one ASG, but managed scaling has no instance weighting and bin-packs and protects on the **smallest** instance type, so mixing GPU types (with different GPU counts / VRAM) breaks the scaling math; one homogeneous ASG per GPU type is therefore the best practice, not a hard limit — plus EC2 Capacity Blocks for ML, AWS Neuron (Inferentia/Trainium) on ECS, container inference/serving, distributed ML, and accelerator observability.
 
 **The single most important constraint, stated first: AWS Fargate has no GPU support.** GPUs and AWS accelerators (Inferentia/Trainium) are available only on **ECS-on-EC2**, **ECS Managed Instances**, and **ECS Anywhere/External** — never on Fargate. Every GPU/ML answer on ECS begins by ruling Fargate out for the accelerated container. See [service-boundaries.md](references/service-boundaries.md) for the exact evidence and the "use EKS / SageMaker / Bedrock instead" routing.
 
@@ -18,7 +20,7 @@ For "which ECS launch model should I use" with no accelerator or ML workload, us
 - Serve an LLM / model inference container on ECS, or run ML training/fine-tuning on ECS
 - Design GPU capacity on ECS at scale — the separate-ASG-per-GPU-type + capacity-provider-strategy pattern, Managed Instances, Spot, and Capacity Blocks for ML
 - Use AWS Neuron (Inferentia/Trainium) on ECS — device allocation, compilation, Inf/Trn instance selection
-- Wire GPU/accelerator observability (Container Insights enhanced / DCGM) on ECS
+- Wire GPU/accelerator observability on ECS — agentless DCGM metrics via Container Insights enhanced observability are **Managed-Instances-only**; the EC2 launch type needs the CloudWatch agent (`nvidia_smi`, host-level) or a DCGM exporter for per-task metrics
 - Decide **when NOT to use ECS** — when EKS (`eks-genai`), SageMaker, or Bedrock is the better home
 
 **Don't use this skill for:**
@@ -27,6 +29,7 @@ For "which ECS launch model should I use" with no accelerator or ML workload, us
 - **Managed foundation-model API with no self-hosting** (no GPU to manage) → **Amazon Bedrock**
 - **Generic ECS launch-type selection / cluster design** with no accelerator or ML workload → `ecs-architect`
 - **Deep Neuron kernel / NKI / model-porting** work → the Neuron-specific skills, not this one
+- **Deep ECS security / regulated-compliance baseline** (PCI/HIPAA/FedRAMP CDE design, org-wide guardrails, threat modeling) → `ecs-security`; this skill carries only the GPU/ML-specific security slice
 - Any assumption that **Fargate can run a GPU** — it cannot; do not design around it
 
 ## The ECS-GPU Decision Framework
@@ -46,7 +49,7 @@ D5  Boundary check    stay on ECS · or route to eks-genai / SageMaker / Bedrock
 **AWS Fargate cannot run GPU or AWS-accelerator workloads.** AWS lists the `gpu` parameter among the task-definition parameters that are **"not valid in Fargate tasks"** (alongside `devices` and `placementConstraints`), and the Fargate task-size model exposes only CPU and memory — valid task sizes run from 256 (.25 vCPU) up to 32768 (32 vCPU), with no GPU dimension at all ([ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)). The `resourceRequirements` `GPU` type and `NeuronDevice` allocation are container-instance (EC2) concepts only. GPU is supported on:
 
 - **ECS-on-EC2** — you own the Auto Scaling group and the GPU-optimized AMI; full control (custom AMI/kernel, EFA, multi-node). The default for training and demanding inference.
-- **ECS Managed Instances** — AWS provisions/patches the EC2 lifecycle for you; supports GPU (e.g. `g4dn`, `g5`, `p3`, `p4d`) with pre-installed NVIDIA drivers + CUDA, and the managed Neuron device-allocation path ([Use GPUs with ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)). GA Sept 2025, all commercial Regions Oct 2025.
+- **ECS Managed Instances** — AWS provisions/patches (~every 14 days) the EC2 lifecycle for you; supports GPU (e.g. `g4dn`, `g5`, `p3`, `p4d`) with pre-installed NVIDIA drivers + CUDA ([Use GPUs with ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)), and the managed `NeuronDevice` allocation path ([ECS task definitions for AWS Neuron ML workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html)). GA Sept 2025, all commercial Regions Oct 2025.
 - **ECS Anywhere / External** — on-prem/hybrid GPU hosts registered with `--enable-gpu`.
 
 Also note: **GPUs are not supported on Windows containers on ECS** ([ECS GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)). Details: [compute-hardware.md](references/compute-hardware.md).
@@ -58,11 +61,11 @@ Also note: **GPUs are not supported on Windows containers on ECS** ([ECS GPU wor
 
 Do not synthesize per-chip specs — cite the ECS GPU/Neuron doc tables. Right accelerator = f(model family × latency × cost posture × team skill × timeline).
 
-### D3 — Capacity: the separate-ASG-per-GPU-type pattern (the ECS-specific crux)
+### D3 — Capacity: one homogeneous ASG per GPU type (the ECS-specific crux)
 
-This is where ECS diverges hardest from EKS. **An ECS capacity-provider Auto Scaling group can't have instance weighting settings** ([ECS capacity providers for EC2](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)), and cluster auto scaling behaves predictably only when an ASG's instances are homogeneous. The consequence: **use one ASG (and one capacity provider) per GPU instance type**, and blend them with a **capacity-provider strategy** rather than stuffing mixed GPU types into a single mixed-instance ASG. There is no Karpenter equivalent on native ECS. Details: [capacity-and-scaling.md](references/capacity-and-scaling.md).
+This is where ECS diverges hardest from EKS. ECS cluster auto scaling **does support an Auto Scaling group with multiple instance types**, but the constraints make heterogeneous *GPU* ASGs a trap: **an ECS capacity-provider ASG can't have instance weighting settings** ([ECS capacity providers for EC2](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)), and managed scaling **bin-packs and protects on the smallest instance type in the ASG** — if a group of tasks needs more than the smallest type provides, that group can't run and the tasks stay `PROVISIONING` ([Amazon ECS managed scaling behavior](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-scaling-behavior.html)). Because `resourceRequirements` `GPU` counts GPUs but not VRAM, mixing GPU types (e.g. g5 24 GiB + p4d 40 GiB) also lets ECS place a large-VRAM task onto a small-VRAM instance and OOM at load. The best practice therefore: **use one homogeneous ASG (and one capacity provider) per GPU instance type**, and blend them with a **capacity-provider strategy**. There is no Karpenter equivalent on native ECS. Details: [capacity-and-scaling.md](references/capacity-and-scaling.md).
 
-For scarce accelerator capacity, use **EC2 Capacity Blocks for ML** (reserve P/Trn UltraCluster capacity for a future window); for cost, layer Spot only on interruption-tolerant work with checkpoint/resume. Managed Instances offers an AWS-managed alternative to hand-rolled ASGs.
+For scarce accelerator capacity, use **EC2 Capacity Blocks for ML** (reserve P/Trn UltraCluster capacity for a future window) — a Capacity Block is delivered in a **single Availability Zone**, so restrict the ASG to that AZ's subnet (and co-locate FSx in the same AZ). For assured non-block inference capacity use **On-Demand Capacity Reservations (ODCRs)** or, on Managed Instances, `capacityOptionType: Reserved` with a Capacity Reservation group. For cost, layer Spot only on interruption-tolerant work with checkpoint/resume. Managed Instances offers an AWS-managed alternative to hand-rolled ASGs.
 
 ### D4 — Workload shape
 
@@ -80,7 +83,7 @@ ECS, by default, **pins whole physical GPUs to containers** — the scheduler as
 
 ## Security Baseline (non-negotiable)
 
-Every GPU/ML-on-ECS recommendation MUST include: **task role + execution role least-privilege** (never static keys in the image/env); **secrets via Secrets Manager / SSM Parameter Store** injected into the task definition (never baked into the model image); **ECR image scanning** (DLC/CUDA/Neuron images carry huge CVE surfaces); **model-artifact provenance** (checksum/signing; pin exact model revisions); **private subnets + VPC endpoints** (S3 for weights, ECR, Secrets Manager, Bedrock-runtime if used) for GPU instances; **CloudTrail + Container Insights** audit; and **GuardDuty ECS Runtime Monitoring** on the EC2 hosts. Details: [security-and-compliance.md](references/security-and-compliance.md).
+Every GPU/ML-on-ECS recommendation MUST include: **task role + execution role least-privilege** (never static keys in the image/env); **secrets via Secrets Manager / SSM Parameter Store** injected into the task definition (never baked into the model image); **ECR image scanning** (DLC/CUDA/Neuron images carry huge CVE surfaces); **model-artifact provenance** (checksum/signing; pin exact model revisions); **private subnets + VPC endpoints** (S3 for weights, ECR, Secrets Manager, Bedrock-runtime if used) for GPU instances; **inference-endpoint authentication** (internal vs internet-facing ALB/NLB + auth in front of the model API — see [security-and-compliance.md](references/security-and-compliance.md)); and **CloudTrail + Container Insights** audit. Add **GuardDuty ECS Runtime Monitoring** on **ECS-on-EC2** hosts — but note it is **not supported on ECS Managed Instances, ECS Anywhere, or Windows** ([GuardDuty Runtime Monitoring considerations](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-guard-duty-integration.html)), so an MI-based fleet needs a different runtime-threat control. For the deep, general ECS security baseline and regulated-compliance design, route to **`ecs-security`**; this skill carries only the GPU/ML-specific slice. Details: [security-and-compliance.md](references/security-and-compliance.md).
 
 ## Cost Optimization
 
@@ -89,8 +92,8 @@ Levers in priority order: (1) **Capacity Blocks for ML** for planned multi-day t
 ## Top Guardrails (the high-cost mistakes)
 
 - **Never design a GPU workload on Fargate** — it has no GPU; use ECS-on-EC2 / Managed Instances / Anywhere.
-- **Don't put mixed GPU instance types in one capacity-provider ASG** — one ASG per GPU type + capacity-provider strategy (no instance weighting allowed).
-- **Don't assume native ECS has MIG/time-slicing** — GPU sharing is coarse and dev/test only; fractional GPU → EKS/SageMaker.
+- **Don't mix GPU instance types in one capacity-provider ASG** — it's *allowed* but managed scaling protects on the smallest type and can't weight, so use one homogeneous ASG per GPU type + a capacity-provider strategy.
+- **Don't assume native ECS has a MIG/time-slicing scheduler** — there is no fractional-GPU *scheduler* primitive; hardware-fractional L4 instances (G6f/Gr6f) exist on Managed Instances, but dynamic multi-model GPU packing (MIG/time-slicing/DRA) → EKS/SageMaker.
 - **Don't compile Neuron models at task startup** — pre-compile offline, ship the artifact via S3/image.
 - **Don't run distributed multi-node training without EFA + placement groups** — bandwidth collapses to TCP.
 - **Don't use Spot for training without checkpoint/resume**, or for latency-SLA inference.
@@ -110,7 +113,7 @@ Progressive disclosure — the essentials are above; load a reference only when 
 | [distributed-training.md](references/distributed-training.md) | Multi-node GPU/Neuron training, EFA + placement groups, NCCL, Ray Train on ECS, checkpointing |
 | [neuron-on-ecs.md](references/neuron-on-ecs.md) | Inferentia/Trainium on ECS, Neuron device allocation (managed vs manual), compilation, Inf/Trn selection |
 | [storage.md](references/storage.md) | Model artifact handling, S3, EFS, FSx for Lustre, checkpoints, container image size |
-| [observability.md](references/observability.md) | Container Insights enhanced (DCGM), GPU/EFA/Neuron metrics, CloudWatch, alerting |
+| [observability.md](references/observability.md) | GPU metrics (Container Insights enhanced = MI-only; CloudWatch agent / DCGM exporter on EC2), Neuron metrics, CloudWatch, alerting |
 | [security-and-compliance.md](references/security-and-compliance.md) | Task/execution-role trust, secrets, private subnets, ECR scanning, provenance, GuardDuty, compliance |
 | [service-boundaries.md](references/service-boundaries.md) | Fargate-GPU exclusion evidence; when to use eks-genai / SageMaker / Bedrock / ecs-architect instead |
 | [use-cases.md](references/use-cases.md) | Worked end-to-end scenarios (inference, distributed training, Neuron migration, GPU dev-sharing) with build paths |

--- a/skills/ecs-genai/references/capacity-and-scaling.md
+++ b/skills/ecs-genai/references/capacity-and-scaling.md
@@ -1,0 +1,98 @@
+# Capacity & Scaling — GPU at Scale on Amazon ECS
+
+The mechanics that make ECS-GPU capacity different from EKS. There is **no Karpenter on native ECS** — capacity is Auto Scaling groups + ECS capacity providers, with a hard structural constraint that dictates the whole pattern.
+
+## The Separate-ASG-Per-GPU-Type Pattern (the crux)
+
+**An ECS capacity-provider Auto Scaling group can't have instance weighting settings** ([ECS capacity providers for EC2 workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)). ECS cluster auto scaling drives the ASG via a single `CapacityProviderReservation` target-tracking metric that assumes the instances in that ASG are effectively **homogeneous** — the formula is `(instances needed) / (running instances) × 100` ([Automatically manage ECS capacity with cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-auto-scaling.html)). Mixing heterogeneous GPU types (e.g. g5 + p4d) in one ASG breaks the scaling math and makes task placement non-deterministic.
+
+There is a second, sharper failure mode: **ECS task placement has no native "GPU model / VRAM" attribute** — a `resourceRequirements` `GPU: 1` only counts GPUs, not their memory. If a g4dn (16 GiB, T4) and a g5 (24 GiB, A10G) share one ASG, ECS can place a task needing 24 GiB onto the 16 GiB T4, and the model OOMs at load time. Homogeneous per-type ASGs (pin `allowedInstanceTypes` in the launch template) are what keep placement correct; use a placement constraint on `ecs.instance-type` to steer within a mixed cluster.
+
+**Therefore, the pattern for GPU at scale on native ECS:**
+
+1. **One Auto Scaling group per GPU instance type** (one for g5, one for g6e, one for p4d, …), each homogeneous.
+2. **One ECS capacity provider per ASG**, with **managed scaling** and **managed termination protection** on.
+3. **Blend them with a capacity-provider strategy** on the service — `base`/`weight` to prefer one pool and spill to another, rather than one mixed ASG.
+
+```json
+// Service capacity-provider strategy: prefer g6e for inference, spill to g5
+{
+  "capacityProviderStrategy": [
+    { "capacityProvider": "cp-g6e", "base": 1, "weight": 3 },
+    { "capacityProvider": "cp-g5",  "base": 0, "weight": 1 }
+  ]
+}
+```
+
+Constraints to respect (from the capacity-providers doc):
+- A capacity-provider strategy can specify **at most 20 capacity providers**.
+- At least one capacity provider must have **weight > 0**; only one may set a **base**.
+- A strategy can contain **either** ASG capacity providers **or** Fargate capacity providers — **not both**. (And Fargate can't run GPU anyway.)
+- You **can't switch** a service between an ASG capacity provider and a Fargate capacity provider without recreating/redeploying; moving a service from `launchType` to a capacity-provider strategy requires a **forced new deployment**.
+- Create the empty ASG with **desired = 0**; ECS scales it out via managed scaling.
+
+### Karpenter equivalent? No.
+
+There is no Karpenter for native ECS. The closest "AWS picks the instance" experience is **ECS Managed Instances** (below), or, if the customer truly wants Karpenter-style provisioning, that is an argument for **EKS (`eks-genai`)**.
+
+## ECS Managed Instances — the AWS-managed alternative
+
+Instead of hand-rolling one ASG per GPU type, **ECS Managed Instances** lets AWS provision, configure, patch (every 14 days), scale, and place tasks on optimal EC2 instances, while you declare requirements ([Amazon ECS Managed Instances](https://aws.amazon.com/ecs/managed-instances/)). You still select GPU/accelerator families through the capacity provider's **`instanceRequirements`** launch template (see [compute-hardware.md](compute-hardware.md) and [neuron-on-ecs.md](neuron-on-ecs.md)). Trade-offs:
+
+- **Pro:** No ASG plumbing, no AMI/driver management, faster to stand up, per-type homogeneity handled by AWS.
+- **Con:** A management charge on top of EC2 cost; less control than self-managed EC2 (no custom kernel/AMI). For custom AMI/kernel or the most demanding multi-node EFA training, self-managed ECS-on-EC2 remains the choice.
+- GA Sept 2025; available in all commercial Regions since Oct 2025.
+
+## EC2 Capacity Blocks for ML — securing scarce GPU capacity
+
+GPU capacity is scarce. **EC2 Capacity Blocks for ML** let you reserve accelerated instances for a future window, colocated in EC2 UltraClusters with EFA ([EC2 Capacity Blocks for ML](https://aws.amazon.com/ec2/capacityblocks/)). Verified current facts:
+
+- **Supported instance types** (per the Capacity Blocks page): P6e-GB200, P6-B300, P6-B200, P5en, P5e, P5, and P4d (NVIDIA Blackwell / H200 / H100 / A100), plus **Trn2 and Trn1** (AWS Trainium).
+- **Reservation duration** is 1–14 days, or a multiple of 7 days up to **182 days** (e.g. 21, 28 days); reservable with a start time **up to 8 weeks in advance**. Each Capacity Block can have **up to 64 instances**, and **up to 256 instances across Capacity Blocks** ([How Capacity Blocks work](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-blocks-how.html)). Instance Capacity Blocks are shareable across accounts (UltraServer Capacity Blocks are not).
+- **Pricing = reservation fee + OS fee.** AWS publishes **no fixed discount vs on-demand** — the value is **guaranteed capacity assurance**, not a headline discount. Do not claim a percentage saving.
+- Best for: planned pre-training/fine-tuning runs, benchmark campaigns, guaranteed-capacity demos. Not for elastic inference (Capacity Blocks don't autoscale).
+
+Use with ECS by launching the reserved instances into a **self-managed GPU ASG capacity provider** for the reservation window: create the ASG's launch template to target the Capacity Block reservation, and — because managed scaling doesn't know the block's expiration — **schedule scale-up at the block start** (Auto Scaling scheduled scaling handles retries) and **drain/checkpoint before it ends** (the block begins terminating instances 30 minutes before end time; an EventBridge event fires 10 minutes before that). The reserved-capacity ASG path is the documented integration; wiring Capacity Blocks directly into an ECS Managed Instances capacity provider is not a documented pattern — fall back to the self-managed ASG for reserved-capacity use cases. Reference: [Capacity Blocks for ML (EC2 User Guide)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html), [How Capacity Blocks work](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-blocks-how.html).
+
+## Spot vs On-Demand for GPU on ECS
+
+| Workload | Capacity type | Condition |
+|---|---|---|
+| **Training** | Spot | ✅ Only with checkpoint/resume wired (see [distributed-training.md](distributed-training.md)) |
+| **Training** | On-Demand / Capacity Blocks | When the job can't tolerate interruption |
+| **Inference (production, SLA-bound)** | On-Demand | Always — Spot interruptions break per-request SLAs |
+| **Dev / experimentation** | Spot | ✅ Tolerable interruption profile |
+
+**Spot without checkpoint/resume is a guaranteed cost-burn** — every interruption restarts training. Use **managed instance draining** (on by default) for graceful task rebalancing when instances terminate ([ECS capacity providers for EC2](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)). Note: separate **Spot and On-Demand into different ASGs/capacity providers** (a single ASG mixing purchase options with per-type homogeneity is fine via a MixedInstancesPolicy for *sizes*, but keep GPU *types* separated per the crux above).
+
+## Cluster Auto Scaling Behavior & Latency
+
+ECS cluster auto scaling is a **CloudWatch-driven, latent** process ([Optimize ECS cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/capacity-cluster-speed-up-ec2.html)):
+
+- Scale-out/in reacts to the `CapacityProviderReservation` metric breaching alarms; there is inherent lag from metric publish + alarm evaluation + EC2 warm-up.
+- **Scale-in requires ~15 minutes of data points** before reducing capacity, then steps down gradually ([Faster Scaling-in for ECS Cluster Auto Scaling](https://aws.amazon.com/blogs/containers/faster-scaling-in-for-amazon-ecs-cluster-auto-scaling/)). This matters for expensive GPU nodes — idle GPU minutes are costly.
+- Speed levers: use **warm pools** of pre-initialized GPU instances (supported by ECS ASG capacity providers) to cut GPU-instance warm-up time; keep GPU AMIs lean; pre-cache large model images (see [storage.md](storage.md)).
+
+## Cost Levers (priority order)
+
+| Priority | Lever | Directional value | Caveat |
+|---|---|---|---|
+| 1 | **Capacity Blocks for ML** | Capacity *assurance* (not a fixed discount) | Reservation + OS fee; no autoscale; advance reservation |
+| 2 | **Neuron over GPU** | Cost-optimized for supported Transformer models | Compilation ramp; verify model support ([neuron-on-ecs.md](neuron-on-ecs.md)) |
+| 3 | **Spot + checkpoint/resume** | Large savings for fault-tolerant training | Requires checkpoint logic; not for SLA inference |
+| 4 | **Right-size GPU instance family** | Avoids paying for idle GPU memory/compute | Match model size to instance; measure first |
+| 5 | **Cluster auto scaling / Managed Instances consolidation** | Reclaims idle GPU nodes off-peak | Scale-in latency (~15 min); warm pools mitigate cold-start |
+| 6 | **GPU sharing (dev only)** | Density for dev/test | No isolation — dev/test only ([compute-hardware.md](compute-hardware.md)) |
+
+Always give **directional ranges with caveats** — never point estimates. Actual savings depend on model size, traffic pattern, batch size, sequence length, and configuration.
+
+## Sources
+
+- [Amazon ECS capacity providers for EC2 workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)
+- [Automatically manage Amazon ECS capacity with cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-auto-scaling.html)
+- [Optimize Amazon ECS cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/capacity-cluster-speed-up-ec2.html)
+- [Deep Dive on Amazon ECS Cluster Auto Scaling](https://aws.amazon.com/blogs/containers/deep-dive-on-amazon-ecs-cluster-auto-scaling/)
+- [Faster Scaling-in for Amazon ECS Cluster Auto Scaling](https://aws.amazon.com/blogs/containers/faster-scaling-in-for-amazon-ecs-cluster-auto-scaling/)
+- [Optimize cost for container workloads with ECS capacity providers and EC2 Spot Instances](https://aws.amazon.com/blogs/containers/optimize-cost-for-container-workloads-with-ecs-capacity-providers-and-ec2-spot-instances/)
+- [EC2 Capacity Blocks for ML](https://aws.amazon.com/ec2/capacityblocks/) · [Capacity Blocks for ML (EC2 User Guide)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html)
+- [Amazon ECS Managed Instances](https://aws.amazon.com/ecs/managed-instances/) · [Managed Instances now in all commercial Regions](https://aws.amazon.com/about-aws/whats-new/2025/10/amazon-ecs-managed-instances-commercial-regions/)

--- a/skills/ecs-genai/references/capacity-and-scaling.md
+++ b/skills/ecs-genai/references/capacity-and-scaling.md
@@ -1,12 +1,16 @@
 # Capacity & Scaling — GPU at Scale on Amazon ECS
 
-The mechanics that make ECS-GPU capacity different from EKS. There is **no Karpenter on native ECS** — capacity is Auto Scaling groups + ECS capacity providers, with a hard structural constraint that dictates the whole pattern.
+The mechanics that make ECS-GPU capacity different from EKS. There is **no Karpenter on native ECS** — capacity is Auto Scaling groups + ECS capacity providers, with a scaling behavior that dictates the whole GPU pattern. (Freshness: Capacity Blocks instance list + Managed Instances facts verified against live AWS docs **2026-07-09** — this is a fast-moving list; re-verify against the cited pages.)
 
-## The Separate-ASG-Per-GPU-Type Pattern (the crux)
+> **Scope note:** This file covers the GPU-specific capacity story. For the generic capacity-provider mechanics — the `CapacityProviderReservation` formula, strategy-shape constraints, managed instance draining — route to **`ecs-architect`** / [ECS capacity providers for EC2 workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html). What follows is only what changes because the instances carry GPUs.
 
-**An ECS capacity-provider Auto Scaling group can't have instance weighting settings** ([ECS capacity providers for EC2 workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)). ECS cluster auto scaling drives the ASG via a single `CapacityProviderReservation` target-tracking metric that assumes the instances in that ASG are effectively **homogeneous** — the formula is `(instances needed) / (running instances) × 100` ([Automatically manage ECS capacity with cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-auto-scaling.html)). Mixing heterogeneous GPU types (e.g. g5 + p4d) in one ASG breaks the scaling math and makes task placement non-deterministic.
+## One Homogeneous ASG Per GPU Type (the crux)
 
-There is a second, sharper failure mode: **ECS task placement has no native "GPU model / VRAM" attribute** — a `resourceRequirements` `GPU: 1` only counts GPUs, not their memory. If a g4dn (16 GiB, T4) and a g5 (24 GiB, A10G) share one ASG, ECS can place a task needing 24 GiB onto the 16 GiB T4, and the model OOMs at load time. Homogeneous per-type ASGs (pin `allowedInstanceTypes` in the launch template) are what keep placement correct; use a placement constraint on `ecs.instance-type` to steer within a mixed cluster.
+Cluster auto scaling **does support an Auto Scaling group with multiple instance types** ([ECS managed scaling behavior](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-scaling-behavior.html) explicitly lists this) — so this is **best practice, not a hard limit**. The reasons a heterogeneous *GPU* ASG is nonetheless a trap:
+
+1. **No instance weighting.** An ECS capacity-provider ASG **can't have instance weighting settings** ([ECS capacity providers for EC2 workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)), so the scaling math can't account for one GPU type being worth more than another.
+2. **Managed scaling bin-packs and protects on the *smallest* instance type.** When an ASG has multiple instance types, ECS sorts them by vCPU/memory/ENI/port/GPU parameters and uses the **smallest** type's values as *protection*: "If a group of tasks have resource requirements that are greater than the smallest instance type in the Auto Scaling group, then that group of tasks can't run with this capacity provider… The tasks remain in the `PROVISIONING` state." AWS's own recommendation is to "create separate Auto Scaling groups and capacity providers for different minimum resource requirements" ([ECS managed scaling behavior](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-scaling-behavior.html)).
+3. **No native "GPU model / VRAM" placement attribute.** A `resourceRequirements` `GPU: 1` only counts GPUs, not their memory. If a g4dn (16 GiB, T4) and a g5 (24 GiB, A10G) share one ASG, ECS can place a task needing 24 GiB onto the 16 GiB T4 and the model OOMs at load time. Homogeneous per-type ASGs (pin `allowedInstanceTypes` in the launch template) keep placement correct; use a placement constraint on `ecs.instance-type` to steer within a mixed cluster.
 
 **Therefore, the pattern for GPU at scale on native ECS:**
 
@@ -24,12 +28,9 @@ There is a second, sharper failure mode: **ECS task placement has no native "GPU
 }
 ```
 
-Constraints to respect (from the capacity-providers doc):
-- A capacity-provider strategy can specify **at most 20 capacity providers**.
-- At least one capacity provider must have **weight > 0**; only one may set a **base**.
-- A strategy can contain **either** ASG capacity providers **or** Fargate capacity providers — **not both**. (And Fargate can't run GPU anyway.)
-- You **can't switch** a service between an ASG capacity provider and a Fargate capacity provider without recreating/redeploying; moving a service from `launchType` to a capacity-provider strategy requires a **forced new deployment**.
-- Create the empty ASG with **desired = 0**; ECS scales it out via managed scaling.
+GPU-relevant reminders (the full strategy-shape rules — the ≤20-provider limit, base/weight semantics, ASG-vs-Fargate exclusivity, launchType migration — are generic capacity-provider mechanics; see `ecs-architect` / the capacity-providers doc):
+- Create the empty GPU ASG with **desired = 0**; ECS scales it out via managed scaling.
+- A strategy can't mix ASG and Fargate capacity providers — moot here, since Fargate can't run GPU anyway.
 
 ### Karpenter equivalent? No.
 
@@ -40,30 +41,42 @@ There is no Karpenter for native ECS. The closest "AWS picks the instance" exper
 Instead of hand-rolling one ASG per GPU type, **ECS Managed Instances** lets AWS provision, configure, patch (every 14 days), scale, and place tasks on optimal EC2 instances, while you declare requirements ([Amazon ECS Managed Instances](https://aws.amazon.com/ecs/managed-instances/)). You still select GPU/accelerator families through the capacity provider's **`instanceRequirements`** launch template (see [compute-hardware.md](compute-hardware.md) and [neuron-on-ecs.md](neuron-on-ecs.md)). Trade-offs:
 
 - **Pro:** No ASG plumbing, no AMI/driver management, faster to stand up, per-type homogeneity handled by AWS.
-- **Con:** A management charge on top of EC2 cost; less control than self-managed EC2 (no custom kernel/AMI). For custom AMI/kernel or the most demanding multi-node EFA training, self-managed ECS-on-EC2 remains the choice.
+- **Con:** A **management charge** on top of the EC2 instance price, billed per-second with a one-minute minimum ([ECS Managed Instances pricing](https://aws.amazon.com/ecs/managed-instances/pricing/)); less control than self-managed EC2 (no custom kernel/AMI). For custom AMI/kernel or the most demanding multi-node EFA training, self-managed ECS-on-EC2 remains the choice.
+- **Instance lifetime caveat for training:** Managed Instances initiates **security patching every 14 days** by replacing instances (drain-and-replace); you can use EC2 event windows to schedule it into weekly maintenance windows ([ECS Managed Instances FAQs](https://aws.amazon.com/ecs/managed-instances/faqs/), [Patching in ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-patching.html)). That is fine for inference, but a **multi-week training run can be interrupted mid-flight** — so multi-week runs need robust checkpoint/resume (see [distributed-training.md](distributed-training.md)), or should run on a self-managed ASG / Capacity Block instead.
 - GA Sept 2025; available in all commercial Regions since Oct 2025.
 
 ## EC2 Capacity Blocks for ML — securing scarce GPU capacity
 
-GPU capacity is scarce. **EC2 Capacity Blocks for ML** let you reserve accelerated instances for a future window, colocated in EC2 UltraClusters with EFA ([EC2 Capacity Blocks for ML](https://aws.amazon.com/ec2/capacityblocks/)). Verified current facts:
+GPU capacity is scarce. **EC2 Capacity Blocks for ML** let you reserve accelerated instances for a future window, colocated in EC2 UltraClusters with EFA ([EC2 Capacity Blocks for ML](https://aws.amazon.com/ec2/capacityblocks/)). Current facts (**verified against live AWS docs 2026-07-09 — the supported-type list moves fast, e.g. it already includes P6e-GB200; always re-check the cited pages**):
 
-- **Supported instance types** (per the Capacity Blocks page): P6e-GB200, P6-B300, P6-B200, P5en, P5e, P5, and P4d (NVIDIA Blackwell / H200 / H100 / A100), plus **Trn2 and Trn1** (AWS Trainium).
-- **Reservation duration** is 1–14 days, or a multiple of 7 days up to **182 days** (e.g. 21, 28 days); reservable with a start time **up to 8 weeks in advance**. Each Capacity Block can have **up to 64 instances**, and **up to 256 instances across Capacity Blocks** ([How Capacity Blocks work](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-blocks-how.html)). Instance Capacity Blocks are shareable across accounts (UltraServer Capacity Blocks are not).
+- **Single Availability Zone.** A Capacity Block is delivered as a **`targeted` Capacity Reservation in one AZ** ([Use Capacity Blocks for ML workloads (EC2 Auto Scaling)](https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-template-capacity-blocks.html)). This is not stated as a passing detail: it means you must **pin the ASG to that AZ's subnet** and **co-locate FSx for Lustre in the same AZ** ([storage.md](storage.md)) — a cross-AZ block/FSx layout silently underperforms or won't place.
+- **Supported instance types** (per the Capacity Blocks page, 2026-07-09): P6e-GB200, P6-B300, P6-B200, P5en, P5e, P5, and P4d (NVIDIA Blackwell / H200 / H100 / A100), plus **Trn2 and Trn1** (AWS Trainium). Capacity Blocks cover **P- and Trn-family only** — there is no g6e Capacity Block, so for assured g6e/inference capacity use **ODCRs** or Managed Instances Capacity Reservations instead (below).
+- **Reservation duration** is 1–14 days, or a multiple of 7 days up to **182 days**; reservable with a start time **up to 8 weeks in advance**. Each Capacity Block can have **up to 64 instances**, and **up to 256 instances across Capacity Blocks** ([How Capacity Blocks work](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-blocks-how.html)). Instance Capacity Blocks are shareable across accounts (UltraServer Capacity Blocks are not).
+- **Cancellations aren't allowed, but a block CAN be extended.** An `active` or `scheduled` block can be extended (subject to available capacity) in 1-day increments up to 14 days and 7-day increments up to 182 days total, from 1 hour to 57 days before it expires, with no limit on the number of extensions — the reservation ID stays the same ([Extend Capacity Blocks](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-blocks-extend.html)). Plan the initial window, but know you can extend a run rather than re-reserving.
 - **Pricing = reservation fee + OS fee.** AWS publishes **no fixed discount vs on-demand** — the value is **guaranteed capacity assurance**, not a headline discount. Do not claim a percentage saving.
 - Best for: planned pre-training/fine-tuning runs, benchmark campaigns, guaranteed-capacity demos. Not for elastic inference (Capacity Blocks don't autoscale).
 
-Use with ECS by launching the reserved instances into a **self-managed GPU ASG capacity provider** for the reservation window: create the ASG's launch template to target the Capacity Block reservation, and — because managed scaling doesn't know the block's expiration — **schedule scale-up at the block start** (Auto Scaling scheduled scaling handles retries) and **drain/checkpoint before it ends** (the block begins terminating instances 30 minutes before end time; an EventBridge event fires 10 minutes before that). The reserved-capacity ASG path is the documented integration; wiring Capacity Blocks directly into an ECS Managed Instances capacity provider is not a documented pattern — fall back to the self-managed ASG for reserved-capacity use cases. Reference: [Capacity Blocks for ML (EC2 User Guide)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html), [How Capacity Blocks work](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-blocks-how.html).
+Use with ECS by launching the reserved instances into a **self-managed GPU ASG capacity provider** for the reservation window: create the ASG's launch template to target the Capacity Block reservation, **restrict the ASG to the block's AZ subnet**, and — because managed scaling doesn't know the block's expiration — **schedule scale-up at the block start** (Auto Scaling scheduled scaling handles retries) and **drain/checkpoint before it ends** (the block begins terminating instances 30 minutes before end time; an EventBridge event fires 10 minutes before that). The reserved-capacity ASG path is the documented integration; wiring Capacity Blocks directly into an ECS Managed Instances capacity provider is not a documented pattern — fall back to the self-managed ASG for reserved-capacity use cases. Reference: [Capacity Blocks for ML (EC2 User Guide)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html), [How Capacity Blocks work](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-blocks-how.html).
+
+### Assured capacity without a Capacity Block (P/Trn only cover part of the story)
+
+For inference families that Capacity Blocks don't cover (e.g. g6e), get capacity assurance with:
+- **On-Demand Capacity Reservations (ODCRs)** in a specific AZ, consumed by a self-managed ASG launch template — the general-purpose assured-capacity lever for g-family inference.
+- **Managed Instances Capacity Reservations:** set `capacityOptionType: Reserved` on the capacity provider and supply a **Capacity Reservation group** ([ECS Managed Instances instance types — billing and purchase options](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-instance-types.html)); you can also set a reservation preference (`reservations-only`, `reservations-first`, `reservations-excluded`).
+> **Reservation-vs-support mismatch to flag:** Capacity Blocks / ODCRs can reserve instance types (P6, P5en, …) that the **ECS-on-EC2 GPU support table stops short of** (it currently ends at p5/g6e). Managed Instances' accelerated list is broader (see [compute-hardware.md](compute-hardware.md)). Before reserving, confirm the target instance type is actually consumable by the ECS launch model you intend to use, or you may reserve a block ECS-on-EC2 can't schedule onto.
 
 ## Spot vs On-Demand for GPU on ECS
 
 | Workload | Capacity type | Condition |
 |---|---|---|
-| **Training** | Spot | ✅ Only with checkpoint/resume wired (see [distributed-training.md](distributed-training.md)) |
+| **Training** | Spot | ✅ Only with checkpoint/resume wired (see [distributed-training.md](distributed-training.md)) — but see the P-family caveat below |
 | **Training** | On-Demand / Capacity Blocks | When the job can't tolerate interruption |
 | **Inference (production, SLA-bound)** | On-Demand | Always — Spot interruptions break per-request SLAs |
 | **Dev / experimentation** | Spot | ✅ Tolerable interruption profile |
 
-**Spot without checkpoint/resume is a guaranteed cost-burn** — every interruption restarts training. Use **managed instance draining** (on by default) for graceful task rebalancing when instances terminate ([ECS capacity providers for EC2](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)). Note: separate **Spot and On-Demand into different ASGs/capacity providers** (a single ASG mixing purchase options with per-type homogeneity is fine via a MixedInstancesPolicy for *sizes*, but keep GPU *types* separated per the crux above).
+**P-family Spot availability caveat:** the "Large savings" story for Spot training assumes the capacity exists. GPU capacity is scarce (the whole reason Capacity Blocks exist), and **large NVIDIA GPU instances — p4d/p5/p5en — are frequently unobtainable on Spot and carry high interruption rates**. Treat P-family Spot as opportunistic, not a capacity plan: for guaranteed multi-day training use **On-Demand or Capacity Blocks**; reserve Spot for smaller/interruption-tolerant phases with checkpoint/resume, and check the Spot placement score / interruption history for the type and AZ first.
+
+**Spot without checkpoint/resume is a guaranteed cost-burn** — every interruption restarts training. Use **managed instance draining** (on by default) for graceful task rebalancing when instances terminate ([ECS capacity providers for EC2](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)). Note: separate **Spot and On-Demand into different ASGs/capacity providers**, and keep GPU *types* separated per the crux above (one homogeneous GPU type per ASG).
 
 ## Cluster Auto Scaling Behavior & Latency
 
@@ -89,7 +102,10 @@ Always give **directional ranges with caveats** — never point estimates. Actua
 ## Sources
 
 - [Amazon ECS capacity providers for EC2 workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)
+- [Amazon ECS managed scaling behavior](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-scaling-behavior.html) (multiple instance types supported; bin-packs/protects on the smallest type)
 - [Automatically manage Amazon ECS capacity with cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-auto-scaling.html)
+- [Extend Capacity Blocks](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-blocks-extend.html) · [Use Capacity Blocks for ML workloads (single-AZ, EC2 Auto Scaling)](https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-template-capacity-blocks.html)
+- [ECS Managed Instances instance types (billing / Capacity Reservations)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-instance-types.html) · [Patching in ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-patching.html) · [ECS Managed Instances pricing](https://aws.amazon.com/ecs/managed-instances/pricing/)
 - [Optimize Amazon ECS cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/capacity-cluster-speed-up-ec2.html)
 - [Deep Dive on Amazon ECS Cluster Auto Scaling](https://aws.amazon.com/blogs/containers/deep-dive-on-amazon-ecs-cluster-auto-scaling/)
 - [Faster Scaling-in for Amazon ECS Cluster Auto Scaling](https://aws.amazon.com/blogs/containers/faster-scaling-in-for-amazon-ecs-cluster-auto-scaling/)

--- a/skills/ecs-genai/references/compute-hardware.md
+++ b/skills/ecs-genai/references/compute-hardware.md
@@ -4,12 +4,12 @@ The foundation of every GPU/ML-on-ECS architecture: **which host, which accelera
 
 ## First-Class Constraint — AWS Fargate Has No GPU
 
-GPUs (and AWS accelerators) are **not available on AWS Fargate**. AWS lists the `gpu` task-definition parameter among those that are **"not valid in Fargate tasks"** (with `devices`, `placementConstraints`, and `privileged`), and the Fargate task-size model exposes only CPU and memory — the valid combinations run from 256 (.25 vCPU) up to 32768 (32 vCPU), with no GPU dimension at all ([ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)). The `resourceRequirements` `GPU` type is a **container-instance (EC2)** concept only. GPU/ML on ECS therefore runs only on:
+GPUs (and AWS accelerators) are **not available on AWS Fargate**. AWS lists the `gpu` task-definition parameter (with `placementConstraints`) among those **"not valid in Fargate tasks"**, and the Fargate task-size model exposes only CPU and memory — the valid combinations run from 256 (.25 vCPU) up to 32768 (32 vCPU), with no GPU dimension at all ([ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)). (Precise framing: on that same Fargate page, `devices` and `privileged` are listed under **`linuxParameters` limitations**, not on the "not valid" list — but the effect is the same, none are usable for a Fargate GPU task.) The `resourceRequirements` `GPU` type is a **container-instance (EC2)** concept only. GPU/ML on ECS therefore runs only on:
 
 | Host | GPU support | Who manages the EC2 lifecycle | Use when |
 |---|---|---|---|
 | **ECS-on-EC2** | ✅ Full (GPU-optimized AMI, custom AMI/kernel, EFA, multi-node) | You (Auto Scaling groups) | Training, demanding inference, full control |
-| **ECS Managed Instances** | ✅ GPU + Neuron (drivers pre-installed) | AWS (provision, patch every 14 days, refresh) | Lower ops overhead; GA Sept 2025, all commercial Regions Oct 2025 |
+| **ECS Managed Instances** | ✅ GPU + Neuron (drivers pre-installed) | AWS (provision; security patching initiated every 14 days by instance replacement — [ECS Managed Instances FAQs](https://aws.amazon.com/ecs/managed-instances/faqs/), [Patching in ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-patching.html)) | Lower ops overhead; GA Sept 2025, all commercial Regions Oct 2025 |
 | **ECS Anywhere / External** | ✅ On-prem GPU hosts (`--enable-gpu`) | You (on-prem) | Hybrid / data-residency |
 | **AWS Fargate** | ❌ **None** | AWS | Never — for GPU, rule Fargate out |
 
@@ -53,7 +53,14 @@ Amazon ECS provides a **GPU-optimized AMI** that ships pre-configured NVIDIA ker
 aws ssm get-parameters \
   --names /aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended \
   --region us-east-1
+
+# Amazon Linux 2023 GPU variant (AL2 is approaching end-of-life — prefer AL2023 for new builds)
+aws ssm get-parameters \
+  --names /aws/service/ecs/optimized-ami/amazon-linux-2023/gpu/recommended \
+  --region us-east-1
 ```
+
+**AMI options:** AWS publishes GPU-optimized variants for both **Amazon Linux 2** and **Amazon Linux 2023** ([ECS-optimized Linux AMIs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)); AL2 is approaching end-of-life, so prefer **AL2023** for new builds. There is also a **Bottlerocket ECS NVIDIA variant** (`aws-ecs-2-nvidia`, and the older `aws-ecs-1-nvidia`) for a minimal, image-based, security-oriented GPU host — exposed in CDK as `BottlerocketEcsVariant.AWS_ECS_2_NVIDIA` ([CDK BottlerocketEcsVariant](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.BottlerocketEcsVariant.html)).
 
 Key operational facts (all from the ECS GPU doc):
 
@@ -111,7 +118,11 @@ sudo systemctl restart docker
 
 ## GPU on ECS Managed Instances
 
-ECS Managed Instances supports GPU-accelerated computing with **NVIDIA drivers and the CUDA toolkit pre-installed** on the instance ([Use GPUs with ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)). Documented GPU families include `g4dn` (NVIDIA T4), `g5` (A10G), `p3` (V100), and `p4d` (A100). You select GPU instances through the **`instanceRequirements`** object in the capacity provider's launch template:
+ECS Managed Instances supports GPU-accelerated computing with **NVIDIA drivers and the CUDA toolkit pre-installed** on the instance ([Use GPUs with ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)). That page calls out `g4dn` (T4), `g5` (A10G), `p3` (V100), and `p4d` (A100) as a **subset** — the actual Managed Instances **accelerated-computing support list is far broader** than the EC2-launch-type GPU table above. Per [ECS Managed Instances instance types](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-instance-types.html) (verified 2026-07-09) it includes: **DL1, G4ad, G4dn, G5, G5g, G6, G6e, G6f, G7e, Gr6, Gr6f, Inf1, Inf2, P3dn, P4d, P4de, P5, P5en, P6-B200, P6-B300, Trn1** (plus HPC families). Re-check the live page — this list moves fast.
+
+**Hardware-fractional L4 (G6f / Gr6f) — MI-only, no scheduler needed.** `G6f` (and Graviton `Gr6f`) are **fractional-GPU** instances that expose a **1/8, 1/4, or 1/2 slice of an NVIDIA L4** as the hardware unit ([EC2 accelerated computing — Fractional-GPU G6 instances](https://aws.amazon.com/ec2/instance-types/accelerated-computing/)): the fractioning is done by the *instance shape*, not by a MIG/time-slicing scheduler, so it fits native ECS's whole-GPU pinning model. **G6f appears on the Managed Instances list but not on the EC2-launch-type GPU table** — treat it as a Managed-Instances lever for small/cost-sensitive L4 inference. This is distinct from *dynamic multi-model GPU packing* (MIG/time-slicing/DRA), which still has no native-ECS scheduler and routes to EKS/SageMaker (see GPU-sharing section and [service-boundaries.md](service-boundaries.md)).
+
+You select GPU instances through the **`instanceRequirements`** object in the capacity provider's launch template:
 
 ```json
 {
@@ -129,7 +140,7 @@ or pin exact types:
 { "instanceRequirements": { "allowedInstanceTypes": ["g4dn.xlarge", "p4de.24xlarge"] } }
 ```
 
-AWS handles instance configuration, capacity provisioning, workload placement, patching (every 14 days), scaling, and maintenance — trading some control for far lower operational overhead than a hand-rolled ASG.
+AWS handles instance configuration, capacity provisioning, workload placement, security patching (initiated every 14 days by instance replacement — [Patching in ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-patching.html)), scaling, and maintenance — trading some control for far lower operational overhead than a hand-rolled ASG. Note: the 14-day drain-and-replace cadence interrupts multi-week training runs — see [capacity-and-scaling.md](capacity-and-scaling.md).
 
 ## Capacity Planning Guidance
 
@@ -147,7 +158,8 @@ AWS handles instance configuration, capacity provisioning, workload placement, p
 - [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)
 - [ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)
 - [ECS task definition parameters for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html)
-- [Use GPUs with Amazon ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)
+- [Use GPUs with Amazon ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html) · [Amazon ECS Managed Instances instance types (full accelerated list, incl. G6f/Gr6f/G7e)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-instance-types.html)
 - [Amazon ECS Managed Instances](https://aws.amazon.com/ecs/managed-instances/) · [Announcing Amazon ECS Managed Instances](https://aws.amazon.com/about-aws/whats-new/2025/09/amazon-ecs-managed-instances/)
-- [Amazon ECS-optimized Linux AMIs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)
+- [Amazon ECS-optimized Linux AMIs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html) · [CDK BottlerocketEcsVariant (aws-ecs-2-nvidia)](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.BottlerocketEcsVariant.html)
+- [EC2 accelerated computing instances (Fractional-GPU G6f / Gr6f)](https://aws.amazon.com/ec2/instance-types/accelerated-computing/)
 - [Using Amazon ECS with NVIDIA GPUs to accelerate drug discovery](https://aws.amazon.com/blogs/containers/using-amazon-ecs-with-nvidia-gpus-to-accelerate-drug-discovery/)

--- a/skills/ecs-genai/references/compute-hardware.md
+++ b/skills/ecs-genai/references/compute-hardware.md
@@ -1,0 +1,153 @@
+# Compute & Hardware — GPU on Amazon ECS
+
+The foundation of every GPU/ML-on-ECS architecture: **which host, which accelerator, which AMI, how GPUs are exposed to containers, and how (little) they can be shared.** Every claim here is cited to an AWS doc — do not synthesize accelerator specs.
+
+## First-Class Constraint — AWS Fargate Has No GPU
+
+GPUs (and AWS accelerators) are **not available on AWS Fargate**. AWS lists the `gpu` task-definition parameter among those that are **"not valid in Fargate tasks"** (with `devices`, `placementConstraints`, and `privileged`), and the Fargate task-size model exposes only CPU and memory — the valid combinations run from 256 (.25 vCPU) up to 32768 (32 vCPU), with no GPU dimension at all ([ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)). The `resourceRequirements` `GPU` type is a **container-instance (EC2)** concept only. GPU/ML on ECS therefore runs only on:
+
+| Host | GPU support | Who manages the EC2 lifecycle | Use when |
+|---|---|---|---|
+| **ECS-on-EC2** | ✅ Full (GPU-optimized AMI, custom AMI/kernel, EFA, multi-node) | You (Auto Scaling groups) | Training, demanding inference, full control |
+| **ECS Managed Instances** | ✅ GPU + Neuron (drivers pre-installed) | AWS (provision, patch every 14 days, refresh) | Lower ops overhead; GA Sept 2025, all commercial Regions Oct 2025 |
+| **ECS Anywhere / External** | ✅ On-prem GPU hosts (`--enable-gpu`) | You (on-prem) | Hybrid / data-residency |
+| **AWS Fargate** | ❌ **None** | AWS | Never — for GPU, rule Fargate out |
+
+Sources: [ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html), [Use GPUs with ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html).
+
+## NVIDIA GPU Instance Support on ECS
+
+Amazon ECS supports GPU workloads on container instances of the **p2, p3, p4d, p5, g3, g4, g5, g6, and g6e** families, which provide NVIDIA GPUs ([ECS GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)). The following table is the **verbatim supported-instance table from the ECS GPU documentation** (subset shown — see the doc for all sizes). Do not restate GPU counts from memory; cite this table.
+
+| Instance type | GPUs | GPU memory (GiB) | vCPUs | Memory (GiB) |
+|---|---|---|---|---|
+| p3.2xlarge | 1 | 16 | 8 | 61 |
+| p3.16xlarge | 8 | 128 | 64 | 488 |
+| p4d.24xlarge | 8 | 320 | 96 | 1152 |
+| p5.48xlarge | 8 | 640 | 192 | 2048 |
+| g4dn.xlarge | 1 | 16 | 4 | 16 |
+| g4dn.12xlarge | 4 | 64 | 48 | 192 |
+| g5.xlarge | 1 | 24 | 4 | 16 |
+| g5.48xlarge | 8 | 192 | 192 | 768 |
+| g6.xlarge | 1 | 24 | 4 | 16 |
+| g6.48xlarge | 8 | 192 | 192 | 768 |
+| g6e.2xlarge | 1 | 48 | 8 | 64 |
+| g6e.48xlarge | 8 | 384 | 192 | 1536 |
+
+Source: [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html).
+
+### Accelerator selection rule of thumb
+
+- **Inference (7B–70B, cost-sensitive):** g6 / g6e (L40S/L4-class) — broad ecosystem; or **Inf2** for supported Transformer models (see [neuron-on-ecs.md](neuron-on-ecs.md)).
+- **Training / fine-tuning at scale:** p4d / p5 (multi-node with EFA); or **Trn1/Trn2** for supported models.
+- **Multi-modal / novel architectures / custom CUDA:** NVIDIA GPU (Neuron support is model-specific).
+
+Right accelerator = f(model family × latency × cost posture × team skill × timeline) — never one dimension alone. AWS-published price-performance claims (e.g. Inferentia2/Trainium savings) belong to the EC2 instance pages; cite those pages rather than restating a number here.
+
+## The ECS GPU-Optimized AMI + NVIDIA Container Runtime
+
+Amazon ECS provides a **GPU-optimized AMI** that ships pre-configured NVIDIA kernel drivers and a Docker GPU (NVIDIA) runtime, so you never manage drivers by hand ([ECS GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)). Retrieve the current AMI ID from SSM Parameter Store rather than hard-coding it:
+
+```bash
+# Recommended ECS GPU-optimized AMI (Amazon Linux 2)
+aws ssm get-parameters \
+  --names /aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended \
+  --region us-east-1
+```
+
+Key operational facts (all from the ECS GPU doc):
+
+- Set **`ECS_ENABLE_GPU_SUPPORT=true`** in the container-agent config on GPU instances.
+- For each container with a GPU `resourceRequirements`, ECS sets the container runtime to the **NVIDIA container runtime** and sets **`NVIDIA_VISIBLE_DEVICES`** to the assigned GPU device IDs.
+- If your image is **not** built from an NVIDIA/CUDA base image, set **`NVIDIA_DRIVER_CAPABILITIES`** to `utility,compute` or `all`.
+- **Clusters can mix GPU and non-GPU container instances.**
+- **GPUs are not supported on Windows containers** on ECS.
+- Version notes: **p5** requires GPU-optimized AMI version `20230929`+; **g4** requires `20230913`+; **p2** is only supported on versions earlier than `20230912` (see the doc's "What to do if you need a P2 instance"); the **g2** family is deprecated. In-place NVIDIA/CUDA driver updates on p2/g2 can cause GPU workload failures.
+
+## Requesting a GPU in the Task Definition
+
+Request GPUs at the container level with `resourceRequirements` type `GPU`. ECS schedules the task onto a container instance with free GPUs and **pins the physical GPUs to the container** for optimal performance:
+
+```json
+{
+  "containerDefinitions": [
+    {
+      "name": "inference",
+      "image": "<account>.dkr.ecr.<region>.amazonaws.com/my-model:latest",
+      "resourceRequirements": [
+        { "type": "GPU", "value": "1" }
+      ],
+      "memory": 8192
+    }
+  ],
+  "family": "gpu-inference"
+}
+```
+
+The number of GPUs reserved across all containers in a task can't exceed the GPUs available on the instance ([CfnTaskDefinition ResourceRequirement](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.CfnTaskDefinition.ResourceRequirementProperty.html)). Use **task placement constraints** on `ecs.instance-type` to steer a task to a specific GPU instance type:
+
+```bash
+aws ecs run-task --cluster default --task-definition gpu-inference \
+  --placement-constraints type=memberOf,expression="attribute:ecs.instance-type == g4dn.xlarge"
+```
+
+## GPU Sharing on ECS — State the Limit Precisely
+
+**Native ECS has no MIG-partitioning, time-slicing-replica, or DRA scheduler primitive** (those are EKS device-plugin features). By default ECS pins **whole physical GPUs** to containers. The only supported sharing path documented for ECS is coarse and unisolated ([ECS GPU workloads — "Share GPUs"](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)):
+
+1. **Remove** the GPU `resourceRequirements` from the task definitions so ECS does not reserve GPUs.
+2. Add EC2 **user data** that makes `nvidia` the **default Docker runtime** on the instance (so all ECS containers can see the GPUs):
+
+```bash
+#!/bin/bash
+sudo rm /etc/sysconfig/docker
+echo 'OPTIONS="--default-ulimit nofile=32768:65536 --default-runtime nvidia"' | sudo tee -a /etc/sysconfig/docker
+sudo systemctl restart docker
+```
+
+3. Set **`NVIDIA_VISIBLE_DEVICES`** per container in the task definition to select which GPU(s) each container sees.
+
+> **Caution:** This provides **no memory or compute isolation** between co-located containers — one container can starve or OOM the others on the shared GPU. Use for **dev/test only.** If the customer needs first-class fractional-GPU scheduling (MIG, time-slicing with per-slice memory, DRA), that is a reason to prefer **EKS (`eks-genai`)** or **SageMaker**, not native ECS. See [service-boundaries.md](service-boundaries.md).
+
+## GPU on ECS Managed Instances
+
+ECS Managed Instances supports GPU-accelerated computing with **NVIDIA drivers and the CUDA toolkit pre-installed** on the instance ([Use GPUs with ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)). Documented GPU families include `g4dn` (NVIDIA T4), `g5` (A10G), `p3` (V100), and `p4d` (A100). You select GPU instances through the **`instanceRequirements`** object in the capacity provider's launch template:
+
+```json
+{
+  "instanceRequirements": {
+    "acceleratorTypes": "gpu",
+    "acceleratorCount": 1,
+    "acceleratorManufacturers": ["nvidia"]
+  }
+}
+```
+
+or pin exact types:
+
+```json
+{ "instanceRequirements": { "allowedInstanceTypes": ["g4dn.xlarge", "p4de.24xlarge"] } }
+```
+
+AWS handles instance configuration, capacity provisioning, workload placement, patching (every 14 days), scaling, and maintenance — trading some control for far lower operational overhead than a hand-rolled ASG.
+
+## Capacity Planning Guidance
+
+| Workload | Start with | Scale signal |
+|---|---|---|
+| Single-model inference (7B–13B) | 1× g6e.2xlarge (1 GPU, 48 GiB) or 1× inf2.8xlarge | Latency p99 > target → add tasks/instances |
+| Larger inference (30B–70B) | g6e.12xlarge / g6e.48xlarge or inf2.48xlarge | GPU memory > ~85% → upsize instance |
+| Distributed training | p4d/p5 or trn1/trn2 with EFA + placement group | All-reduce/EFA throughput, loss convergence |
+| GPU dev sharing | 1× g5/g6 with default-runtime sharing (dev only) | Contention/OOM between tenants → isolate on EKS/SageMaker |
+
+> **Rule:** Start small, measure, scale. Over-provisioning GPU instances is a top-two cost mistake (after choosing the wrong accelerator family). Always give directional ranges with caveats — never point cost estimates.
+
+## Sources
+
+- [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)
+- [ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)
+- [ECS task definition parameters for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html)
+- [Use GPUs with Amazon ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)
+- [Amazon ECS Managed Instances](https://aws.amazon.com/ecs/managed-instances/) · [Announcing Amazon ECS Managed Instances](https://aws.amazon.com/about-aws/whats-new/2025/09/amazon-ecs-managed-instances/)
+- [Amazon ECS-optimized Linux AMIs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)
+- [Using Amazon ECS with NVIDIA GPUs to accelerate drug discovery](https://aws.amazon.com/blogs/containers/using-amazon-ecs-with-nvidia-gpus-to-accelerate-drug-discovery/)

--- a/skills/ecs-genai/references/distributed-training.md
+++ b/skills/ecs-genai/references/distributed-training.md
@@ -1,0 +1,73 @@
+# Distributed ML Training on Amazon ECS
+
+Running multi-GPU and multi-node training / fine-tuning on ECS-on-EC2. ECS is a viable orchestrator for distributed ML — AWS documents an end-to-end pattern using **PyTorch + Ray Train** with distributed data parallel on ECS ([Distributed machine learning with Amazon ECS](https://aws.amazon.com/blogs/containers/distributed-machine-learning-with-amazon-ecs/)). Training runs on ECS-on-EC2 (or Managed Instances); **not Fargate** (no GPU/accelerator).
+
+## When ECS Fits Distributed Training — and When It Doesn't
+
+- **ECS fits** when the team wants a simple control plane (no Kubernetes to operate), IAM-native auth, and transparent control-plane upgrades, and the job is **single-node multi-GPU** (all GPUs on one instance; PyTorch DDP/FSDP inside one task with `GPU: ALL`) or a moderate multi-node data-parallel run driven by Ray. AWS's reference shows distributed data parallel (DDP) with Ray Train on ECS.
+- **Know the hard gap:** ECS has **no native multi-node distributed-training job primitive** — there is no equivalent to the Kubeflow `PyTorchJob`/`MPIJob`, the KubeRay operator, or `torchrun` auto peer-discovery across nodes. On ECS you wire rendezvous yourself (Ray head/worker tasks, or Cloud Map service discovery + `MASTER_ADDR`/`MASTER_PORT`), and you own job-level restart/checkpoint-resume on node failure. Multi-node scale beyond a Ray-managed run is where teams feel the absence most.
+- **Prefer EKS (`eks-genai`)** for large or multi-tenant training platforms needing gang scheduling (Volcano/Kueue), KubeRay operators, distributed-job CRDs, and Karpenter-driven elastic GPU provisioning.
+- **Prefer SageMaker** (training jobs / HyperPod) for fully-managed large-scale training where you don't want to own capacity or the training harness — including managed Spot with automatic checkpoint/resume.
+
+## Parallelism Techniques (choose by model size)
+
+Per the AWS ECS distributed-training reference:
+- **Distributed Data Parallel (DDP)** — a full copy of the model on each GPU; data split across GPUs. Simplest; use when the model fits in a single GPU's memory.
+- **Pipeline parallelism** — different model layers on different GPUs. For models too large for one GPU.
+- **Tensor parallelism** — a single layer split across GPUs. For very large layers.
+
+Frameworks run inside the container: **PyTorch (DDP/FSDP)**, **Ray Train** (wraps PyTorch with fault tolerance + orchestration), DeepSpeed, or Megatron. For Neuron training, use `neuronx-distributed` on Trn1/Trn2 ([neuron-on-ecs.md](neuron-on-ecs.md)).
+
+## Multi-Node Networking — EFA + Placement Groups
+
+Multi-node training is bottlenecked by inter-node collective communication (NCCL all-reduce). Without a high-bandwidth fabric, throughput collapses to standard TCP.
+
+- **Elastic Fabric Adapter (EFA):** attach EFA interfaces to the GPU instances (p4d/p5/trn) for low-latency, high-throughput RDMA. EFA is optimized for **NCCL** on AWS ([EFA for ML](https://aws.amazon.com/hpc/efa/)). The container image must include NCCL + the EFA/libfabric stack (use AWS Deep Learning Containers or build with `aws-ofi-nccl`).
+- **Cluster placement group:** launch the training ASG's instances into a **cluster placement group** so they are physically close for lowest latency ([Get started with EFA and NCCL for ML on EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start-nccl.html)).
+- **Capacity Blocks for ML** colocate reserved P/Trn instances in EC2 UltraClusters with EFA already — the simplest way to get a well-connected multi-node training cluster ([capacity-and-scaling.md](capacity-and-scaling.md)).
+
+Typical NCCL/EFA container environment:
+
+```bash
+FI_PROVIDER=efa
+FI_EFA_USE_DEVICE_RDMA=1
+NCCL_PROTO=simple
+NCCL_DEBUG=WARN
+```
+
+Expose EFA to the task via the instance (EFA interfaces are configured on the ENI/launch template); the training task uses host networking or `awsvpc` with the EFA-enabled ENI. Because ECS capacity-provider ASGs must be homogeneous ([capacity-and-scaling.md](capacity-and-scaling.md)), a multi-node training job uses **one ASG of one GPU type** sized to the job.
+
+## Orchestrating the Job on ECS
+
+Two common patterns:
+
+1. **Ray on ECS** — run a Ray head task + Ray worker tasks (each a GPU task) as ECS services/tasks; Ray Train handles worker placement, checkpointing, and fault-tolerant resume. This is the AWS-documented ECS distributed-training approach.
+2. **Rank-addressed tasks** — launch N training tasks (one per node) with a shared rendezvous (torchrun/`c10d` or an MPI launcher); each task pins its GPUs via `resourceRequirements`. Use a placement constraint to spread one task per instance.
+
+Keep the **whole job on one homogeneous GPU ASG** and size the ASG to the node count; ECS cluster auto scaling reacts with latency, so pre-provision (or use Capacity Blocks) for large runs rather than relying on reactive scale-out.
+
+## Checkpoint / Resume — Mandatory for Spot
+
+**Never run distributed training on Spot without checkpoint/resume.** Every interruption otherwise restarts from epoch 0 — a guaranteed cost-burn.
+
+```text
+Training task → checkpoint to FSx for Lustre (fast, same-AZ)  ── or ──  directly to S3
+FSx for Lustre → S3 Data Repository Association (async durable offload)
+On interruption → replacement task launches → loads latest checkpoint from S3/FSx → resumes
+```
+
+- Checkpoint every **15–30 min** on Spot (Spot gives a 2-minute warning; managed instance draining helps drain gracefully).
+- Keep checkpoint storage **same-AZ** as the GPU instances — cross-AZ latency dwarfs FSx's native performance ([storage.md](storage.md)).
+- Set the training tasks to **not be disrupted** by scale-in during an active run (schedule on On-Demand/Capacity Blocks, or isolate Spot to interruption-tolerant phases).
+
+## Train → Register → Serve Handoff
+
+The trained artifact (e.g. SafeTensors weights) is written to **S3**; the inference service reads from the same S3 path ([inference-serving.md](inference-serving.md), [storage.md](storage.md)). Version with an S3 key path (`s3://models/llama-7b-ft/v3/`); promote by updating the inference task definition to the new version and forcing a rolling service deployment. For richer pipelines, orchestrate `data-prep → train → eval → register → deploy` with Step Functions or an external workflow engine (Argo/Airflow) — ECS itself has no built-in ML-pipeline DAG.
+
+## Sources
+
+- [Distributed machine learning with Amazon ECS](https://aws.amazon.com/blogs/containers/distributed-machine-learning-with-amazon-ecs/)
+- [Elastic Fabric Adapter (EFA) for ML](https://aws.amazon.com/hpc/efa/) · [Get started with EFA and NCCL for ML workloads on Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start-nccl.html)
+- [EC2 Capacity Blocks for ML](https://aws.amazon.com/ec2/capacityblocks/)
+- [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html) · [ECS task definitions for AWS Neuron ML workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html)
+- [Amazon FSx for Lustre](https://docs.aws.amazon.com/fsx/latest/LustreGuide/what-is.html)

--- a/skills/ecs-genai/references/distributed-training.md
+++ b/skills/ecs-genai/references/distributed-training.md
@@ -2,6 +2,8 @@
 
 Running multi-GPU and multi-node training / fine-tuning on ECS-on-EC2. ECS is a viable orchestrator for distributed ML — AWS documents an end-to-end pattern using **PyTorch + Ray Train** with distributed data parallel on ECS ([Distributed machine learning with Amazon ECS](https://aws.amazon.com/blogs/containers/distributed-machine-learning-with-amazon-ecs/)). Training runs on ECS-on-EC2 (or Managed Instances); **not Fargate** (no GPU/accelerator).
 
+> **Managed Instances caveat for long training runs:** Managed Instances is convenient, but it **initiates security patching every ~14 days by replacing (drain-and-replace) the instance** ([capacity-and-scaling.md](capacity-and-scaling.md)). A multi-week pre-training/fine-tuning run **will be interrupted** by this cadence — so on MI you must have robust checkpoint/resume, schedule patching into a maintenance window, or prefer a **self-managed ASG / Capacity Block** for uninterrupted multi-week jobs.
+
 ## When ECS Fits Distributed Training — and When It Doesn't
 
 - **ECS fits** when the team wants a simple control plane (no Kubernetes to operate), IAM-native auth, and transparent control-plane upgrades, and the job is **single-node multi-GPU** (all GPUs on one instance; PyTorch DDP/FSDP inside one task with `GPU: ALL`) or a moderate multi-node data-parallel run driven by Ray. AWS's reference shows distributed data parallel (DDP) with Ray Train on ECS.
@@ -31,11 +33,12 @@ Typical NCCL/EFA container environment:
 ```bash
 FI_PROVIDER=efa
 FI_EFA_USE_DEVICE_RDMA=1
-NCCL_PROTO=simple
 NCCL_DEBUG=WARN
 ```
 
-Expose EFA to the task via the instance (EFA interfaces are configured on the ENI/launch template); the training task uses host networking or `awsvpc` with the EFA-enabled ENI. Because ECS capacity-provider ASGs must be homogeneous ([capacity-and-scaling.md](capacity-and-scaling.md)), a multi-node training job uses **one ASG of one GPU type** sized to the job.
+(Don't set `NCCL_PROTO=simple` — it's a legacy workaround that disables faster NCCL protocols and is not needed on recent `aws-ofi-nccl`; leave NCCL to auto-select.)
+
+**Exposing EFA to the container — the mechanism (get this right):** EFA attaches to the **instance at launch** via the launch template (an EFA-enabled ENI plus the EFA/libfabric driver baked into the AMI). To let the container use it you must **map the EFA device into the container with `linuxParameters.devices`** — `hostPath` (and, if set, `containerPath`) `/dev/infiniband/uverbs0`, with `permissions` `READ | WRITE | MKNOD` (multi-EFA instances such as p4d expose `uverbs0..uverbs3`). This is the documented device-mapping mechanism ([EFA on AWS Batch](https://docs.aws.amazon.com/batch/latest/userguide/efa.html)); also set the `memlock` ulimit to unlimited, and place all instances in the **same cluster placement group and AZ** (EFA OS-bypass traffic is limited to one AZ). Important: an `awsvpc` task ENI is a **plain interface ENI — it is never the EFA device**, so choosing `awsvpc` networking does not by itself grant EFA access; the `devices` mapping is what does (host networking is the other documented option). Because a heterogeneous GPU ASG breaks managed scaling ([capacity-and-scaling.md](capacity-and-scaling.md)), a multi-node training job uses **one homogeneous ASG of one GPU type** sized to the job.
 
 ## Orchestrating the Job on ECS
 
@@ -67,7 +70,7 @@ The trained artifact (e.g. SafeTensors weights) is written to **S3**; the infere
 ## Sources
 
 - [Distributed machine learning with Amazon ECS](https://aws.amazon.com/blogs/containers/distributed-machine-learning-with-amazon-ecs/)
-- [Elastic Fabric Adapter (EFA) for ML](https://aws.amazon.com/hpc/efa/) · [Get started with EFA and NCCL for ML workloads on Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start-nccl.html)
+- [Elastic Fabric Adapter (EFA) for ML](https://aws.amazon.com/hpc/efa/) · [Get started with EFA and NCCL for ML workloads on Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start-nccl.html) · [EFA device mapping into containers (AWS Batch)](https://docs.aws.amazon.com/batch/latest/userguide/efa.html)
 - [EC2 Capacity Blocks for ML](https://aws.amazon.com/ec2/capacityblocks/)
 - [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html) · [ECS task definitions for AWS Neuron ML workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html)
 - [Amazon FSx for Lustre](https://docs.aws.amazon.com/fsx/latest/LustreGuide/what-is.html)

--- a/skills/ecs-genai/references/inference-serving.md
+++ b/skills/ecs-genai/references/inference-serving.md
@@ -22,6 +22,11 @@ Key choices:
 - **Capacity:** route the service to the right GPU pool with a **capacity-provider strategy** (one ASG per GPU type — see [capacity-and-scaling.md](capacity-and-scaling.md)).
 - **Load balancer:** ALB for HTTP/gRPC inference APIs; NLB for raw TCP / ultra-low-overhead. Tune the **health-check grace period** generously — model load + warmup can take minutes, and a too-short grace period kills tasks mid-warmup.
 - **Networking:** `awsvpc` mode (task ENI) is the default for services behind a load balancer.
+- **Endpoint authentication + exposure:** decide **internal (internal ALB/NLB in private subnets, reached over VPC/PrivateLink)** vs **internet-facing** up front. A self-hosted model endpoint has **no built-in auth** — put authentication in front of it: Cognito/OIDC on the ALB, an API Gateway or a mutual-TLS/JWT-validating reverse-proxy sidecar, or WAF + an authorizer. Never expose a raw model API to the internet unauthenticated. Deep endpoint-security / compliance design → route to **`ecs-security`**.
+
+### Token streaming vs ALB idle timeout (the canonical self-hosted-LLM gotcha)
+
+Streaming LLM responses (SSE / chunked `text/event-stream`) that keep a single HTTP connection open longer than the **ALB idle timeout (default 60s)** get **severed mid-generation** — the client sees a truncated stream on long completions. Fix by **raising the ALB idle timeout** to exceed the longest expected generation (e.g. several minutes), ensuring the serving engine **emits tokens/keep-alive frequently** (regular SSE chunks reset the idle timer), and setting client and target-group timeouts consistently. This is the most common "streaming works in dev, breaks in prod" failure for self-hosted LLMs on ECS behind an ALB.
 
 ## Serving Engine — Bring Your Own Container
 
@@ -48,14 +53,23 @@ Choose based on model size and cold-start tolerance (full matrix in [storage.md]
 | **Mount EFS** | Any (shared) | Low | Multiple tasks/nodes sharing weights (ReadWriteMany) |
 | **FSx for Lustre** | Very large | Zero if pre-warmed | High-throughput weight/checkpoint I/O |
 
-Rules: **pre-cache large model images** (SOCI/parallel pull helps GPU-pod start; huge CUDA/DLC images dominate task launch time); **never pull weights from Hugging Face at every task start** (egress cost, rate limits, cold-start) — stage in S3/ECR first. For Neuron, **pre-compile and ship the compiled artifact** — never compile at task startup ([neuron-on-ecs.md](neuron-on-ecs.md)).
+Rules: **on the EC2 launch type the container image downloads fully before the task starts** — SOCI lazy loading is a **Fargate-PV1.4-only** feature, and Fargate has no GPU, so SOCI is unavailable on every host this skill covers ([storage.md](storage.md)). Mitigate the multi-GB CUDA/DLC image tax with **warm pools of pre-pulled instances, image caching on the instance NVMe, and lean/baked AMI layers** — not SOCI. **Never pull weights from Hugging Face at every task start** (egress cost, rate limits, cold-start) — stage in S3/ECR first. For Neuron, **pre-compile and ship the compiled artifact** — never compile at task startup ([neuron-on-ecs.md](neuron-on-ecs.md)).
+
+## Sizing the GPU to the Model — VRAM Method (not just size buckets)
+
+The coarse "7B–13B → g6e" buckets are a starting point; size VRAM explicitly before choosing an instance:
+
+- **Weights:** `params × bytes-per-param` — FP16/BF16 = 2 bytes (a 7B model ≈ 14 GB; 70B ≈ 140 GB), INT8 ≈ 1 byte, INT4/AWQ/GPTQ ≈ 0.5 byte.
+- **KV cache (often the silent OOM):** grows with `batch × sequence_length × 2 (K+V) × num_layers × hidden_dim × bytes` — at long context and high concurrency this can rival or exceed the weights. Size for peak concurrent context, not just the model.
+- **Overhead:** add headroom for activations, CUDA context, and fragmentation (rule of thumb ~10–20%).
+- Sum the three, then pick a GPU whose memory (from the [compute-hardware.md](compute-hardware.md) table) fits with margin — or shard across GPUs (tensor parallel) when it doesn't. This is why a 70B model at long context needs multi-GPU (e.g. g6e.48xlarge / p4d) even though the weights alone might "fit."
 
 ## Autoscaling the Inference Service
 
 Use **ECS Service Auto Scaling** (Application Auto Scaling) — target-tracking on a meaningful signal:
 
 - **ALB request count per target** (`ALBRequestCountPerTarget`) — simplest proxy for load.
-- **Custom CloudWatch metric** — publish queue depth / in-flight requests / TTFT from the serving engine for a truer signal; GPU utilization from Container Insights enhanced observability (see [observability.md](observability.md)).
+- **Custom CloudWatch metric** — publish queue depth / in-flight requests / TTFT from the serving engine for a truer signal. GPU utilization as an autoscaling signal is **agentless only on Managed Instances**; on the **EC2 launch type** you must publish it via the CloudWatch agent (`nvidia_smi`, host-level) or a DCGM exporter (per-task) — the agentless MI metrics won't exist (see [observability.md](observability.md)).
 - Cluster-level: ECS **cluster auto scaling** grows the GPU ASG when tasks can't place (`PROVISIONING`). Remember the **~15-minute scale-in latency** — factor it into GPU cost. Use warm pools to cut GPU-instance warm-up.
 
 ```json
@@ -84,6 +98,11 @@ Set `scale-out` faster than `scale-in` for GPU services — losing a warm GPU ta
 - Just need a **managed foundation-model API** with no self-hosting → **Amazon Bedrock**.
 
 See [service-boundaries.md](service-boundaries.md).
+
+## AI Gateway / Agentic & RAG on ECS
+
+- **AI gateway:** a self-hosted model-routing/observability/rate-limiting gateway such as **LiteLLM** runs well as a CPU-only ECS service in front of both your ECS-hosted models and Bedrock — this is a documented `ai-gateway` target. Use it to give clients one OpenAI-compatible endpoint, centralize auth/keys, and do cost attribution across self-hosted + managed models.
+- **Agentic / RAG orchestrators:** a CPU-only orchestrator/RAG retriever (calling your GPU inference service and/or Bedrock) fits fine on ECS — including on Fargate for the non-accelerated part ([service-boundaries.md](service-boundaries.md)). Boundary to name: for a **fully-managed agent runtime with memory/tools/identity**, route to **Amazon Bedrock AgentCore**; **self-host on ECS** when you need to own the framework/serving stack. Agentic workloads with autonomous tool/code execution raise sandbox-escape risk → loop in **`ecs-security`**.
 
 ## Sources
 

--- a/skills/ecs-genai/references/inference-serving.md
+++ b/skills/ecs-genai/references/inference-serving.md
@@ -1,0 +1,94 @@
+# Model Inference & Serving on Amazon ECS
+
+Patterns for serving ML / LLM inference from containers on ECS-on-EC2 (or Managed Instances) GPU/Neuron capacity. ECS gives you the container primitives — task definition, service, load balancer, autoscaling — and you bring the serving engine inside the container.
+
+## The Inference Service Shape on ECS
+
+A production inference service on ECS is a standard **ECS Service** with GPU/Neuron tasks behind a load balancer:
+
+```text
+ALB / NLB
+   │  target group (health check → /health or /v1/models)
+   ▼
+ECS Service  (desired count N, capacity-provider strategy → GPU ASG)
+   │
+   ├── Task: [ serving-engine container ]  resourceRequirements GPU:1
+   │        weights loaded from S3 / EFS (see storage.md)
+   └── Task: …  (Service Auto Scaling on request/latency metric)
+```
+
+Key choices:
+- **Launch host:** ECS-on-EC2 or Managed Instances (never Fargate — no GPU). CPU-only pre/post-processing sidecars can share the task.
+- **Capacity:** route the service to the right GPU pool with a **capacity-provider strategy** (one ASG per GPU type — see [capacity-and-scaling.md](capacity-and-scaling.md)).
+- **Load balancer:** ALB for HTTP/gRPC inference APIs; NLB for raw TCP / ultra-low-overhead. Tune the **health-check grace period** generously — model load + warmup can take minutes, and a too-short grace period kills tasks mid-warmup.
+- **Networking:** `awsvpc` mode (task ENI) is the default for services behind a load balancer.
+
+## Serving Engine — Bring Your Own Container
+
+ECS is engine-agnostic; the engine runs inside your image. Common choices (all deployable as an ECS task):
+
+| Engine | Fit | Notes on ECS |
+|---|---|---|
+| **vLLM** | High-throughput LLM inference (GPU or Neuron via `neuronx-distributed-inference`) | OpenAI-compatible API; PagedAttention; run as a single GPU task or scale via ECS Service Auto Scaling |
+| **NVIDIA Triton Inference Server** | Multi-framework / ensembles / TensorRT | One server, multiple model formats; model repo on S3 |
+| **TorchServe / TensorFlow Serving** | Framework-native serving | Straightforward container; good for classic models |
+| **Text Generation Inference (TGI)** | HF-ecosystem LLM serving | Container image + weights from S3/HF |
+| **Custom (FastAPI + framework)** | Bespoke pre/post-processing | Full control; you own batching/metrics |
+
+Note: **KubeRay / Ray Serve, KServe, and the JARK stack are Kubernetes constructs** — they belong to `eks-genai`, not ECS. On ECS you can still run **Ray** inside a task (see [distributed-training.md](distributed-training.md)), but the K8s-operator serving stacks do not apply.
+
+## Model Loading — Get Weights to the Task
+
+Choose based on model size and cold-start tolerance (full matrix in [storage.md](storage.md)):
+
+| Pattern | Model size | Cold-start | Best for |
+|---|---|---|---|
+| **Bake into image** | < ~5 GB | Zero (in image layers) | Small/classic models; air-gapped |
+| **Pull from S3 at start** | 5–200+ GB | Seconds–minutes | LLMs; decoupled model/image release |
+| **Mount EFS** | Any (shared) | Low | Multiple tasks/nodes sharing weights (ReadWriteMany) |
+| **FSx for Lustre** | Very large | Zero if pre-warmed | High-throughput weight/checkpoint I/O |
+
+Rules: **pre-cache large model images** (SOCI/parallel pull helps GPU-pod start; huge CUDA/DLC images dominate task launch time); **never pull weights from Hugging Face at every task start** (egress cost, rate limits, cold-start) — stage in S3/ECR first. For Neuron, **pre-compile and ship the compiled artifact** — never compile at task startup ([neuron-on-ecs.md](neuron-on-ecs.md)).
+
+## Autoscaling the Inference Service
+
+Use **ECS Service Auto Scaling** (Application Auto Scaling) — target-tracking on a meaningful signal:
+
+- **ALB request count per target** (`ALBRequestCountPerTarget`) — simplest proxy for load.
+- **Custom CloudWatch metric** — publish queue depth / in-flight requests / TTFT from the serving engine for a truer signal; GPU utilization from Container Insights enhanced observability (see [observability.md](observability.md)).
+- Cluster-level: ECS **cluster auto scaling** grows the GPU ASG when tasks can't place (`PROVISIONING`). Remember the **~15-minute scale-in latency** — factor it into GPU cost. Use warm pools to cut GPU-instance warm-up.
+
+```json
+// Application Auto Scaling target tracking on ALB requests per target
+{
+  "TargetValue": 30.0,
+  "PredefinedMetricSpecification": { "PredefinedMetricType": "ALBRequestCountPerTarget" },
+  "ScaleInCooldown": 300,
+  "ScaleOutCooldown": 60
+}
+```
+
+Set `scale-out` faster than `scale-in` for GPU services — losing a warm GPU task is expensive to re-warm; adding one late hurts latency.
+
+## Serving Availability & Deployment Safety
+
+- **Min-healthy-% / max-%** tuned for GPU scarcity: a rolling deploy that briefly needs 2× GPU capacity may not place if the ASG can't scale. Confirm headroom or use a slower rollout.
+- **Deployment circuit breaker** with rollback protects against a bad model image.
+- **Health-check grace period** long enough for model load + warmup, or ECS will kill healthy-but-warming tasks.
+- **Connection draining** so in-flight inference requests complete before task stop.
+
+## When to Route Off ECS for Serving
+
+- Need **scale-to-zero**, **fractional-GPU (MIG/time-slicing) multi-model packing**, or a **Kubernetes-native serving mesh (KServe/Ray Serve/JARK)** → **`eks-genai`**.
+- Want a **fully-managed inference endpoint** (autoscaling, multi-model endpoints, no cluster to run) → **Amazon SageMaker** real-time/serverless/async inference.
+- Just need a **managed foundation-model API** with no self-hosting → **Amazon Bedrock**.
+
+See [service-boundaries.md](service-boundaries.md).
+
+## Sources
+
+- [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)
+- [Amazon ECS Best Practices Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-best-practices.html) (tasks & services, health checks, autoscaling)
+- [Target tracking scaling for Amazon ECS Service Auto Scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-auto-scaling.html)
+- [Automatically manage Amazon ECS capacity with cluster auto scaling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-auto-scaling.html)
+- [Using Amazon ECS with NVIDIA GPUs to accelerate drug discovery](https://aws.amazon.com/blogs/containers/using-amazon-ecs-with-nvidia-gpus-to-accelerate-drug-discovery/)

--- a/skills/ecs-genai/references/neuron-on-ecs.md
+++ b/skills/ecs-genai/references/neuron-on-ecs.md
@@ -36,7 +36,7 @@ aws ssm get-parameters \
   --names /aws/service/ecs/optimized-ami/amazon-linux-2023/neuron/recommended
 ```
 
-(The AWS CDK exposes the same via `EcsOptimizedImage.amazonLinux2(AmiHardwareType.NEURON)` for Inf1/Trn1/Inf2 launches.)
+> **CDK caveat (AL2 vs AL2023 mismatch):** `EcsOptimizedImage.amazonLinux2(AmiHardwareType.NEURON)` returns the **Amazon Linux 2 (Neuron)** AMI — *not* the AL2023 Neuron AMI recommended above ([CDK aws-ecs — Amazon Linux 2 (Neuron) Instances](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs-readme.html)). To launch the **AL2023** Neuron AMI in CDK, don't rely on `amazonLinux2(...NEURON)`; use the **SSM parameter above directly** (e.g. `MachineImage.fromSsmParameter(...)`) so the launch template actually gets AL2023.
 
 ## Two Ways to Give a Container Neuron Devices
 
@@ -112,5 +112,5 @@ AWS-published price-performance claims for Inferentia2/Trainium live on the EC2 
 - [Amazon ECS task definitions for AWS Neuron machine learning workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html)
 - [Example Neuron task definitions for Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference-task-def.html)
 - [AWS Neuron](https://aws.amazon.com/ai/machine-learning/neuron/) · [AWS Inferentia](https://aws.amazon.com/ai/machine-learning/inferentia/) · [AWS Trainium](https://aws.amazon.com/ai/machine-learning/trainium/)
-- [Use GPUs with Amazon ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html) (Neuron selection via instanceRequirements)
+- [Amazon ECS task definitions for AWS Neuron ML workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html) — the authoritative source for the managed `NeuronDevice` allocation path and `instanceRequirements` Neuron selection (the NVIDIA-only [managed-instances-gpu.html](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html) does *not* cover Neuron device allocation)
 - [aws-cdk-lib.aws_ecs — Amazon Linux 2 (Neuron) Instances](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs-readme.html)

--- a/skills/ecs-genai/references/neuron-on-ecs.md
+++ b/skills/ecs-genai/references/neuron-on-ecs.md
@@ -1,0 +1,116 @@
+# AWS Neuron (Inferentia / Trainium) on Amazon ECS
+
+Running AWS purpose-built ML accelerators — **AWS Inferentia (Inf1, Inf2)** and **AWS Trainium (Trn1, Trn2)** — as ECS workloads. Neuron is the cost-optimized alternative to NVIDIA GPU for **supported Transformer-family models**, at the cost of an ahead-of-time compilation step. Like GPU, **Neuron is not available on Fargate** — it runs on ECS-on-EC2 and ECS Managed Instances (Inf1 is EC2-launch-type only).
+
+## Supported Instances & What Each Is For
+
+Per [ECS task definitions for AWS Neuron ML workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html):
+
+| Family | Chip | Role | ECS support |
+|---|---|---|---|
+| **Trn1, Trn2** | AWS Trainium | High-performance, low-cost **training** (also large-model inference) | EC2 launch type + Managed Instances |
+| **Inf2** | AWS Inferentia2 | High-performance, low-cost **inference** | EC2 launch type + Managed Instances |
+| **Inf1** | AWS Inferentia | Inference (first-gen) | **EC2 launch type only** |
+
+Verbatim device mapping from the ECS Neuron doc (subset — chips per instance, used for manual device specification):
+
+| Instance | vCPUs | RAM (GiB) | Neuron chips | Device paths |
+|---|---|---|---|---|
+| trn1.2xlarge | 8 | 32 | 1 | /dev/neuron0 |
+| trn1.32xlarge | 128 | 512 | 16 | /dev/neuron0 … /dev/neuron15 |
+| trn2.48xlarge | 192 | 2048 | 16 | /dev/neuron0 … /dev/neuron15 |
+| inf1.xlarge | 4 | 8 | 1 | /dev/neuron0 |
+| inf1.24xlarge | 96 | 192 | 16 | /dev/neuron0 … /dev/neuron15 |
+| inf2.xlarge | 4 | 16 | 1 | /dev/neuron0 |
+| inf2.24xlarge | 96 | 384 | 6 | /dev/neuron0 … /dev/neuron5 |
+| inf2.48xlarge | 192 | 768 | 12 | /dev/neuron0 … /dev/neuron11 |
+
+Clusters can mix Trn1, Trn2, Inf1, Inf2, and other instances (subject to the per-type-ASG capacity rule in [capacity-and-scaling.md](capacity-and-scaling.md)). The workload must be a **Linux** container using a framework with Neuron support (PyTorch, TensorFlow) via the **AWS Neuron SDK** (compiler + runtime + profiling tools). Non-Neuron frameworks won't get accelerated performance on these instances.
+
+## The ECS Neuron-Optimized AMI
+
+ECS provides a **Neuron-optimized Amazon Linux 2023 AMI** with the AWS Neuron drivers and Docker runtime pre-installed — recommended for launching Trn1, Inf1, and Inf2 instances ([ECS Neuron ML workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html)):
+
+```bash
+aws ssm get-parameters \
+  --names /aws/service/ecs/optimized-ami/amazon-linux-2023/neuron/recommended
+```
+
+(The AWS CDK exposes the same via `EcsOptimizedImage.amazonLinux2(AmiHardwareType.NEURON)` for Inf1/Trn1/Inf2 launches.)
+
+## Two Ways to Give a Container Neuron Devices
+
+ECS supports **two approaches** for Neuron device access — use one consistently to avoid conflicts:
+
+### 1. Managed Neuron device allocation (Managed Instances only)
+
+Use `resourceRequirements` type **`NeuronDevice`** with value `ALL`. ECS discovers Neuron devices on the instance, assigns them, and gives the container access to **all** Neuron devices — so **only one Neuron task runs per instance** (exclusive access).
+
+```json
+{
+  "containerDefinitions": [
+    {
+      "name": "neuron-inference",
+      "image": "<account>.dkr.ecr.<region>.amazonaws.com/vllm-neuron:latest",
+      "resourceRequirements": [
+        { "type": "NeuronDevice", "value": "ALL" }
+      ]
+    }
+  ]
+}
+```
+
+Constraints: at most one container definition may specify `NeuronDevice`; you can't combine `NeuronDevice` `resourceRequirements` with `linuxParameters.devices` for Neuron in the same task definition. After launch, verify via `DescribeTasks` (`neuronDeviceIds` per container) or `DescribeContainerInstances` (`NEURON_DEVICES` in registered/remaining resources). Select Neuron instances in the Managed Instances launch template with `instanceRequirements`:
+
+```json
+{
+  "instanceRequirements": {
+    "acceleratorManufacturers": ["amazon-web-services"],
+    "acceleratorNames": ["inferentia2", "trainium", "trainium2"],
+    "allowedInstanceTypes": ["inf*", "trn*"]
+  }
+}
+```
+
+### 2. Manual Neuron device specification (EC2 launch type + Managed Instances)
+
+Explicitly map device paths with `linuxParameters.devices`. **Only one inference/training task can run per Trainium/Inferentia chip**; you can run as many tasks as there are chips by assigning different devices to each. The **task definition must be specific to a single instance type** (device paths differ per instance — see the table above). Use task placement constraints on `ecs.instance-type` to land the task on the right family.
+
+```json
+{
+  "containerDefinitions": [
+    {
+      "name": "neuron-inference",
+      "image": "…/vllm-neuron:latest",
+      "linuxParameters": {
+        "devices": [
+          { "hostPath": "/dev/neuron0", "containerPath": "/dev/neuron0", "permissions": ["read","write"] }
+        ]
+      }
+    }
+  ]
+}
+```
+
+## Compilation — The Ramp Cost
+
+Neuron requires **ahead-of-time compilation** of the model (via `torch-neuronx` / `neuronx-distributed-inference` for Inf2/Trn; `torch-neuron` for Inf1). This is the primary adoption friction vs NVIDIA GPU:
+
+- Budget **1–2 weeks** for the first model (SDK learning, graph-break debugging, tensor/pipeline-parallel tuning). Subsequent versions are much faster (reuse compilation cache).
+- **Pre-compile offline** in CI and ship the compiled artifact via S3 or bake it into the container image. **Never compile at task startup** in production — it puts a multi-minute step on the critical path.
+- **Verify the specific model architecture is Neuron-supported before committing budget** — not all Hugging Face models have Neuron support; verify against the [AWS Neuron](https://aws.amazon.com/ai/machine-learning/neuron/) supported-models list, and run an eval suite comparing GPU vs Neuron output quality before shifting production traffic.
+
+## When Neuron Wins (and When It Doesn't)
+
+- **Recommend Neuron when:** the model is Transformer-family (Llama, Mistral, Qwen, etc.), framework is PyTorch/TensorFlow with Neuron support, the workload is steady-state production (inference on Inf2) or cost-sensitive training (Trn1/Trn2), and the team can absorb the compilation ramp.
+- **Stay on NVIDIA GPU when:** fastest time-to-first-success matters, there are CUDA-only dependencies, the architecture is novel/non-Transformer or multi-modal, or Neuron support for the model is unverified.
+
+AWS-published price-performance claims for Inferentia2/Trainium live on the EC2 instance-type pages — cite those pages rather than restating a percentage here. Give directional ranges with caveats.
+
+## Sources
+
+- [Amazon ECS task definitions for AWS Neuron machine learning workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html)
+- [Example Neuron task definitions for Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference-task-def.html)
+- [AWS Neuron](https://aws.amazon.com/ai/machine-learning/neuron/) · [AWS Inferentia](https://aws.amazon.com/ai/machine-learning/inferentia/) · [AWS Trainium](https://aws.amazon.com/ai/machine-learning/trainium/)
+- [Use GPUs with Amazon ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html) (Neuron selection via instanceRequirements)
+- [aws-cdk-lib.aws_ecs — Amazon Linux 2 (Neuron) Instances](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs-readme.html)

--- a/skills/ecs-genai/references/observability.md
+++ b/skills/ecs-genai/references/observability.md
@@ -1,0 +1,61 @@
+# Observability for GPU / ML Workloads on Amazon ECS
+
+GPU/ML observability on ECS adds three concerns over standard container monitoring: **accelerator utilization/memory**, **per-request/inference latency**, and **cost attribution** for expensive GPU/Neuron capacity. The primary AWS-native path is **CloudWatch Container Insights with enhanced observability**.
+
+## GPU Metrics — Container Insights Enhanced Observability
+
+For ECS running **NVIDIA GPU** instances, **Container Insights with enhanced observability collects GPU metrics from NVIDIA DCGM (Data Center GPU Manager) at the container, task, and instance levels** — with **no additional agent installation** required. GPU metrics are collected automatically on supported instance types once enhanced observability is enabled on the cluster ([Monitoring ECS Managed Instances — GPU monitoring](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/monitoring-managed-instances.html)).
+
+- **GPU metrics are NOT collected with basic Container Insights** — you must **enable enhanced observability** to get GPU telemetry.
+- Metrics land in CloudWatch (the `ECS/ContainerInsights` enhanced namespace); build dashboards and alarms there.
+- Typical DCGM-sourced signals: GPU compute utilization, GPU memory utilization, GPU temperature, at node/task/container granularity (analogous to the EKS Container Insights GPU metric set — e.g. `*_gpu_utilization`, `*_gpu_memory_utilization`, `*_gpu_temperature`).
+
+Enable on the cluster:
+
+```bash
+aws ecs update-cluster-settings \
+  --cluster my-gpu-cluster \
+  --settings name=containerInsights,value=enhanced
+```
+
+## What to Watch (and rough thresholds)
+
+| Signal | Why it matters | Guidance |
+|---|---|---|
+| **GPU utilization** | Are you paying for idle GPUs? | <50% sustained → consolidate/right-size; >90% sustained → capacity risk |
+| **GPU memory utilization** | KV-cache / model headroom | >~90% → OOM risk; upsize instance or reduce batch/context |
+| **GPU temperature** | Thermal throttling | Alert high temps; correlate with throughput drops |
+| **Inference latency (TTFT / p99)** | User-perceived quality | Publish from the serving engine as a custom CloudWatch metric |
+| **In-flight / queued requests** | Saturation signal for autoscaling | Drive ECS Service Auto Scaling ([inference-serving.md](inference-serving.md)) |
+| **EFA traffic (multi-node training)** | Inter-node fabric health | Packet drops / throughput dips precede training stalls |
+
+## Neuron (Inferentia / Trainium) Metrics
+
+For Neuron workloads, use the **AWS Neuron Monitor** tooling / `neuron-monitor` (part of the Neuron SDK on the ECS Neuron-optimized AMI) to expose NeuronCore utilization, HBM usage, and EFA interface health. Publish to CloudWatch (Container Insights) or a Prometheus scrape. Key categories: per-NeuronCore compute/memory %, HBM used/free per device, EFA Tx/Rx and drops, and compilation-cache hit/miss (a miss ratio > 0 in steady state signals models aren't pre-compiled — see [neuron-on-ecs.md](neuron-on-ecs.md)).
+
+## Standard ECS Telemetry (still applies)
+
+- **CloudWatch metrics** — CPU, memory, network at cluster/service/task level (free, 2-week retention); Container Insights adds task/instance-level and diagnostics.
+- **Logs** — `awslogs` driver to CloudWatch Logs, or **FireLens** (Fluent Bit) to route to OpenSearch/S3/third-party. Keep log routing off the GPU's critical path.
+- **CloudTrail** — API audit (task launches, S3 model-bucket data events).
+- **Third-party** — Datadog/Dynatrace/New Relic as agent sidecars; they can scrape DCGM/Neuron and the serving-engine `/metrics` endpoint.
+
+## Cost Attribution
+
+GPU/Neuron capacity is the dominant cost. Attribute it with:
+- **AWS Split Cost Allocation Data (SCAD)** for per-task ECS cost allocation in Cost Explorer.
+- **Cost allocation tags** on services/task definitions (team, model, environment).
+- **Custom per-request accounting** from the serving engine (tokens/requests per tenant) when you need per-tenant chargeback.
+
+## Keep Observability Off the GPU's Back
+
+DCGM collection is agentless via Container Insights (no scheduling concern), but any **heavy log-processing or metrics sidecars** should be sized carefully — GPU-instance memory is precious. Don't co-locate memory-hungry aggregation with large model tasks; prefer routing to managed backends (CloudWatch, AMP, third-party SaaS).
+
+## Sources
+
+- [Monitoring Amazon ECS Managed Instances (GPU / DCGM via Container Insights enhanced)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/monitoring-managed-instances.html)
+- [Amazon ECS CloudWatch Container Insights](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-container-insights.html)
+- [Gain operational insights for NVIDIA GPU workloads using CloudWatch Container Insights](https://aws.amazon.com/blogs/mt/gain-operational-insights-for-nvidia-gpu-workloads-using-amazon-cloudwatch-container-insights/)
+- [AWS Neuron Monitor](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/tools/neuron-sys-tools/neuron-monitor-user-guide.html)
+- [Send Amazon ECS logs to CloudWatch / FireLens](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html)
+- [AWS Split Cost Allocation Data](https://docs.aws.amazon.com/cur/latest/userguide/split-cost-allocation-data.html)

--- a/skills/ecs-genai/references/observability.md
+++ b/skills/ecs-genai/references/observability.md
@@ -2,13 +2,16 @@
 
 GPU/ML observability on ECS adds three concerns over standard container monitoring: **accelerator utilization/memory**, **per-request/inference latency**, and **cost attribution** for expensive GPU/Neuron capacity. The primary AWS-native path is **CloudWatch Container Insights with enhanced observability**.
 
-## GPU Metrics — Container Insights Enhanced Observability
+## GPU Metrics — Two Different Paths (MI vs EC2 launch type)
 
-For ECS running **NVIDIA GPU** instances, **Container Insights with enhanced observability collects GPU metrics from NVIDIA DCGM (Data Center GPU Manager) at the container, task, and instance levels** — with **no additional agent installation** required. GPU metrics are collected automatically on supported instance types once enhanced observability is enabled on the cluster ([Monitoring ECS Managed Instances — GPU monitoring](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/monitoring-managed-instances.html)).
+This is the single most-often-wrong claim about GPU observability on ECS: the **agentless DCGM path is Managed-Instances-only**, not "all ECS NVIDIA instances." Get the path right for the launch model.
 
-- **GPU metrics are NOT collected with basic Container Insights** — you must **enable enhanced observability** to get GPU telemetry.
-- Metrics land in CloudWatch (the `ECS/ContainerInsights` enhanced namespace); build dashboards and alarms there.
-- Typical DCGM-sourced signals: GPU compute utilization, GPU memory utilization, GPU temperature, at node/task/container granularity (analogous to the EKS Container Insights GPU metric set — e.g. `*_gpu_utilization`, `*_gpu_memory_utilization`, `*_gpu_temperature`).
+### Managed Instances — agentless DCGM via Container Insights enhanced observability
+
+For **ECS Managed Instances running NVIDIA GPU-enabled EC2 types**, Container Insights with enhanced observability collects GPU metrics from NVIDIA DCGM at the container, task, and instance levels, with **no additional agent installation** ([Monitoring ECS Managed Instances — GPU monitoring](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/monitoring-managed-instances.html)). Every one of these GPU metrics is documented as **"Available only for Amazon ECS Managed Instances running NVIDIA GPU-enabled Amazon EC2 instance types"** ([Container Insights enhanced observability metrics for ECS](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-enhanced-observability-metrics-ECS.html)).
+
+- **GPU metrics are NOT collected with basic Container Insights** — you must **enable enhanced observability**.
+- Metrics land in the `ECS/ContainerInsights` namespace. The **actual metric names** are `TaskGPUUtilization`, `TaskGPUMemoryUtilization`, `TaskGPUMemoryUsed`/`TaskGPUMemoryTotal`, `TaskGPUPowerDraw`, `TaskGPUTemperature`, `TaskGPURestartAppXidCount` (and the `ContainerGPU*` and `InstanceGPULimit`/`InstanceGPUUsageTotal` families) — **not** the EKS-style `*_gpu_utilization` names. Cite these exact names.
 
 Enable on the cluster:
 
@@ -17,6 +20,14 @@ aws ecs update-cluster-settings \
   --cluster my-gpu-cluster \
   --settings name=containerInsights,value=enhanced
 ```
+
+### ECS-on-EC2 launch type — no agentless DCGM path
+
+On the **EC2 launch type there is no agentless DCGM collection**. To get GPU telemetry you deploy an agent:
+- **CloudWatch agent with `nvidia_smi`** — the CloudWatch-agent collects host-level NVIDIA GPU metrics (utilization, memory, temperature, power) per **instance**. Simplest, but **host-level only — no per-task attribution**.
+- **DCGM exporter (or the Neuron/DCGM exporter sidecar) → CloudWatch/AMP/Prometheus** — deploy the exporter as a container to get **per-task / per-GPU** granularity, at the cost of running and sizing the exporter yourself.
+
+So if an inference service on the **EC2 launch type** wants GPU utilization as an autoscaling signal (see [inference-serving.md](inference-serving.md)), it must publish it via one of these agents — the agentless MI metrics won't exist.
 
 ## What to Watch (and rough thresholds)
 
@@ -31,11 +42,13 @@ aws ecs update-cluster-settings \
 
 ## Neuron (Inferentia / Trainium) Metrics
 
-For Neuron workloads, use the **AWS Neuron Monitor** tooling / `neuron-monitor` (part of the Neuron SDK on the ECS Neuron-optimized AMI) to expose NeuronCore utilization, HBM usage, and EFA interface health. Publish to CloudWatch (Container Insights) or a Prometheus scrape. Key categories: per-NeuronCore compute/memory %, HBM used/free per device, EFA Tx/Rx and drops, and compilation-cache hit/miss (a miss ratio > 0 in steady state signals models aren't pre-compiled — see [neuron-on-ecs.md](neuron-on-ecs.md)).
+For Neuron workloads, use the **AWS Neuron Monitor** tooling / `neuron-monitor` (part of the Neuron SDK on the ECS Neuron-optimized AMI) and publish to CloudWatch (via `neuron-monitor-cloudwatch.py`) or a Prometheus scrape. Its **documented metric groups** are: `neuroncore_counters` (per-NeuronCore utilization), `memory_used`, `neuron_runtime_vcpu_usage`, `execution_stats` (error count + latency), and the system groups `vcpu_usage`, `memory_info`, and `neuron_hw_counters` — where `neuron_hw_counters` is **ECC event counters only** (corrected/uncorrected DRAM and SRAM ECC), *not* general hardware telemetry ([neuron-monitor User Guide](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/tools/neuron-sys-tools/neuron-monitor-user-guide.html)).
+
+Two corrections to a common mis-statement: **neuron-monitor has no EFA metric group** — get EFA Tx/Rx and drops from `ethtool` / `/sys/class/infiniband/*/ports/*/counters` or the CloudWatch agent, not neuron-monitor. And **neuron-monitor exposes no compilation-cache hit/miss metric** — don't monitor for it; instead enforce pre-compilation at the pipeline level (ship the compiled artifact — see [neuron-on-ecs.md](neuron-on-ecs.md)).
 
 ## Standard ECS Telemetry (still applies)
 
-- **CloudWatch metrics** — CPU, memory, network at cluster/service/task level (free, 2-week retention); Container Insights adds task/instance-level and diagnostics.
+- **CloudWatch metrics** — CPU, memory, network at cluster/service/task level; Container Insights adds task/instance-level and diagnostics. **Retention:** 1-minute datapoints are kept **15 days**, but metrics persist up to **15 months** at coarser resolution (5-min to 63 days, 1-hour to 455 days) — data is aggregated, not deleted ([CloudWatch metrics retention](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html)). Note Container Insights metrics are billed as custom metrics.
 - **Logs** — `awslogs` driver to CloudWatch Logs, or **FireLens** (Fluent Bit) to route to OpenSearch/S3/third-party. Keep log routing off the GPU's critical path.
 - **CloudTrail** — API audit (task launches, S3 model-bucket data events).
 - **Third-party** — Datadog/Dynatrace/New Relic as agent sidecars; they can scrape DCGM/Neuron and the serving-engine `/metrics` endpoint.
@@ -49,12 +62,13 @@ GPU/Neuron capacity is the dominant cost. Attribute it with:
 
 ## Keep Observability Off the GPU's Back
 
-DCGM collection is agentless via Container Insights (no scheduling concern), but any **heavy log-processing or metrics sidecars** should be sized carefully — GPU-instance memory is precious. Don't co-locate memory-hungry aggregation with large model tasks; prefer routing to managed backends (CloudWatch, AMP, third-party SaaS).
+DCGM collection is agentless **only on Managed Instances** (no scheduling concern there), but on the EC2 launch type the CloudWatch-agent / DCGM-exporter and any **heavy log-processing or metrics sidecars** should be sized carefully — GPU-instance memory is precious. Don't co-locate memory-hungry aggregation with large model tasks; prefer routing to managed backends (CloudWatch, AMP, third-party SaaS).
 
 ## Sources
 
 - [Monitoring Amazon ECS Managed Instances (GPU / DCGM via Container Insights enhanced)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/monitoring-managed-instances.html)
-- [Amazon ECS CloudWatch Container Insights](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-container-insights.html)
+- [Amazon ECS Container Insights with enhanced observability metrics (GPU metric names; MI-only)](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-enhanced-observability-metrics-ECS.html)
+- [Amazon ECS CloudWatch Container Insights](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-container-insights.html) · [CloudWatch metrics retention](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html)
 - [Gain operational insights for NVIDIA GPU workloads using CloudWatch Container Insights](https://aws.amazon.com/blogs/mt/gain-operational-insights-for-nvidia-gpu-workloads-using-amazon-cloudwatch-container-insights/)
 - [AWS Neuron Monitor](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/tools/neuron-sys-tools/neuron-monitor-user-guide.html)
 - [Send Amazon ECS logs to CloudWatch / FireLens](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html)

--- a/skills/ecs-genai/references/security-and-compliance.md
+++ b/skills/ecs-genai/references/security-and-compliance.md
@@ -1,0 +1,95 @@
+# Security & Compliance for GPU / ML Workloads on Amazon ECS
+
+Non-negotiable security baseline for every GPU/ML-on-ECS deployment. GenAI workloads add supply-chain (model artifacts, huge dependency images) and data-processing (prompts, outputs, embeddings) risk on top of standard ECS hardening. For deep, general ECS security use the `ecs-security` skill; this file is the GPU/ML-specific slice.
+
+## The Non-Negotiable Baseline
+
+Include every item in every GPU/ML-on-ECS response.
+
+### 1. Task role + execution role — least-privilege, no static keys
+
+- **Task role** grants the *application* (model server / trainer) its AWS permissions — S3 for weights/checkpoints, Bedrock-runtime if used as a gateway target, Secrets Manager. Scope to specific buckets/prefixes/secrets; **never** put `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` in env vars, the task definition, or the image.
+- **Execution role** grants the *ECS agent* rights to pull the ECR image and inject secrets/logs — keep it separate and minimal.
+- The recurring hard failure on ECS is the **task-role trust-relationship error** ("ECS was unable to assume the role"): the role's trust policy must allow `ecs-tasks.amazonaws.com` to `sts:AssumeRole`, and `iam:PassRole` must be granted to whoever registers/runs the task. Get the trust policy right first.
+
+```json
+// Task role trust policy
+{ "Version": "2012-10-17", "Statement": [{
+  "Effect": "Allow",
+  "Principal": { "Service": "ecs-tasks.amazonaws.com" },
+  "Action": "sts:AssumeRole"
+}]}
+```
+
+### 2. Secrets — Secrets Manager / SSM Parameter Store injection
+
+Store model-registry tokens, API keys, and gateway keys in **AWS Secrets Manager** or **SSM Parameter Store**; inject via the task definition `secrets` block (resolved by the execution role) — never bake secrets into the (often cached, widely-pulled) model image or a ConfigMap-style env.
+
+```json
+"secrets": [
+  { "name": "HF_TOKEN", "valueFrom": "arn:aws:secretsmanager:REGION:ACCT:secret:hf-token" }
+]
+```
+
+### 3. ECR image scanning
+
+Enable **ECR enhanced scanning (Amazon Inspector)** and block deployment of critical/high CVEs. GPU/ML images (CUDA, cuDNN, PyTorch, Neuron SDK, DLC) carry **far larger dependency trees** than typical microservices — scan on push and periodically for base-image drift.
+
+### 4. Model-artifact provenance
+
+A poisoned model artifact executes arbitrary inference on customer data — treat weights like application binaries. Verify integrity before serving: pin **exact model revisions** (not floating tags/branches); verify **SHA256 checksums** for downloaded weights; use **image signing** (AWS Signer / Sigstore) for baked-in models; enable **S3 Object Lock** for production artifact buckets.
+
+### 5. Network isolation
+
+Place GPU/Neuron container instances in **private subnets** with no direct inbound internet. Route AWS API calls through **VPC endpoints**:
+
+| Endpoint | Why |
+|---|---|
+| `s3` (Gateway) | Model weights, checkpoints, training data |
+| `ecr.api` + `ecr.dkr` | Image pull |
+| `secretsmanager` | Secrets injection |
+| `logs` / `monitoring` | CloudWatch Logs / metrics |
+| `bedrock-runtime` (Interface) | Only if the app calls Bedrock as a model target |
+
+Egress for any unavoidable downloads via a NAT gateway with restrictive SGs — or eliminate by pre-caching all artifacts to S3/ECR. Use **security-group-per-task** (`awsvpc` mode) to scope task-to-task traffic.
+
+### 6. Container hardening
+
+Run containers **non-root**, with **read-only root filesystem** where the framework allows, and drop unneeded Linux capabilities. Note the GPU-sharing exception: making `nvidia` the default Docker runtime for GPU sharing loosens isolation — reserve that pattern for dev/test ([compute-hardware.md](compute-hardware.md)).
+
+### 7. GuardDuty ECS Runtime Monitoring + audit logging
+
+Enable **GuardDuty ECS Runtime Monitoring** on the EC2 container instances for runtime threat detection. Enable **CloudTrail** (management + S3 model-bucket data events) and **Container Insights** for audit and forensics. Retain per compliance requirement.
+
+## Compliance-Regime Notes
+
+- **HIPAA:** GPU tasks processing PHI on a HIPAA-eligible account (BAA in place); KMS-CMK encryption for EBS/S3/EFS; audit all access; verify Bedrock/other targets' HIPAA status at deployment.
+- **PCI-DSS:** isolate GPU/ML workloads in a dedicated cluster or node group + namespace + SG boundary within the CDE; encrypt task-to-task traffic; quarterly image scans retained.
+- **FedRAMP:** GovCloud or FedRAMP-authorized Regions; FIPS-validated modules; images only from an approved ECR in-boundary (no Docker Hub / HF pulls in prod).
+- **GDPR:** EU-region deployment for EU personal data; design right-to-erasure so deleting source documents cascades to derived embeddings; treat stored prompts/outputs as personal data.
+
+## When to Escalate to a Specialist Review
+
+1. Regulated data (HIPAA/PCI/FedRAMP/GDPR) processed by the GenAI workload — GenAI compliance is materially harder (prompts, outputs, embeddings are all data-processing).
+2. Multi-tenant SaaS needing cross-tenant isolation of models/data on shared GPU capacity.
+3. Agentic workloads with autonomous code/tool execution — sandbox-escape risk.
+4. Air-gapped environments with no VPC-endpoint path — custom supply-chain design.
+
+## Quick-Reference Checklist
+
+- [ ] Task role + execution role least-privilege; trust policy allows `ecs-tasks.amazonaws.com`; `iam:PassRole` scoped
+- [ ] Secrets via Secrets Manager / SSM — never in image/env
+- [ ] ECR enhanced scanning — critical/high blocked
+- [ ] Model provenance — pinned revision + checksum/signing
+- [ ] Private subnets + VPC endpoints (S3, ECR, Secrets Manager, logs; Bedrock if used)
+- [ ] Non-root, read-only rootfs, dropped capabilities
+- [ ] GuardDuty ECS Runtime Monitoring + CloudTrail + Container Insights
+
+## Sources
+
+- [Amazon ECS security best practices](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/security.html) · [Amazon ECS Best Practices Guide — security](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-best-practices.html)
+- [Amazon ECS task IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) · [Task execution IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html)
+- [Passing sensitive data to a container (Secrets Manager / SSM)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html)
+- [Amazon ECR image scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html)
+- [GuardDuty Runtime Monitoring for Amazon ECS](https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring.html)
+- [Interface VPC endpoints for Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/vpc-endpoints.html)

--- a/skills/ecs-genai/references/security-and-compliance.md
+++ b/skills/ecs-genai/references/security-and-compliance.md
@@ -1,71 +1,41 @@
 # Security & Compliance for GPU / ML Workloads on Amazon ECS
 
-Non-negotiable security baseline for every GPU/ML-on-ECS deployment. GenAI workloads add supply-chain (model artifacts, huge dependency images) and data-processing (prompts, outputs, embeddings) risk on top of standard ECS hardening. For deep, general ECS security use the `ecs-security` skill; this file is the GPU/ML-specific slice.
+This file is the **GPU/ML-specific security slice only.** The generic ECS security baseline — task/execution-role least-privilege and the `ecs-tasks.amazonaws.com` trust policy, secrets via Secrets Manager/SSM, ECR enhanced scanning, private subnets + VPC endpoints, `awsvpc` security-group-per-task, non-root/read-only-rootfs container hardening, CloudTrail + Container Insights audit — is **owned by the `ecs-security` skill; route deep compliance and CDE design there** and don't restate it in full here. What follows is only what changes because the workload is GPU/ML/GenAI.
 
-## The Non-Negotiable Baseline
+## Baseline pointer (apply via `ecs-security`)
 
-Include every item in every GPU/ML-on-ECS response.
+Every GPU/ML-on-ECS response still MUST include the standard baseline (roles, secrets, ECR scanning, private subnets + endpoints, hardening, audit) — see **`ecs-security`** for the how. Two baseline items have GPU/ML-specific twists worth stating inline:
 
-### 1. Task role + execution role — least-privilege, no static keys
+- **Task role** grants the model server/trainer its S3 (weights/checkpoints), Secrets Manager, and — if the app calls Bedrock as a model target — **`bedrock-runtime`** permissions; scope to exact buckets/prefixes/secrets, never static keys.
+- **Container hardening exception:** the GPU-sharing pattern (making `nvidia` the default Docker runtime) **loosens isolation** — reserve it for dev/test ([compute-hardware.md](compute-hardware.md)).
 
-- **Task role** grants the *application* (model server / trainer) its AWS permissions — S3 for weights/checkpoints, Bedrock-runtime if used as a gateway target, Secrets Manager. Scope to specific buckets/prefixes/secrets; **never** put `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` in env vars, the task definition, or the image.
-- **Execution role** grants the *ECS agent* rights to pull the ECR image and inject secrets/logs — keep it separate and minimal.
-- The recurring hard failure on ECS is the **task-role trust-relationship error** ("ECS was unable to assume the role"): the role's trust policy must allow `ecs-tasks.amazonaws.com` to `sts:AssumeRole`, and `iam:PassRole` must be granted to whoever registers/runs the task. Get the trust policy right first.
+## GPU/ML-Specific Controls (the reason this file exists)
 
-```json
-// Task role trust policy
-{ "Version": "2012-10-17", "Statement": [{
-  "Effect": "Allow",
-  "Principal": { "Service": "ecs-tasks.amazonaws.com" },
-  "Action": "sts:AssumeRole"
-}]}
-```
+### Model-artifact provenance (the top GenAI supply-chain risk)
 
-### 2. Secrets — Secrets Manager / SSM Parameter Store injection
+A poisoned model artifact executes arbitrary inference on customer data — treat weights like application binaries. Verify integrity before serving: pin **exact model revisions** (not floating tags/branches); verify **SHA256 checksums** for downloaded weights; use **image signing** (AWS Signer / Sigstore) for baked-in models; enable **S3 Object Lock** for production artifact buckets. Never pull weights from Hugging Face at task start in prod — stage in S3/ECR first ([storage.md](storage.md)).
 
-Store model-registry tokens, API keys, and gateway keys in **AWS Secrets Manager** or **SSM Parameter Store**; inject via the task definition `secrets` block (resolved by the execution role) — never bake secrets into the (often cached, widely-pulled) model image or a ConfigMap-style env.
+### GPU/ML-specific supply chain
 
-```json
-"secrets": [
-  { "name": "HF_TOKEN", "valueFrom": "arn:aws:secretsmanager:REGION:ACCT:secret:hf-token" }
-]
-```
+GPU/ML images (CUDA, cuDNN, PyTorch, Neuron SDK, DLC) carry **far larger dependency trees** than typical microservices — ECR enhanced scanning matters more here; scan on push and periodically for base-image drift, and block critical/high CVEs.
 
-### 3. ECR image scanning
+### `bedrock-runtime` VPC endpoint
 
-Enable **ECR enhanced scanning (Amazon Inspector)** and block deployment of critical/high CVEs. GPU/ML images (CUDA, cuDNN, PyTorch, Neuron SDK, DLC) carry **far larger dependency trees** than typical microservices — scan on push and periodically for base-image drift.
+If the ECS app calls Bedrock as a downstream model target, add the **`bedrock-runtime` interface endpoint** so that traffic stays private — this is the one VPC endpoint beyond the standard S3/ECR/Secrets/logs set that GenAI-on-ECS specifically adds.
 
-### 4. Model-artifact provenance
+### Inference-endpoint authentication
 
-A poisoned model artifact executes arbitrary inference on customer data — treat weights like application binaries. Verify integrity before serving: pin **exact model revisions** (not floating tags/branches); verify **SHA256 checksums** for downloaded weights; use **image signing** (AWS Signer / Sigstore) for baked-in models; enable **S3 Object Lock** for production artifact buckets.
+A self-hosted model endpoint has **no built-in auth**. Decide **internal vs internet-facing** (internal ALB/NLB in private subnets reached via VPC/PrivateLink is the default for internal consumers), and always put an authN/authZ layer in front — Cognito/OIDC on the ALB, API Gateway, or a JWT/mTLS-validating reverse proxy — plus WAF for internet-facing. Deep endpoint-security design → **`ecs-security`**. See [inference-serving.md](inference-serving.md) for the streaming/idle-timeout interaction.
 
-### 5. Network isolation
+### GuardDuty Runtime Monitoring — MI carve-out
 
-Place GPU/Neuron container instances in **private subnets** with no direct inbound internet. Route AWS API calls through **VPC endpoints**:
+Enable **GuardDuty ECS Runtime Monitoring** on **ECS-on-EC2** container instances for runtime threat detection. **Critical caveat given how heavily this skill promotes Managed Instances:** Runtime Monitoring is **not supported on ECS Managed Instances**, and also **not on ECS Anywhere or the Windows OS** ([Runtime Monitoring considerations](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-guard-duty-integration.html)). An MI-based GPU fleet therefore cannot rely on GuardDuty RM for the host — plan a different runtime-threat control (or keep sensitive runtime-monitored workloads on ECS-on-EC2). Pair with CloudTrail (management + S3 model-bucket data events).
 
-| Endpoint | Why |
-|---|---|
-| `s3` (Gateway) | Model weights, checkpoints, training data |
-| `ecr.api` + `ecr.dkr` | Image pull |
-| `secretsmanager` | Secrets injection |
-| `logs` / `monitoring` | CloudWatch Logs / metrics |
-| `bedrock-runtime` (Interface) | Only if the app calls Bedrock as a model target |
+## Compliance-Regime Notes (GPU/ML angle; full regime design → `ecs-security`)
 
-Egress for any unavoidable downloads via a NAT gateway with restrictive SGs — or eliminate by pre-caching all artifacts to S3/ECR. Use **security-group-per-task** (`awsvpc` mode) to scope task-to-task traffic.
-
-### 6. Container hardening
-
-Run containers **non-root**, with **read-only root filesystem** where the framework allows, and drop unneeded Linux capabilities. Note the GPU-sharing exception: making `nvidia` the default Docker runtime for GPU sharing loosens isolation — reserve that pattern for dev/test ([compute-hardware.md](compute-hardware.md)).
-
-### 7. GuardDuty ECS Runtime Monitoring + audit logging
-
-Enable **GuardDuty ECS Runtime Monitoring** on the EC2 container instances for runtime threat detection. Enable **CloudTrail** (management + S3 model-bucket data events) and **Container Insights** for audit and forensics. Retain per compliance requirement.
-
-## Compliance-Regime Notes
-
-- **HIPAA:** GPU tasks processing PHI on a HIPAA-eligible account (BAA in place); KMS-CMK encryption for EBS/S3/EFS; audit all access; verify Bedrock/other targets' HIPAA status at deployment.
-- **PCI-DSS:** isolate GPU/ML workloads in a dedicated cluster or node group + namespace + SG boundary within the CDE; encrypt task-to-task traffic; quarterly image scans retained.
-- **FedRAMP:** GovCloud or FedRAMP-authorized Regions; FIPS-validated modules; images only from an approved ECR in-boundary (no Docker Hub / HF pulls in prod).
+- **HIPAA:** GPU tasks processing PHI on a HIPAA-eligible account (BAA in place); KMS-CMK encryption for EBS/S3/EFS; verify Bedrock/other model targets' HIPAA status at deployment.
+- **PCI-DSS:** isolate GPU/ML workloads within the CDE using **ECS-native** boundaries — a **dedicated cluster** *or* a **dedicated capacity provider / ASG** + **security-group-per-task** (`awsvpc`) + **separate task/execution roles (and ideally separate accounts)**. (Node groups and namespaces are **Kubernetes** constructs that **don't exist in ECS** — don't prescribe them here; that's an `eks-genai` pattern.) Encrypt task-to-task traffic; retain quarterly image scans.
+- **FedRAMP:** GovCloud or FedRAMP-authorized Regions; FIPS-validated modules; images only from an approved in-boundary ECR (no Docker Hub / HF pulls in prod).
 - **GDPR:** EU-region deployment for EU personal data; design right-to-erasure so deleting source documents cascades to derived embeddings; treat stored prompts/outputs as personal data.
 
 ## When to Escalate to a Specialist Review
@@ -77,13 +47,18 @@ Enable **GuardDuty ECS Runtime Monitoring** on the EC2 container instances for r
 
 ## Quick-Reference Checklist
 
-- [ ] Task role + execution role least-privilege; trust policy allows `ecs-tasks.amazonaws.com`; `iam:PassRole` scoped
+Baseline items (details in **`ecs-security`**):
+- [ ] Task + execution role least-privilege; trust policy allows `ecs-tasks.amazonaws.com`; `iam:PassRole` scoped
 - [ ] Secrets via Secrets Manager / SSM — never in image/env
 - [ ] ECR enhanced scanning — critical/high blocked
-- [ ] Model provenance — pinned revision + checksum/signing
-- [ ] Private subnets + VPC endpoints (S3, ECR, Secrets Manager, logs; Bedrock if used)
-- [ ] Non-root, read-only rootfs, dropped capabilities
-- [ ] GuardDuty ECS Runtime Monitoring + CloudTrail + Container Insights
+- [ ] Private subnets + VPC endpoints (S3, ECR, Secrets Manager, logs); non-root, read-only rootfs, dropped capabilities
+- [ ] CloudTrail + Container Insights audit
+
+GPU/ML-specific (this file):
+- [ ] Model provenance — pinned revision + SHA256 checksum / signing; S3 Object Lock on prod artifact buckets
+- [ ] `bedrock-runtime` VPC endpoint if the app calls Bedrock
+- [ ] Inference-endpoint authN/authZ + internal-vs-internet-facing decision
+- [ ] GuardDuty ECS Runtime Monitoring on **ECS-on-EC2** hosts — **not available on Managed Instances / Anywhere / Windows** (plan an alternative for MI fleets)
 
 ## Sources
 
@@ -91,5 +66,6 @@ Enable **GuardDuty ECS Runtime Monitoring** on the EC2 container instances for r
 - [Amazon ECS task IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) · [Task execution IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html)
 - [Passing sensitive data to a container (Secrets Manager / SSM)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html)
 - [Amazon ECR image scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html)
-- [GuardDuty Runtime Monitoring for Amazon ECS](https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring.html)
+- [GuardDuty Runtime Monitoring for Amazon ECS — considerations (not supported on Managed Instances / Anywhere / Windows)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-guard-duty-integration.html)
 - [Interface VPC endpoints for Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/vpc-endpoints.html)
+- For the full ECS security baseline and regulated-compliance design: the **`ecs-security`** skill

--- a/skills/ecs-genai/references/service-boundaries.md
+++ b/skills/ecs-genai/references/service-boundaries.md
@@ -1,0 +1,55 @@
+# Service Boundaries — Fargate-GPU Exclusion & When to Leave ECS
+
+This skill's most important job is to keep GPU/ML workloads on the *right* AWS service. Two questions: (1) is Fargate viable? (never, for GPU) and (2) is ECS-on-EC2 the right home, or should this be EKS / SageMaker / Bedrock?
+
+## 1. AWS Fargate Has No GPU — the Evidence
+
+State this as fact, not opinion. GPU is a **container-instance (EC2)** capability on ECS; Fargate exposes only CPU + memory.
+
+- AWS lists the **`gpu` task-definition parameter among those "not valid in Fargate tasks"** — alongside `devices`, `placementConstraints`, and `privileged` ([ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)).
+- The **Fargate task-size model** enumerates valid CPU/memory combinations only — 256 (.25 vCPU) through 32768 (32 vCPU), with matching memory ranges — and **no GPU dimension**.
+- AWS documents the GPU `resourceRequirements` type as the number of physical GPUs the **ECS container agent** reserves on the **container instance**. The ECS GPU documentation is entirely about **EC2 GPU-based container instances** and the GPU-optimized AMI — there is no Fargate GPU path ([ECS GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)).
+
+**Consequence:** any GPU/accelerator container must run on **ECS-on-EC2**, **ECS Managed Instances**, or **ECS Anywhere/External**. Fargate can still host **CPU-only** parts of a GenAI app (an API front-end, an orchestrator, a RAG retriever calling Bedrock) — just not the accelerated container.
+
+## 2. Stay on ECS vs Route Elsewhere
+
+| Signal | Right home | Why |
+|---|---|---|
+| Team wants a **simple control plane**, IAM-native, no Kubernetes to operate; GPU/Neuron container inference or moderate training | **ECS-on-EC2 (this skill)** | ECS gives container + capacity primitives without K8s operational surface |
+| Needs **Karpenter-style GPU provisioning**, **KubeRay/Ray Serve/JARK**, **KServe scale-to-zero**, **fractional-GPU (MIG/time-slicing/DRA)**, or a **Kubernetes serving mesh** | **EKS (`eks-genai`)** | These are Kubernetes-native constructs with no native-ECS equivalent |
+| Wants **fully-managed training** (no capacity/harness to own) or a **managed inference endpoint** (real-time/serverless/async, multi-model, autoscaling) | **Amazon SageMaker** | SageMaker manages the training/hosting plane end-to-end; HyperPod for large clusters |
+| Wants a **managed foundation-model API** with **no self-hosting** (no GPU at all) | **Amazon Bedrock** | Zero infrastructure; pay-per-use FMs, Knowledge Bases, Agents, Guardrails |
+| Generic **ECS launch-type / cluster design** with **no accelerator or ML workload** | **`ecs-architect`** | Model selection/design without the GPU/ML specialization |
+
+### Sharper EKS boundary (vs `eks-genai`)
+
+Route to **`eks-genai`** the moment the requirement names a Kubernetes primitive: Karpenter, node pools, device plugins, KubeRay, Ray Serve on K8s, KServe, JARK, Kubeflow, gang scheduling (Volcano/Kueue), MIG/time-slicing/DRA fractional-GPU, or an existing EKS estate the team wants to extend. ECS deliberately has **no** Karpenter and **no** fractional-GPU scheduler — if those are hard requirements, ECS is the wrong tool.
+
+### Sharper SageMaker boundary
+
+Route to **SageMaker** when the customer does **not want to own container orchestration or GPU capacity** at all: managed training jobs, managed endpoints, built-in model registry/pipelines, HyperPod for very large training. If they *want* to own the container/service (custom serving stack, existing ECS estate, tight infra control), ECS-on-EC2 is the fit.
+
+### Sharper Bedrock boundary
+
+Route to **Bedrock** when there is **no self-hosting** — the customer just wants to call managed FMs. This skill covers Bedrock only as a *downstream target* a self-hosted ECS app might also call (hybrid: self-host cost-sensitive models on ECS-GPU, call Bedrock for best-of-breed).
+
+## 3. Quick Router
+
+```text
+GPU / accelerator container?
+  ├─ No GPU, just "which ECS model"      → ecs-architect
+  ├─ Fargate?                            → NO (no GPU) — use ECS-on-EC2 / Managed Instances / Anywhere
+  ├─ Kubernetes primitive named / EKS    → eks-genai
+  ├─ Fully-managed train/host, no infra  → SageMaker
+  ├─ Managed FM API, no self-hosting     → Bedrock
+  └─ Self-hosted GPU/Neuron on ECS       → THIS SKILL (ecs-genai)
+```
+
+## Sources
+
+- [Amazon ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)
+- [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)
+- [Use GPUs with Amazon ECS Managed Instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-instances-gpu.html)
+- [Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/dg/whatis.html) · [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html)
+- [Best Practices for AI/ML Workloads on Amazon EKS](https://docs.aws.amazon.com/eks/latest/best-practices/aiml.html) (the eks-genai counterpart)

--- a/skills/ecs-genai/references/service-boundaries.md
+++ b/skills/ecs-genai/references/service-boundaries.md
@@ -6,11 +6,13 @@ This skill's most important job is to keep GPU/ML workloads on the *right* AWS s
 
 State this as fact, not opinion. GPU is a **container-instance (EC2)** capability on ECS; Fargate exposes only CPU + memory.
 
-- AWS lists the **`gpu` task-definition parameter among those "not valid in Fargate tasks"** — alongside `devices`, `placementConstraints`, and `privileged` ([ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)).
+- AWS lists the **`gpu` task-definition parameter among those "not valid in Fargate tasks"** (alongside `placementConstraints`); `devices` and `privileged` appear separately under **`linuxParameters` limitations** on the same page — either way none work for a Fargate GPU task ([ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)).
 - The **Fargate task-size model** enumerates valid CPU/memory combinations only — 256 (.25 vCPU) through 32768 (32 vCPU), with matching memory ranges — and **no GPU dimension**.
 - AWS documents the GPU `resourceRequirements` type as the number of physical GPUs the **ECS container agent** reserves on the **container instance**. The ECS GPU documentation is entirely about **EC2 GPU-based container instances** and the GPU-optimized AMI — there is no Fargate GPU path ([ECS GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html)).
 
 **Consequence:** any GPU/accelerator container must run on **ECS-on-EC2**, **ECS Managed Instances**, or **ECS Anywhere/External**. Fargate can still host **CPU-only** parts of a GenAI app (an API front-end, an orchestrator, a RAG retriever calling Bedrock) — just not the accelerated container.
+
+**Guidance for the CPU-only orchestrator/RAG/gateway pieces** (so this isn't a dead-end blessing): a **RAG retriever or agent orchestrator** that calls a model runs fine on Fargate — the boundary to name is **Amazon Bedrock AgentCore** for a fully-managed agent runtime (memory/tools/identity) vs **self-hosting the framework on ECS** when you want to own it. A self-hosted **AI gateway (e.g. LiteLLM)** — model routing, key management, cost attribution across your ECS-hosted models and Bedrock — is a documented `ai-gateway` target and also runs as a CPU-only ECS/Fargate service. See [inference-serving.md](inference-serving.md) for the gateway/agentic patterns; agentic workloads with autonomous tool/code execution → also loop in `ecs-security`.
 
 ## 2. Stay on ECS vs Route Elsewhere
 

--- a/skills/ecs-genai/references/storage.md
+++ b/skills/ecs-genai/references/storage.md
@@ -1,0 +1,60 @@
+# Storage for GPU / ML Workloads on Amazon ECS
+
+Where model weights, training data, and checkpoints live — and how to get them to GPU/Neuron tasks fast enough that expensive accelerators aren't idle waiting on I/O.
+
+## Decision Table — Workload Pattern → Storage
+
+| Workload pattern | Recommended storage | Why |
+|---|---|---|
+| **Inference weights (single task)** | S3 (pull at start) or bake into image (<5 GB) | Decoupled model/image release; lazy availability |
+| **Inference weights shared across many tasks/nodes** | Amazon EFS (ReadWriteMany) | Concurrent read from multiple tasks; simple, elastic |
+| **Distributed training data + checkpoints** | FSx for Lustre (same-AZ) + S3 DRA | Sub-ms latency, high aggregate throughput, durable offload |
+| **Training checkpoints (durable)** | FSx for Lustre → S3 Data Repository Association | Fast local write; async durable copy to S3 |
+| **Very large weights, I/O-bound cold start** | FSx for Lustre (pre-warmed) | Eliminates S3 cold-start when bandwidth-bound |
+
+## Model Artifact Handling — Getting Weights to the Task
+
+| Strategy | Model size | Cold-start | Coupling | Best for |
+|---|---|---|---|---|
+| **Bake into container image** | < ~5 GB | Zero (in layers) | Model release = image release | Small/classic models; air-gapped |
+| **Pull from S3 at task start** | 5 GB – 200+ GB | Seconds–minutes | Decoupled | LLMs; frequent model updates |
+| **Mount EFS** | Any (shared) | Low | Decoupled | Many tasks/nodes sharing the same weights |
+| **Pre-cache on FSx for Lustre** | Any | Zero if pre-warmed | FSx lifecycle to manage | Training; very large weights where S3 is the bottleneck |
+
+Rules:
+- **Never pull weights from Hugging Face at every task start** — egress cost, rate limits, and cold-start. Stage in **S3** (or ECR for baked images) first.
+- **Pre-compile Neuron models offline** and ship the compiled artifact via S3/image — never compile at task startup ([neuron-on-ecs.md](neuron-on-ecs.md)).
+- **Access S3 via the task role** (least-privilege, per-bucket/prefix) — never static keys ([security-and-compliance.md](security-and-compliance.md)).
+
+## Container Image Size — the Cold-Start Tax
+
+CUDA / Deep Learning Container / Neuron images are large (often 5–15+ GB). On GPU/Neuron instances with local NVMe, ECS benefits from **parallel image pull/unpack (SOCI-style)** to speed multi-GB image starts; keep images lean (multi-stage builds, drop build toolchains) and pre-pull onto warm-pool instances so a scale-out event isn't dominated by image download. Decouple weights from the image (pull from S3) so a model update doesn't force a full image re-pull.
+
+## FSx for Lustre — Training I/O
+
+For distributed training and checkpoint-heavy workloads, FSx for Lustre delivers high aggregate throughput and low latency, with an **S3 Data Repository Association (DRA)** for import (training data) and async export (checkpoints):
+
+- **Same-AZ rule (critical):** deploy FSx in the **same Availability Zone** as the GPU/Neuron instances. Cross-AZ round-trip latency dwarfs FSx's native performance — a top silent-bad-architecture decision.
+- **Pre-warm** FSx with training data (via an admin task) **before** launching Spot GPU capacity, so you don't burn expensive accelerator minutes waiting on data ingest.
+- **Checkpoint flow:** training task writes to FSx → DRA async-exports to S3 → on interruption a replacement task lazy-loads the latest checkpoint from S3 into a fresh FSx volume. See [distributed-training.md](distributed-training.md).
+
+## Amazon EFS — Shared Weights
+
+Use EFS when multiple inference tasks (possibly across instances) must read the same weights concurrently (ReadWriteMany) and FSx's throughput/complexity isn't warranted. EFS is elastic (no sizing), mounts in each AZ, and is simple to attach as an ECS volume — moderate throughput, low-single-digit-ms latency. Good for 5–20 model variants shared across an inference fleet.
+
+## Amazon S3 — the Backbone
+
+S3 is the durable source of truth for weights, checkpoints, and the train→serve handoff artifact. Access via the **task role**; reach it privately from GPU instances in private subnets via an **S3 VPC endpoint** ([security-and-compliance.md](security-and-compliance.md)). Version models by key path (`s3://models/<name>/v3/`) to make promotion a task-definition update.
+
+## Storage + Capacity Notes
+
+- **FSx same-AZ:** pin the training ASG to the FSx AZ; accept reduced Spot diversity in exchange for correct latency.
+- **EFS / S3:** regional/multi-AZ — no zone pinning needed for tasks.
+- **Checkpoint safety:** ensure training tasks aren't scaled-in mid-write — schedule long runs on On-Demand/Capacity Blocks, or checkpoint frequently on Spot.
+
+## Sources
+
+- [Amazon FSx for Lustre](https://docs.aws.amazon.com/fsx/latest/LustreGuide/what-is.html) · [FSx for Lustre and Amazon S3](https://docs.aws.amazon.com/fsx/latest/LustreGuide/fsx-data-repositories.html)
+- [Amazon EFS volumes for Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/efs-volumes.html)
+- [Amazon ECS Best Practices Guide — task definitions (volumes, images)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-best-practices.html)
+- [Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)

--- a/skills/ecs-genai/references/storage.md
+++ b/skills/ecs-genai/references/storage.md
@@ -28,7 +28,7 @@ Rules:
 
 ## Container Image Size — the Cold-Start Tax
 
-CUDA / Deep Learning Container / Neuron images are large (often 5–15+ GB). On GPU/Neuron instances with local NVMe, ECS benefits from **parallel image pull/unpack (SOCI-style)** to speed multi-GB image starts; keep images lean (multi-stage builds, drop build toolchains) and pre-pull onto warm-pool instances so a scale-out event isn't dominated by image download. Decouple weights from the image (pull from S3) so a model update doesn't force a full image re-pull.
+CUDA / Deep Learning Container / Neuron images are large (often 5–15+ GB). **On the ECS-on-EC2 launch type the container image downloads completely before the container starts** — the same behavior as all non-1.4.0 Fargate platform versions ([ECS task definition differences for Fargate — SOCI lazy loading](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)). **SOCI lazy loading is Fargate-PV1.4-only, and Fargate has no GPU**, so SOCI is **unavailable on every host this skill covers** — do not plan around it for GPU/Neuron cold-start. Real EC2 mitigations: **pre-pull the image onto warm-pool instances**, **cache images on the instance NVMe**, **bake heavy layers into the AMI**, and keep images lean (multi-stage builds, drop build toolchains). Decouple weights from the image (pull from S3) so a model update doesn't force a full image re-pull.
 
 ## FSx for Lustre — Training I/O
 

--- a/skills/ecs-genai/references/use-cases.md
+++ b/skills/ecs-genai/references/use-cases.md
@@ -14,15 +14,15 @@ Four condensed scenarios. Each gives: customer profile, the ECS-specific decisio
 |---|---|---|
 | D1 Host | ECS-on-EC2 (or Managed Instances) | Fargate has no GPU |
 | D2 Accelerator | g6e (NVIDIA L40S) for 7B–13B; evaluate Inf2 as phase-2 cost play | Broad ecosystem first; Neuron savings later |
-| D3 Capacity | One capacity-provider ASG for the g6e type + service capacity-provider strategy | ASGs must be homogeneous (no instance weighting) |
-| D4 Shape | Single GPU task behind an ALB; Service Auto Scaling on requests/latency | Standard inference service |
-| Storage | Weights in S3, pulled at task start | Decoupled model/image release ([storage.md](storage.md)) |
-| Observability | Container Insights **enhanced** (DCGM GPU metrics) + serving-engine latency metric | Enable enhanced — basic has no GPU metrics ([observability.md](observability.md)) |
+| D3 Capacity | One homogeneous g6e capacity-provider ASG + service capacity-provider strategy | Mixed-GPU ASGs are allowed but managed scaling protects on the smallest type — keep one type per ASG ([capacity-and-scaling.md](capacity-and-scaling.md)) |
+| D4 Shape | Single GPU task behind an ALB; Service Auto Scaling on requests/latency; raise ALB idle timeout for token streaming | Standard inference service ([inference-serving.md](inference-serving.md)) |
+| Storage | Weights in S3, pulled at task start | Decoupled model/image release; on EC2 the image downloads fully first (no SOCI) ([storage.md](storage.md)) |
+| Observability | **On g6e MI:** agentless DCGM via Container Insights **enhanced**. **On g6e ECS-on-EC2:** CloudWatch agent (`nvidia_smi`) or DCGM exporter — the agentless MI metrics don't exist there. Plus serving-engine latency metric | Pick the path by launch model ([observability.md](observability.md)) |
 | Security | Task role → S3 (prefix-scoped); private subnet + S3/ECR VPC endpoints; ECR scanning | Baseline ([security-and-compliance.md](security-and-compliance.md)) |
 
 **Build path:** stand up the g6e capacity provider + service; validate the model + a generous health-check grace period; wire enhanced Container Insights + latency-based Service Auto Scaling; harden (task role, secrets, private subnets, image scanning); then run a g6e-vs-inf2 cost comparison and migrate to Neuron if the savings justify the compilation ramp.
 
-**Route out if:** the team wants scale-to-zero or fractional-GPU multi-model packing → `eks-genai`; or a fully-managed endpoint → SageMaker.
+**Route out if:** the team wants scale-to-zero or **scheduler-driven** fractional-GPU multi-model packing (MIG/time-slicing/DRA) → `eks-genai`; or a fully-managed endpoint → SageMaker. (Hardware-fractional L4 via G6f/Gr6f on Managed Instances stays on ECS — see [compute-hardware.md](compute-hardware.md).)
 
 ---
 
@@ -79,7 +79,7 @@ Four condensed scenarios. Each gives: customer profile, the ECS-specific decisio
 
 **Build path:** launch a small g5/g6 ASG with the default-runtime user data; publish task-definition templates with `NVIDIA_VISIBLE_DEVICES` set; document the no-isolation caveat.
 
-**Route out if:** the team needs isolated fractional GPUs (MIG / time-slicing with per-slice memory / DRA) → `eks-genai`; or managed notebooks/experiments → SageMaker Studio.
+**Route out if:** the team needs **dynamic multi-model GPU packing** — a MIG / time-slicing / DRA *scheduler* — → `eks-genai`; or managed notebooks/experiments → SageMaker Studio. (But note: **hardware-fractional L4 instances (G6f/Gr6f)** are supported on ECS **Managed Instances** for small/cost-sensitive inference — the slice is the instance shape, no scheduler needed; see [compute-hardware.md](compute-hardware.md). Route to EKS only when the requirement is a *scheduler-driven* fractional-GPU platform.)
 
 ---
 

--- a/skills/ecs-genai/references/use-cases.md
+++ b/skills/ecs-genai/references/use-cases.md
@@ -1,0 +1,101 @@
+# Worked Use Cases — GPU / ML on Amazon ECS
+
+Four condensed scenarios. Each gives: customer profile, the ECS-specific decisions, and a build path. All keep the first-class constraint in view — **GPU is never on Fargate**.
+
+---
+
+## Use Case 1 — Single-Model LLM Inference on ECS-on-EC2
+
+**Profile:** Team already runs services on ECS (non-AI). Wants to self-host an open Transformer LLM (Llama/Mistral/Qwen) for a product feature. Balanced cost, no strong hardware preference, no Kubernetes appetite.
+
+**ECS-specific decisions:**
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| D1 Host | ECS-on-EC2 (or Managed Instances) | Fargate has no GPU |
+| D2 Accelerator | g6e (NVIDIA L40S) for 7B–13B; evaluate Inf2 as phase-2 cost play | Broad ecosystem first; Neuron savings later |
+| D3 Capacity | One capacity-provider ASG for the g6e type + service capacity-provider strategy | ASGs must be homogeneous (no instance weighting) |
+| D4 Shape | Single GPU task behind an ALB; Service Auto Scaling on requests/latency | Standard inference service |
+| Storage | Weights in S3, pulled at task start | Decoupled model/image release ([storage.md](storage.md)) |
+| Observability | Container Insights **enhanced** (DCGM GPU metrics) + serving-engine latency metric | Enable enhanced — basic has no GPU metrics ([observability.md](observability.md)) |
+| Security | Task role → S3 (prefix-scoped); private subnet + S3/ECR VPC endpoints; ECR scanning | Baseline ([security-and-compliance.md](security-and-compliance.md)) |
+
+**Build path:** stand up the g6e capacity provider + service; validate the model + a generous health-check grace period; wire enhanced Container Insights + latency-based Service Auto Scaling; harden (task role, secrets, private subnets, image scanning); then run a g6e-vs-inf2 cost comparison and migrate to Neuron if the savings justify the compilation ramp.
+
+**Route out if:** the team wants scale-to-zero or fractional-GPU multi-model packing → `eks-genai`; or a fully-managed endpoint → SageMaker.
+
+---
+
+## Use Case 2 — Distributed Multi-Node Training on ECS
+
+**Profile:** Team fine-tuning / pre-training a 7B–70B Transformer across multiple GPU nodes. Cost-conscious. PyTorch + Ray. No Kubernetes platform team.
+
+**ECS-specific decisions:**
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| D1 Host | ECS-on-EC2 | Custom AMI/kernel + EFA control; not Fargate |
+| D2 Accelerator | p4d/p5 (GPU) or trn1/trn2 (Neuron) | Model-family + cost dependent |
+| D3 Capacity | One homogeneous ASG of the chosen type in a **cluster placement group**; **Capacity Blocks for ML** for guaranteed multi-day capacity | UltraCluster + EFA; capacity assurance ([capacity-and-scaling.md](capacity-and-scaling.md)) |
+| D4 Shape | Ray head + worker tasks (DDP/FSDP); EFA + NCCL in the image | AWS-documented ECS distributed-training pattern |
+| Storage | FSx for Lustre same-AZ + S3 DRA for checkpoints | Fast I/O; durable offload ([distributed-training.md](distributed-training.md)) |
+
+**Build path:** reserve capacity (Capacity Blocks) into a placement-group ASG; validate single-node training + Neuron compilation (if Trn); wire checkpoint→FSx→S3 every 15–30 min; scale to multi-node and confirm EFA/NCCL throughput; run with Spot only on interruption-tolerant phases with checkpoint/resume.
+
+**Route out if:** the team needs gang scheduling / a multi-tenant training platform → `eks-genai`; or fully-managed large-scale training → SageMaker HyperPod.
+
+---
+
+## Use Case 3 — Cost-Optimized Inference via Neuron Migration on ECS
+
+**Profile:** Production inference on ECS using g5/g6 GPUs, steady high-volume traffic, cost-first. Models are Transformer-family. Considering Inf2.
+
+**ECS-specific decisions:**
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| D2 Accelerator | Add Inf2 alongside existing GPU | Cost-optimized for supported models |
+| D3 Capacity | New Inf2 capacity provider/ASG beside the GPU one; blend via capacity-provider strategy during canary | Separate homogeneous ASGs; shift weight gradually |
+| Neuron | Managed device allocation (`NeuronDevice: ALL`) on Managed Instances, or manual `linuxParameters.devices` on EC2 | ([neuron-on-ecs.md](neuron-on-ecs.md)) |
+| Compilation | Pre-compile offline, ship artifact via S3 | Never compile at task start |
+
+**Build path:** verify the model architecture is Neuron-supported; compile offline (budget 1–2 weeks for the first model); deploy an Inf2 service; run an eval suite comparing GPU vs Neuron output quality; canary traffic 5%→100% by shifting the capacity-provider-strategy weights; decommission the GPU pool; document the compilation pipeline for future model versions.
+
+**Risk callouts:** compilation ramp adds lead time to each new model version; not all HF models are Neuron-supported; validate output parity before shifting production traffic.
+
+---
+
+## Use Case 4 — Shared GPU Dev Cluster on ECS
+
+**Profile:** A data-science team wants several people to share a couple of GPU instances for experimentation. Cost-sensitive; isolation not critical.
+
+**ECS-specific decisions:**
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| D1 Host | ECS-on-EC2, g5/g6 | Not Fargate |
+| Sharing | Remove GPU `resourceRequirements`; set `nvidia` as default Docker runtime via user data; set `NVIDIA_VISIBLE_DEVICES` per container | The only ECS GPU-sharing path ([compute-hardware.md](compute-hardware.md)) |
+| Guardrail | **Dev/test only — no memory/compute isolation** | One container can starve/OOM others |
+
+**Build path:** launch a small g5/g6 ASG with the default-runtime user data; publish task-definition templates with `NVIDIA_VISIBLE_DEVICES` set; document the no-isolation caveat.
+
+**Route out if:** the team needs isolated fractional GPUs (MIG / time-slicing with per-slice memory / DRA) → `eks-genai`; or managed notebooks/experiments → SageMaker Studio.
+
+---
+
+## Pattern Summary
+
+| Scenario | Primary lever | Key ECS-specific gotcha |
+|---|---|---|
+| Single-model inference | Right-size GPU family; enhanced Container Insights | Health-check grace period for model warmup |
+| Distributed training | Capacity Blocks + EFA + placement group | One homogeneous ASG; checkpoint or lose Spot progress |
+| Neuron migration | Neuron over GPU for supported models | Pre-compile offline; verify model support + output parity |
+| Shared GPU dev | GPU sharing via default runtime | No isolation — dev/test only |
+
+## Sources
+
+- [Amazon ECS task definitions for GPU workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-gpu.html) · [ECS Neuron ML workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-inference.html)
+- [Distributed machine learning with Amazon ECS](https://aws.amazon.com/blogs/containers/distributed-machine-learning-with-amazon-ecs/)
+- [EC2 Capacity Blocks for ML](https://aws.amazon.com/ec2/capacityblocks/)
+- [Amazon ECS capacity providers for EC2 workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)
+- [Monitoring Amazon ECS Managed Instances (GPU / DCGM)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/monitoring-managed-instances.html)


### PR DESCRIPTION
## Summary

Adds `ecs-genai` — GenAI/GPU/ML workloads on ECS-on-EC2 (Fargate has no GPU, stated first-class): GPU-optimized AMIs + instance families, EC2 Capacity Blocks for ML, the separate-ASG-per-GPU-type + capacity-provider pattern, Inferentia/Neuron on ECS, inference serving, single-node multi-GPU training, and clear EKS/SageMaker/Bedrock boundaries. Zero unsourced hardware/perf claims. SKILL.md + 10 references.

Part of the ECS skill suite mirroring the EKS skills (GTM Containers SA effort). Authored via the `/apex:new-skill` greenfield flow; every factual claim was live-verified against public AWS docs (ECS Best Practices Guide + Developer Guide) on 2026-07-08 and enriched via the Containers specialist knowledge base. Unverifiable claims were softened/deferred rather than asserted.

## If this PR adds or changes a skill

- [x] Walked the equivalent manual steps in `CONTRIBUTING.md` (greenfield authoring + GATE-1 currency + 8-lens self-review)
- [x] `skills/<skill>/SKILL.md` present with valid frontmatter
- [ ] `misc/evals/<skill>/triggering.json` — **deferred to a follow-up eval PR** (evals are not a CI gate; batching the eval set + bidirectional SIBLING_MAP once the full ECS suite lands)
- [ ] Neighbour `SIBLING_MAP` updates — **deferred to the same follow-up** (several ECS siblings, incl. `ecs-recon`, are not yet in-repo; sibling-map fan-out will run when they land)
- [x] Regenerated docs (README + skills/README Skills Reference marker blocks, Docusaurus wrappers/manifests) and committed them — `docs-sync` CI is green

## Notes for reviewers

- **Scope:** self-contained content PR (skill + regenerated catalogs/pages). No `steering/ecs.md` hub or `/apex:ecs-*` command shim yet — those come with the suite-level wiring PR.
- **`ecs-recon` routing:** references to the not-yet-merged `ecs-recon` skill are softened ("once available") so nothing dangles.
- **Docs regen on macOS:** used GNU awk (`gawk`) to match CI's Ubuntu awk; both `update-all-references.sh --check` and `update-pages.sh --check` pass locally.