### PR TITLE
fix: devops-agent index sidebar position + table format

### DIFF
--- a/misc/update-pages.sh
+++ b/misc/update-pages.sh
@@ -809,7 +809,7 @@ fi
 build_devops_index() {
   cat <<'INDEXEOF'
 ---
-sidebar_position: 7
+sidebar_position: 3.5
 title: DevOps Agent Skills
 description: "Skills ported for fully autonomous execution on AWS DevOps Agent — read-only EKS cluster assessments without interactive prompts."
 ---
@@ -820,6 +820,8 @@ description: "Skills ported for fully autonomous execution on AWS DevOps Agent �
 
 A subset of APEX skills ported for the [AWS DevOps Agent](https://docs.aws.amazon.com/devopsagent/latest/userguide/) runtime. These run fully autonomously — no interactive prompts, no scripts, no MCP server references.
 
+<table>
+<tr><th>Skill</th><th>Status</th><th>Description</th></tr>
 INDEXEOF
 
   for skill_dir in "$DEVOPS_DIR"/*/; do
@@ -832,16 +834,24 @@ INDEXEOF
     [[ -z "$title" ]] && title="$(title_from_filename "$folder")"
     local desc
     desc="$(parse_frontmatter "$skill_md" "description")"
-    [[ -z "$desc" ]] && desc="_(no description)_"
-    # Truncate at last word boundary for card display
-    if [[ ${#desc} -gt 150 ]]; then
+    [[ -z "$desc" ]] && desc="<em>(no description)</em>"
+    # Truncate at first sentence boundary (". " only — avoids cutting "EKS 1.32")
+    # Fall back to word boundary + ellipsis for descriptions without sentence ends
+    if [[ "$desc" == *". "* ]]; then
+      desc="${desc%%". "*}."
+    elif [[ ${#desc} -gt 150 ]]; then
       desc="${desc:0:150}"
-      desc="${desc% *}..."
+      desc="${desc% *}…"
+    fi
+    if [[ ${#desc} -gt 200 ]]; then
+      desc="${desc:0:200}"
+      desc="${desc% *}…"
     fi
     local status="Placeholder"
     [[ -d "$skill_dir/references" ]] && status="Active"
-    echo "- **[$title](./$folder/)** — $status — $desc"
+    echo "<tr><td><a href=\"./$folder/\"><b>$title</b></a></td><td>$status</td><td>$desc</td></tr>"
   done
+  echo "</table>"
 }
 
 if [[ "$MODE" == "dry-run" ]]; then

--- a/misc/website/docs/devops-agent/index.md
+++ b/misc/website/docs/devops-agent/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 3.5
 title: DevOps Agent Skills
 description: "Skills ported for fully autonomous execution on AWS DevOps Agent — read-only EKS cluster assessments without interactive prompts."
 ---
@@ -10,7 +10,10 @@ description: "Skills ported for fully autonomous execution on AWS DevOps Agent �
 
 A subset of APEX skills ported for the [AWS DevOps Agent](https://docs.aws.amazon.com/devopsagent/latest/userguide/) runtime. These run fully autonomously — no interactive prompts, no scripts, no MCP server references.
 
-- **[eks-cost-intelligence](./eks-cost-intelligence/)** — Active — EKS cost efficiency assessment — 6-dimension analysis, weighted 0-100 Cost Score, and dollar-quantified remediation report.
-- **[eks-operation-review](./eks-operation-review/)** — Placeholder — Run a structured EKS operational excellence assessment across 10 areas
-- **[eks-security](./eks-security/)** — Active — EKS security and compliance assessment — 7-layer hardening stack, CIS/HIPAA/PCI/FedRAMP/SOC2/GDPR audit prep, and 30/60/90 roadmap.
-- **[eks-upgrade-check](./eks-upgrade-check/)** — Placeholder — Assess EKS cluster upgrade readiness by running automated checks across
+<table>
+<tr><th>Skill</th><th>Status</th><th>Description</th></tr>
+<tr><td><a href="./eks-cost-intelligence/"><b>eks-cost-intelligence</b></a></td><td>Active</td><td>EKS cost efficiency assessment — 6-dimension analysis, weighted 0-100 Cost Score, and dollar-quantified remediation report.</td></tr>
+<tr><td><a href="./eks-operation-review/"><b>eks-operation-review</b></a></td><td>Placeholder</td><td>Run a structured EKS operational excellence assessment across 10 areas</td></tr>
+<tr><td><a href="./eks-security/"><b>eks-security</b></a></td><td>Active</td><td>EKS security and compliance assessment — 7-layer hardening stack, CIS/HIPAA/PCI/FedRAMP/SOC2/GDPR audit prep, and 30/60/90 roadmap.</td></tr>
+<tr><td><a href="./eks-upgrade-check/"><b>eks-upgrade-check</b></a></td><td>Placeholder</td><td>Assess EKS cluster upgrade readiness by running automated checks across</td></tr>
+</table>


### PR DESCRIPTION
## Summary

- `sidebar_position` 7 → 3.5 (lands DevOps Agent Skills between Skills and Steering in sidebar)
- Replace bullet list with HTML `<table>` (Skill | Status | Description columns)
- Truncation uses first-sentence boundary (`". "` split) instead of 150-char mid-word cut

## Test plan

- [ ] `./misc/update-pages.sh --check` passes (docs-sync CI)
- [ ] Verify sidebar order in local Docusaurus build
- [ ] No other generated pages changed (`git diff --stat` shows only 2 files)