### PR TITLE
ci: strict frontmatter validation + YAML-correct doc generators (fixes #131)

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -27,6 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Validate SKILL.md frontmatter
+        run: pip install pyyaml && python3 misc/validate-frontmatter.py
       - name: Regenerate and fail on diff
         run: |
           ./misc/update-all-references.sh --check
@@ -44,6 +49,8 @@ jobs:
           ./misc/update-all-references.sh && ./misc/update-pages.sh && git add -A
           git commit -m "docs: regenerate reference tables and pages"
           ```
+
+          If the failure is from `validate-frontmatter.py`, check your `SKILL.md` frontmatter YAML syntax and description length (max 1024 chars).
 
           Full details: [`CONTRIBUTING.md` → Keeping docs in sync](../blob/${{ github.head_ref || github.ref_name }}/CONTRIBUTING.md#keeping-docs-in-sync-auto-generated-catalogues).
           EOF

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -10,6 +10,7 @@ on:
       - "devops-agent/**"
       - "README.md"
       - "CONTRIBUTING.md"
+      - ".github/workflows/docs-sync.yml"
   push:
     branches:
       - main
@@ -31,13 +32,35 @@ jobs:
         with:
           python-version: '3.x'
       - name: Validate SKILL.md frontmatter
-        run: pip install pyyaml && python3 misc/validate-frontmatter.py
+        id: validate
+        run: pip install 'pyyaml>=6,<7' && python3 misc/validate-frontmatter.py
       - name: Regenerate and fail on diff
+        id: regen
         run: |
           ./misc/update-all-references.sh --check
           ./misc/update-pages.sh --check
-      - name: How to fix (shown on failure)
-        if: failure()
+      - name: How to fix frontmatter validation (shown on failure)
+        if: failure() && steps.validate.outcome == 'failure'
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## SKILL.md frontmatter failed validation
+
+          `misc/validate-frontmatter.py` strict-parses the frontmatter of every `skills/*/SKILL.md` and `devops-agent/*/SKILL.md`. Check the job log above for the exact file and error, then verify:
+
+          - the frontmatter is valid YAML (a mapping between `---` delimiters — watch unquoted `:` and stray quotes)
+          - `name` and `description` keys are present
+          - `description` is at most 1024 characters
+          - for `skills/*/SKILL.md` only: `description` matches the generated `skills.json` manifest (`devops-agent/` is exempt; a missing manifest entry is only a warning) — if you changed a description, regenerate:
+
+          ```bash
+          ./misc/update-all-references.sh && ./misc/update-pages.sh && git add -A
+          git commit -m "docs: regenerate reference tables and pages"
+          ```
+          EOF
+      - name: How to fix stale docs (shown on failure)
+        if: failure() && steps.regen.outcome == 'failure'
+        env:
+          BRANCH_REF: ${{ github.head_ref || github.ref_name }}
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
           ## Docs auto-gen blocks are stale
@@ -50,7 +73,5 @@ jobs:
           git commit -m "docs: regenerate reference tables and pages"
           ```
 
-          If the failure is from `validate-frontmatter.py`, check your `SKILL.md` frontmatter YAML syntax and description length (max 1024 chars).
-
-          Full details: [`CONTRIBUTING.md` → Keeping docs in sync](../blob/${{ github.head_ref || github.ref_name }}/CONTRIBUTING.md#keeping-docs-in-sync-auto-generated-catalogues).
           EOF
+          printf 'Full details: [`CONTRIBUTING.md` → Keeping docs in sync](%s/%s/blob/%s/CONTRIBUTING.md#keeping-docs-in-sync-auto-generated-catalogues).\n' "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "${BRANCH_REF}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/vendor-update.yml
+++ b/.github/workflows/vendor-update.yml
@@ -108,14 +108,23 @@ jobs:
         run: |
           echo "${{ steps.check.outputs.upstream_sha }}" > "${{ matrix.skill.path }}/.vendor-sha"
 
+      - uses: actions/setup-python@v5
+        if: steps.sync.outcome == 'success'
+        with:
+          python-version: '3.x'
+
+      - name: Install docs-generation dependencies
+        if: steps.sync.outcome == 'success'
+        run: pip install 'pyyaml>=6,<7'
+
       - name: Regenerate docs
         if: steps.sync.outcome == 'success'
         run: |
           if [ -x misc/update-all-references.sh ]; then
-            ./misc/update-all-references.sh || true
+            ./misc/update-all-references.sh
           fi
           if [ -x misc/update-pages.sh ]; then
-            ./misc/update-pages.sh || true
+            ./misc/update-pages.sh
           fi
 
       - name: Check for actual diff

--- a/.github/workflows/vendor-update.yml
+++ b/.github/workflows/vendor-update.yml
@@ -74,8 +74,16 @@ jobs:
           inputs.skill == '' ||
           inputs.skill == matrix.skill.name
         run: |
-          # Get upstream HEAD
-          UPSTREAM_SHA=$(git ls-remote "${{ matrix.skill.upstream }}" HEAD | cut -f1)
+          # Get upstream HEAD (capture first so a ls-remote failure isn't masked by the pipe)
+          if ! LS_REMOTE=$(git ls-remote "${{ matrix.skill.upstream }}" HEAD); then
+            echo "error: git ls-remote failed for ${{ matrix.skill.name }} (${{ matrix.skill.upstream }})" >&2
+            exit 1
+          fi
+          UPSTREAM_SHA=$(echo "$LS_REMOTE" | cut -f1)
+          if [ -z "$UPSTREAM_SHA" ]; then
+            echo "error: could not resolve upstream SHA for ${{ matrix.skill.name }}" >&2
+            exit 1
+          fi
           echo "upstream_sha=${UPSTREAM_SHA}" >> "$GITHUB_OUTPUT"
 
           # Compare with last synced SHA (stored in UPSTREAM.md or .vendor-sha)
@@ -120,12 +128,8 @@ jobs:
       - name: Regenerate docs
         if: steps.sync.outcome == 'success'
         run: |
-          if [ -x misc/update-all-references.sh ]; then
-            ./misc/update-all-references.sh
-          fi
-          if [ -x misc/update-pages.sh ]; then
-            ./misc/update-pages.sh
-          fi
+          bash misc/update-all-references.sh
+          bash misc/update-pages.sh
 
       - name: Check for actual diff
         id: diff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -355,7 +355,11 @@ Each block is delimited by HTML markers like `<!-- SKILLS_REFERENCE_START -->` /
 ./misc/update-all-references.sh
 ```
 
+The generator scripts (including `./misc/update-pages.sh`) parse frontmatter with PyYAML, so running them locally requires it: `pip install pyyaml`.
+
 **CI enforcement.** The `docs-sync` job in `.github/workflows/docs-sync.yml` runs `./misc/update-all-references.sh --check` and `./misc/update-pages.sh --check` on every PR. If the rendered blocks or Docusaurus wrappers diverge from frontmatter, the job fails and prints the exact diff. The fix is always the same: run both commands locally, commit the result.
+
+CI also strict-parses `SKILL.md` frontmatter via `misc/validate-frontmatter.py` before regenerating: the frontmatter must be a valid YAML mapping, `name` and `description` are required, `description` is capped at 1024 characters, and for `skills/` each description must match the generated `skills.json` manifest (`devops-agent/` is exempt from the manifest check; a missing manifest entry is only a warning). If validation fails, fix the frontmatter YAML and rerun the regeneration commands above.
 
 ## Creating a New Example
 

--- a/misc/README.md
+++ b/misc/README.md
@@ -63,6 +63,10 @@ After syncing, run `./update-skills-references.sh` to regenerate the skills READ
 **What gets synced:** Core skill components only — `SKILL.md`, `LICENSE`, `references/*.md`  
 **What gets excluded:** Everything else (README, CLAUDE.md, CONTRIBUTING.md, CHANGELOG.md, tests/, `.github/`, `.claude-plugin/`)
 
+## Validate Frontmatter
+
+`validate-frontmatter.py` strict-parses the YAML frontmatter of every `skills/*/SKILL.md` and `devops-agent/*/SKILL.md` (valid mapping, `name` + `description` present, description ≤ 1024 chars; for `skills/` the description must also be in sync with the generated `skills.json` manifest — `devops-agent/` is exempt, and a missing manifest entry is only a warning). CI runs it in the `docs-sync` job; run it locally with `python3 misc/validate-frontmatter.py` (requires PyYAML).
+
 ## Docs site
 
 The Docusaurus site lives at `misc/website/`. Key commands:

--- a/misc/evals/scripts/run_triggering.py
+++ b/misc/evals/scripts/run_triggering.py
@@ -394,6 +394,8 @@ def _read_skill_meta_regex(fm: str, skill_dir: Path) -> tuple[str, str]:
     """Stdlib-only fallback frontmatter scraper (pre-PyYAML behavior).
     Only understands top-level `name:` and `description:` (plain or block
     scalar) — kept for environments without PyYAML installed.
+    Known divergence from the YAML path: quoted values keep their
+    surrounding quotes (cosmetic; description is output-metadata only).
     """
     name = None
     description_lines: list[str] = []

--- a/misc/evals/scripts/run_triggering.py
+++ b/misc/evals/scripts/run_triggering.py
@@ -45,6 +45,11 @@ import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
+try:  # PyYAML is present in this eval env (siblings import it unconditionally),
+    import yaml  # but keep the stdlib-only regex fallback below so this runner
+except ImportError:  # still works in a bare interpreter.
+    yaml = None
+
 
 # Claude Code ships these skills in v2.1.121; system/init.skills lists them
 # before any project-level or plugin skills. Update if a CLI bump changes
@@ -356,9 +361,12 @@ _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
 
 def read_skill_meta(skill_dir: Path) -> tuple[str, str]:
-    """Parse SKILL.md frontmatter for (name, description). Simple YAML reader
-    — only `name:` and `description:` fields are needed, so we don't pull in
-    a YAML dependency.
+    """Parse SKILL.md frontmatter for (name, description).
+
+    Uses yaml.safe_load when PyYAML is importable (matching the docs
+    pipeline's parsing contract); falls back to the original stdlib-only
+    regex scraper otherwise. Raises RuntimeError on missing frontmatter,
+    missing `name`, or (yaml path only) invalid YAML.
     """
     text = (skill_dir / "SKILL.md").read_text()
     m = _FRONTMATTER_RE.match(text)
@@ -366,6 +374,27 @@ def read_skill_meta(skill_dir: Path) -> tuple[str, str]:
         raise RuntimeError(f"SKILL.md has no YAML frontmatter: {skill_dir}")
     fm = m.group(1)
 
+    if yaml is not None:
+        try:
+            data = yaml.safe_load(fm)
+        except yaml.YAMLError as e:
+            raise RuntimeError(
+                f"SKILL.md frontmatter is not valid YAML: {skill_dir}: {e}"
+            ) from e
+        if not isinstance(data, dict) or not data.get("name"):
+            raise RuntimeError(f"SKILL.md frontmatter missing `name`: {skill_dir}")
+        name = str(data["name"]).strip()
+        description = str(data.get("description") or "").strip()
+        return name, description
+
+    return _read_skill_meta_regex(fm, skill_dir)
+
+
+def _read_skill_meta_regex(fm: str, skill_dir: Path) -> tuple[str, str]:
+    """Stdlib-only fallback frontmatter scraper (pre-PyYAML behavior).
+    Only understands top-level `name:` and `description:` (plain or block
+    scalar) — kept for environments without PyYAML installed.
+    """
     name = None
     description_lines: list[str] = []
     in_description = False

--- a/misc/update-devops-agent-references.sh
+++ b/misc/update-devops-agent-references.sh
@@ -45,8 +45,9 @@ path, key = sys.argv[1], sys.argv[2]
 try:
     with open(path, encoding="utf-8") as f:
         lines = f.readlines()
-except (OSError, UnicodeDecodeError):
-    sys.exit(0)
+except (OSError, UnicodeDecodeError) as e:
+    print(f"ERROR: {path}: {e}", file=sys.stderr)
+    sys.exit(2)
 if not lines or lines[0].rstrip() != "---":
     sys.exit(0)
 fm = []
@@ -55,7 +56,8 @@ for line in lines[1:]:
         break
     fm.append(line)
 else:
-    sys.exit(0)
+    print(f"ERROR: {path}: unclosed frontmatter block (missing closing '---')", file=sys.stderr)
+    sys.exit(2)
 try:
     data = yaml.safe_load("".join(fm))
 except yaml.YAMLError as e:

--- a/misc/update-devops-agent-references.sh
+++ b/misc/update-devops-agent-references.sh
@@ -13,6 +13,12 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+python3 -c 'import yaml' 2>/dev/null || {
+  echo "ERROR: PyYAML is required (pip install pyyaml)" >&2
+  exit 1
+}
+
 DEVOPS_README="$REPO_ROOT/devops-agent/README.md"
 DEVOPS_DIR="$REPO_ROOT/devops-agent"
 DRY_RUN=false
@@ -29,47 +35,34 @@ fi
 parse_frontmatter() {
   local file="$1"
   local key="$2"
-  awk -v key="$key" '
-    /^---$/ { block++; next }
-    block == 1 && $0 ~ "^" key ":" {
-      sub("^" key ":[ ]*", "")
-      sub("^\"", ""); sub("\"$", "")
-      sub("^'\''", ""); sub("'\''$", "")
-      print
-      exit
-    }
-    block >= 2 { exit }
-  ' "$file"
-}
-
-# --- Parse multi-line frontmatter value ---
-# For descriptions that span multiple lines (YAML folded/flow style)
-parse_frontmatter_multiline() {
-  local file="$1"
-  local key="$2"
-  awk -v key="$key" '
-    /^---$/ { block++; next }
-    block == 1 && found {
-      if (/^[a-zA-Z_-]+:/) { exit }
-      gsub(/^[ \t]+/, "")
-      result = result " " $0
-      next
-    }
-    block == 1 && $0 ~ "^" key ":" {
-      sub("^" key ":[ ]*", "")
-      sub("^\"", ""); sub("\"$", "")
-      sub("^'\''", ""); sub("'\''$", "")
-      if (length($0) > 0) { result = $0 }
-      found = 1
-      next
-    }
-    block >= 2 { exit }
-    END {
-      gsub(/^[ \t]+/, "", result)
-      gsub(/[ \t]+$/, "", result)
-      print result
-    }
-  ' "$file"
+  python3 - "$file" "$key" <<'PY'
+import sys, yaml
+path, key = sys.argv[1], sys.argv[2]
+try:
+    with open(path, encoding="utf-8") as f:
+        lines = f.readlines()
+except (OSError, UnicodeDecodeError):
+    sys.exit(0)
+if not lines or lines[0].rstrip() != "---":
+    sys.exit(0)
+fm = []
+for line in lines[1:]:
+    if line.rstrip() == "---":
+        break
+    fm.append(line)
+else:
+    sys.exit(0)
+try:
+    data = yaml.safe_load("".join(fm))
+except yaml.YAMLError:
+    sys.exit(0)
+if not isinstance(data, dict):
+    sys.exit(0)
+val = data.get(key)
+if val is None:
+    sys.exit(0)
+print(" ".join(str(val).split()))
+PY
 }
 
 # --- Determine skill status ---
@@ -104,7 +97,7 @@ build_table() {
     fi
 
     local description
-    description="$(parse_frontmatter_multiline "$skill_md" "description")"
+    description="$(parse_frontmatter "$skill_md" "description")"
     if [[ -z "$description" ]]; then
       description="_(no description in frontmatter)_"
     fi

--- a/misc/update-devops-agent-references.sh
+++ b/misc/update-devops-agent-references.sh
@@ -11,6 +11,10 @@
 #   ./misc/update-devops-agent-references.sh --dry-run # preview without writing
 
 set -euo pipefail
+# Command substitutions must inherit errexit so a parse_frontmatter failure
+# (exit 2 on invalid YAML) inside $(build_table) aborts before README.md is
+# rewritten.
+shopt -s inherit_errexit
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
@@ -54,8 +58,9 @@ else:
     sys.exit(0)
 try:
     data = yaml.safe_load("".join(fm))
-except yaml.YAMLError:
-    sys.exit(0)
+except yaml.YAMLError as e:
+    print(f"ERROR: {path}: {e}", file=sys.stderr)
+    sys.exit(2)
 if not isinstance(data, dict):
     sys.exit(0)
 val = data.get(key)

--- a/misc/update-examples-references.sh
+++ b/misc/update-examples-references.sh
@@ -45,8 +45,9 @@ path, key = sys.argv[1], sys.argv[2]
 try:
     with open(path, encoding="utf-8") as f:
         lines = f.readlines()
-except (OSError, UnicodeDecodeError):
-    sys.exit(0)
+except (OSError, UnicodeDecodeError) as e:
+    print(f"ERROR: {path}: {e}", file=sys.stderr)
+    sys.exit(2)
 if not lines or lines[0].rstrip() != "---":
     sys.exit(0)
 fm = []
@@ -55,7 +56,8 @@ for line in lines[1:]:
         break
     fm.append(line)
 else:
-    sys.exit(0)
+    print(f"ERROR: {path}: unclosed frontmatter block (missing closing '---')", file=sys.stderr)
+    sys.exit(2)
 try:
     data = yaml.safe_load("".join(fm))
 except yaml.YAMLError as e:

--- a/misc/update-examples-references.sh
+++ b/misc/update-examples-references.sh
@@ -14,6 +14,10 @@
 #   ./misc/update-examples-references.sh --dry-run # preview without writing
 
 set -euo pipefail
+# Command substitutions must inherit errexit so a parse_frontmatter failure
+# (exit 2 on invalid YAML) inside $(build_table) aborts before README.md is
+# rewritten.
+shopt -s inherit_errexit
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
@@ -54,8 +58,9 @@ else:
     sys.exit(0)
 try:
     data = yaml.safe_load("".join(fm))
-except yaml.YAMLError:
-    sys.exit(0)
+except yaml.YAMLError as e:
+    print(f"ERROR: {path}: {e}", file=sys.stderr)
+    sys.exit(2)
 if not isinstance(data, dict):
     sys.exit(0)
 val = data.get(key)

--- a/misc/update-examples-references.sh
+++ b/misc/update-examples-references.sh
@@ -16,6 +16,12 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+python3 -c 'import yaml' 2>/dev/null || {
+  echo "ERROR: PyYAML is required (pip install pyyaml)" >&2
+  exit 1
+}
+
 README="$REPO_ROOT/README.md"
 EXAMPLES_README="$REPO_ROOT/examples/README.md"
 EXAMPLES_DIR="$REPO_ROOT/examples"
@@ -29,17 +35,34 @@ fi
 parse_frontmatter() {
   local file="$1"
   local key="$2"
-  awk -v key="$key" '
-    /^---$/ { block++; next }
-    block == 1 && $0 ~ "^" key ":" {
-      sub("^" key ":[ ]*", "")
-      sub("^\"", ""); sub("\"$", "")
-      sub("^'\''", ""); sub("'\''$", "")
-      print
-      exit
-    }
-    block >= 2 { exit }
-  ' "$file"
+  python3 - "$file" "$key" <<'PY'
+import sys, yaml
+path, key = sys.argv[1], sys.argv[2]
+try:
+    with open(path, encoding="utf-8") as f:
+        lines = f.readlines()
+except (OSError, UnicodeDecodeError):
+    sys.exit(0)
+if not lines or lines[0].rstrip() != "---":
+    sys.exit(0)
+fm = []
+for line in lines[1:]:
+    if line.rstrip() == "---":
+        break
+    fm.append(line)
+else:
+    sys.exit(0)
+try:
+    data = yaml.safe_load("".join(fm))
+except yaml.YAMLError:
+    sys.exit(0)
+if not isinstance(data, dict):
+    sys.exit(0)
+val = data.get(key)
+if val is None:
+    sys.exit(0)
+print(" ".join(str(val).split()))
+PY
 }
 
 # --- Convert filename to human-readable label ---

--- a/misc/update-pages.sh
+++ b/misc/update-pages.sh
@@ -500,30 +500,28 @@ _emit_skills_index_grid() {
 # --- Build skills.json manifest to stdout ---------------------------------
 build_manifest() {
   python3 - "$SKILLS_DIR" <<'PY'
-import json, os, re, sys
+import json, os, sys
+import yaml
 
 skills_dir = sys.argv[1]
 
 
 def parse_fm(path):
     with open(path, encoding="utf-8") as f:
-        lines = f.read().splitlines()
-    if not lines or lines[0].strip() != "---":
+        lines = f.readlines()
+    if not lines or lines[0].rstrip() != "---":
         return {}
-    fm = {}
+    fm_lines = []
     for line in lines[1:]:
-        if line.strip() == "---":
+        if line.rstrip() == "---":
             break
-        m = re.match(r'^([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)$', line)
-        if not m:
-            continue
-        k, v = m.group(1), m.group(2).strip()
-        if (v.startswith('"') and v.endswith('"')) or (
-            v.startswith("'") and v.endswith("'")
-        ):
-            v = v[1:-1]
-        fm[k] = v
-    return fm
+        fm_lines.append(line)
+    else:
+        return {}
+    data = yaml.safe_load("".join(fm_lines))
+    if not isinstance(data, dict):
+        return {}
+    return {k: str(v) for k, v in data.items() if v is not None}
 
 
 out = []
@@ -660,11 +658,11 @@ examples_dir = sys.argv[1]
 def parse_fm(path):
     with open(path, encoding="utf-8") as f:
         lines = f.read().splitlines()
-    if not lines or lines[0].strip() != "---":
+    if not lines or lines[0].rstrip() != "---":
         return {}
     fm = {}
     for line in lines[1:]:
-        if line.strip() == "---":
+        if line.rstrip() == "---":
             break
         m = re.match(r'^([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)$', line)
         if not m:

--- a/misc/update-pages.sh
+++ b/misc/update-pages.sh
@@ -41,6 +41,11 @@
 # Fix: `./misc/update-pages.sh && git add … && commit`.
 
 set -euo pipefail
+# Command substitutions must inherit errexit: parse_frontmatter exits 2 on
+# invalid YAML, and most callers run inside $(...) (derive_title, the index
+# builders). Without this, a broken SKILL.md would be swallowed and the
+# wrapper written with an empty description.
+shopt -s inherit_errexit
 
 MODE="run"
 if [[ "${1:-}" == "--check" ]]; then
@@ -103,8 +108,9 @@ else:
     sys.exit(0)
 try:
     data = yaml.safe_load("".join(fm))
-except yaml.YAMLError:
-    sys.exit(0)
+except yaml.YAMLError as e:
+    print(f"ERROR: {path}: {e}", file=sys.stderr)
+    sys.exit(2)
 if not isinstance(data, dict):
     sys.exit(0)
 val = data.get(key)
@@ -311,9 +317,9 @@ vendored_skill_admonition() {
   # Fallback: frontmatter metadata
   if [[ -z "$author" ]]; then
     local skill_md="$skill_dir/SKILL.md"
-    author="$(parse_frontmatter "$skill_md" "author" 2>/dev/null)"
+    author="$(parse_frontmatter "$skill_md" "author")"
   fi
-  license_id="$(parse_frontmatter "$skill_dir/SKILL.md" "license" 2>/dev/null)"
+  license_id="$(parse_frontmatter "$skill_dir/SKILL.md" "license")"
   [[ -z "$license_id" ]] && license_id="Apache-2.0"
   [[ -z "$source_url" ]] && source_url="$GH_BASE/skills/$skill_name"
   [[ -z "$author" ]] && author="third party"

--- a/misc/update-pages.sh
+++ b/misc/update-pages.sh
@@ -800,7 +800,7 @@ done
 # --- Skills index (card grid) ---
 if [[ "$MODE" == "dry-run" ]]; then
   echo "--- $SKILLS_OUT/index.md ---"
-  build_skills_index | head -20
+  build_skills_index | head -20 || true
   echo "  [... truncated ...]"
   echo ""
 else

--- a/misc/update-pages.sh
+++ b/misc/update-pages.sh
@@ -95,8 +95,9 @@ path, key = sys.argv[1], sys.argv[2]
 try:
     with open(path, encoding="utf-8") as f:
         lines = f.readlines()
-except (OSError, UnicodeDecodeError):
-    sys.exit(0)
+except (OSError, UnicodeDecodeError) as e:
+    print(f"ERROR: {path}: {e}", file=sys.stderr)
+    sys.exit(2)
 if not lines or lines[0].rstrip() != "---":
     sys.exit(0)
 fm = []
@@ -105,7 +106,8 @@ for line in lines[1:]:
         break
     fm.append(line)
 else:
-    sys.exit(0)
+    print(f"ERROR: {path}: unclosed frontmatter block (missing closing '---')", file=sys.stderr)
+    sys.exit(2)
 try:
     data = yaml.safe_load("".join(fm))
 except yaml.YAMLError as e:
@@ -545,7 +547,8 @@ def parse_fm(path):
             break
         fm_lines.append(line)
     else:
-        return {}
+        print(f"ERROR: {path}: unclosed frontmatter block (missing closing '---')", file=sys.stderr)
+        sys.exit(2)
     data = yaml.safe_load("".join(fm_lines))
     if not isinstance(data, dict):
         return {}
@@ -699,7 +702,8 @@ def parse_fm(path):
             break
         fm_lines.append(line)
     else:
-        return {}
+        print(f"ERROR: {path}: unclosed frontmatter block (missing closing '---')", file=sys.stderr)
+        sys.exit(2)
     data = yaml.safe_load("".join(fm_lines))
     if not isinstance(data, dict):
         return {}
@@ -828,7 +832,8 @@ fi
 # --- Examples index (card grid) ---
 if [[ "$MODE" == "dry-run" ]]; then
   echo "--- $EXAMPLES_OUT/index.md ---"
-  build_examples_index | head -20
+  examples_index_out="$(build_examples_index)"
+  head -20 <<<"$examples_index_out"
   echo "  [... truncated ...]"
   echo ""
 else
@@ -888,7 +893,8 @@ INDEXEOF
 
 if [[ "$MODE" == "dry-run" ]]; then
   echo "--- $DEVOPS_OUT/index.md ---"
-  build_devops_index | head -20
+  devops_index_out="$(build_devops_index)"
+  head -20 <<<"$devops_index_out"
   echo "  [... truncated ...]"
   echo ""
 else

--- a/misc/update-pages.sh
+++ b/misc/update-pages.sh
@@ -52,6 +52,11 @@ fi
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
+python3 -c 'import yaml' 2>/dev/null || {
+  echo "ERROR: PyYAML is required (pip install pyyaml)" >&2
+  exit 1
+}
+
 SKILLS_OUT="$REPO_ROOT/misc/website/docs/skills"
 STEERING_OUT="$REPO_ROOT/misc/website/docs/steering"
 EXAMPLES_OUT="$REPO_ROOT/misc/website/docs/examples"
@@ -79,17 +84,34 @@ TOUCHED_PATHS=(
 parse_frontmatter() {
   local file="$1"
   local key="$2"
-  awk -v key="$key" '
-    /^---$/ { block++; next }
-    block == 1 && $0 ~ "^" key ":" {
-      sub("^" key ":[ ]*", "")
-      sub("^\"", ""); sub("\"$", "")
-      sub("^'\''", ""); sub("'\''$", "")
-      print
-      exit
-    }
-    block >= 2 { exit }
-  ' "$file"
+  python3 - "$file" "$key" <<'PY'
+import sys, yaml
+path, key = sys.argv[1], sys.argv[2]
+try:
+    with open(path, encoding="utf-8") as f:
+        lines = f.readlines()
+except (OSError, UnicodeDecodeError):
+    sys.exit(0)
+if not lines or lines[0].rstrip() != "---":
+    sys.exit(0)
+fm = []
+for line in lines[1:]:
+    if line.rstrip() == "---":
+        break
+    fm.append(line)
+else:
+    sys.exit(0)
+try:
+    data = yaml.safe_load("".join(fm))
+except yaml.YAMLError:
+    sys.exit(0)
+if not isinstance(data, dict):
+    sys.exit(0)
+val = data.get(key)
+if val is None:
+    sys.exit(0)
+print(" ".join(str(val).split()))
+PY
 }
 
 # --- Extract first # heading from a markdown file -------------------------
@@ -289,7 +311,7 @@ vendored_skill_admonition() {
   # Fallback: frontmatter metadata
   if [[ -z "$author" ]]; then
     local skill_md="$skill_dir/SKILL.md"
-    author="$(awk '/author:/{sub(/.*author: */, ""); print; exit}' "$skill_md" 2>/dev/null)"
+    author="$(parse_frontmatter "$skill_md" "author" 2>/dev/null)"
   fi
   license_id="$(parse_frontmatter "$skill_dir/SKILL.md" "license" 2>/dev/null)"
   [[ -z "$license_id" ]] && license_id="Apache-2.0"
@@ -530,7 +552,11 @@ for entry in sorted(os.listdir(skills_dir)):
     sm = os.path.join(sd, "SKILL.md")
     if not os.path.isfile(sm):
         continue
-    fm = parse_fm(sm)
+    try:
+        fm = parse_fm(sm)
+    except Exception as e:
+        print(f"ERROR: {sm}: {e}", file=sys.stderr)
+        sys.exit(1)
     name = fm.get("name") or entry
     # Classify by prefix
     if entry.startswith("eks-"):
@@ -650,30 +676,28 @@ EOF
 # --- Build examples.json manifest to stdout --------------------------------
 build_examples_manifest() {
   python3 - "$EXAMPLES_DIR" <<'PY'
-import json, os, re, sys
+import json, os, sys
+import yaml
 
 examples_dir = sys.argv[1]
 
 
 def parse_fm(path):
     with open(path, encoding="utf-8") as f:
-        lines = f.read().splitlines()
+        lines = f.readlines()
     if not lines or lines[0].rstrip() != "---":
         return {}
-    fm = {}
+    fm_lines = []
     for line in lines[1:]:
         if line.rstrip() == "---":
             break
-        m = re.match(r'^([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)$', line)
-        if not m:
-            continue
-        k, v = m.group(1), m.group(2).strip()
-        if (v.startswith('"') and v.endswith('"')) or (
-            v.startswith("'") and v.endswith("'")
-        ):
-            v = v[1:-1]
-        fm[k] = v
-    return fm
+        fm_lines.append(line)
+    else:
+        return {}
+    data = yaml.safe_load("".join(fm_lines))
+    if not isinstance(data, dict):
+        return {}
+    return {k: str(v) for k, v in data.items() if v is not None}
 
 
 out = []
@@ -682,7 +706,11 @@ for root, dirs, files in sorted(os.walk(examples_dir)):
     if "README.md" not in files:
         continue
     readme_path = os.path.join(root, "README.md")
-    fm = parse_fm(readme_path)
+    try:
+        fm = parse_fm(readme_path)
+    except Exception as e:
+        print(f"ERROR: {readme_path}: {e}", file=sys.stderr)
+        sys.exit(1)
     name = fm.get("name")
     if not name:
         continue

--- a/misc/update-skills-references.sh
+++ b/misc/update-skills-references.sh
@@ -45,8 +45,9 @@ path, key = sys.argv[1], sys.argv[2]
 try:
     with open(path, encoding="utf-8") as f:
         lines = f.readlines()
-except (OSError, UnicodeDecodeError):
-    sys.exit(0)
+except (OSError, UnicodeDecodeError) as e:
+    print(f"ERROR: {path}: {e}", file=sys.stderr)
+    sys.exit(2)
 if not lines or lines[0].rstrip() != "---":
     sys.exit(0)
 fm = []
@@ -55,7 +56,8 @@ for line in lines[1:]:
         break
     fm.append(line)
 else:
-    sys.exit(0)
+    print(f"ERROR: {path}: unclosed frontmatter block (missing closing '---')", file=sys.stderr)
+    sys.exit(2)
 try:
     data = yaml.safe_load("".join(fm))
 except yaml.YAMLError as e:

--- a/misc/update-skills-references.sh
+++ b/misc/update-skills-references.sh
@@ -15,6 +15,12 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+python3 -c 'import yaml' 2>/dev/null || {
+  echo "ERROR: PyYAML is required (pip install pyyaml)" >&2
+  exit 1
+}
+
 README="$REPO_ROOT/README.md"
 SKILLS_README="$REPO_ROOT/skills/README.md"
 SKILLS_DIR="$REPO_ROOT/skills"
@@ -29,18 +35,34 @@ fi
 parse_frontmatter() {
   local file="$1"
   local key="$2"
-  # Read between first and second --- lines, then grab the key
-  awk -v key="$key" '
-    /^---$/ { block++; next }
-    block == 1 && $0 ~ "^" key ":" {
-      sub("^" key ":[ ]*", "")
-      sub("^\"", ""); sub("\"$", "")
-      sub("^'\''", ""); sub("'\''$", "")
-      print
-      exit
-    }
-    block >= 2 { exit }
-  ' "$file"
+  python3 - "$file" "$key" <<'PY'
+import sys, yaml
+path, key = sys.argv[1], sys.argv[2]
+try:
+    with open(path, encoding="utf-8") as f:
+        lines = f.readlines()
+except (OSError, UnicodeDecodeError):
+    sys.exit(0)
+if not lines or lines[0].rstrip() != "---":
+    sys.exit(0)
+fm = []
+for line in lines[1:]:
+    if line.rstrip() == "---":
+        break
+    fm.append(line)
+else:
+    sys.exit(0)
+try:
+    data = yaml.safe_load("".join(fm))
+except yaml.YAMLError:
+    sys.exit(0)
+if not isinstance(data, dict):
+    sys.exit(0)
+val = data.get(key)
+if val is None:
+    sys.exit(0)
+print(" ".join(str(val).split()))
+PY
 }
 
 # --- Classify a skill into a service group ---

--- a/misc/update-skills-references.sh
+++ b/misc/update-skills-references.sh
@@ -13,6 +13,10 @@
 #   ./misc/update-skills-references.sh --dry-run # preview without writing
 
 set -euo pipefail
+# Command substitutions must inherit errexit so a parse_frontmatter failure
+# (exit 2 on invalid YAML) inside $(build_table) aborts before README.md is
+# rewritten.
+shopt -s inherit_errexit
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
@@ -54,8 +58,9 @@ else:
     sys.exit(0)
 try:
     data = yaml.safe_load("".join(fm))
-except yaml.YAMLError:
-    sys.exit(0)
+except yaml.YAMLError as e:
+    print(f"ERROR: {path}: {e}", file=sys.stderr)
+    sys.exit(2)
 if not isinstance(data, dict):
     sys.exit(0)
 val = data.get(key)

--- a/misc/update-steering-references.sh
+++ b/misc/update-steering-references.sh
@@ -16,6 +16,12 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+python3 -c 'import yaml' 2>/dev/null || {
+  echo "ERROR: PyYAML is required (pip install pyyaml)" >&2
+  exit 1
+}
+
 README="$REPO_ROOT/README.md"
 STEERING_DIR="$REPO_ROOT/steering"
 DRY_RUN=false
@@ -28,17 +34,34 @@ fi
 parse_frontmatter() {
   local file="$1"
   local key="$2"
-  awk -v key="$key" '
-    /^---$/ { block++; next }
-    block == 1 && $0 ~ "^" key ":" {
-      sub("^" key ":[ ]*", "")
-      sub("^\"", ""); sub("\"$", "")
-      sub("^'\''", ""); sub("'\''$", "")
-      print
-      exit
-    }
-    block >= 2 { exit }
-  ' "$file"
+  python3 - "$file" "$key" <<'PY'
+import sys, yaml
+path, key = sys.argv[1], sys.argv[2]
+try:
+    with open(path, encoding="utf-8") as f:
+        lines = f.readlines()
+except (OSError, UnicodeDecodeError):
+    sys.exit(0)
+if not lines or lines[0].rstrip() != "---":
+    sys.exit(0)
+fm = []
+for line in lines[1:]:
+    if line.rstrip() == "---":
+        break
+    fm.append(line)
+else:
+    sys.exit(0)
+try:
+    data = yaml.safe_load("".join(fm))
+except yaml.YAMLError:
+    sys.exit(0)
+if not isinstance(data, dict):
+    sys.exit(0)
+val = data.get(key)
+if val is None:
+    sys.exit(0)
+print(" ".join(str(val).split()))
+PY
 }
 
 # --- Pick column count based on item count ---

--- a/misc/update-steering-references.sh
+++ b/misc/update-steering-references.sh
@@ -44,8 +44,9 @@ path, key = sys.argv[1], sys.argv[2]
 try:
     with open(path, encoding="utf-8") as f:
         lines = f.readlines()
-except (OSError, UnicodeDecodeError):
-    sys.exit(0)
+except (OSError, UnicodeDecodeError) as e:
+    print(f"ERROR: {path}: {e}", file=sys.stderr)
+    sys.exit(2)
 if not lines or lines[0].rstrip() != "---":
     sys.exit(0)
 fm = []
@@ -54,7 +55,8 @@ for line in lines[1:]:
         break
     fm.append(line)
 else:
-    sys.exit(0)
+    print(f"ERROR: {path}: unclosed frontmatter block (missing closing '---')", file=sys.stderr)
+    sys.exit(2)
 try:
     data = yaml.safe_load("".join(fm))
 except yaml.YAMLError as e:

--- a/misc/update-steering-references.sh
+++ b/misc/update-steering-references.sh
@@ -14,6 +14,10 @@
 #   ./misc/update-steering-references.sh --dry-run # preview without writing
 
 set -euo pipefail
+# Command substitutions must inherit errexit so a parse_frontmatter failure
+# (exit 2 on invalid YAML) inside $(build_table) aborts before README.md is
+# rewritten.
+shopt -s inherit_errexit
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
@@ -53,8 +57,9 @@ else:
     sys.exit(0)
 try:
     data = yaml.safe_load("".join(fm))
-except yaml.YAMLError:
-    sys.exit(0)
+except yaml.YAMLError as e:
+    print(f"ERROR: {path}: {e}", file=sys.stderr)
+    sys.exit(2)
 if not isinstance(data, dict):
     sys.exit(0)
 val = data.get(key)

--- a/misc/validate-frontmatter.py
+++ b/misc/validate-frontmatter.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Validate SKILL.md frontmatter: parseable YAML, description present and <= 1024 chars, manifest sync."""
+
+import json
+import os
+import sys
+from glob import glob
+
+import yaml
+
+
+def extract_frontmatter(path):
+    """Extract frontmatter YAML string using line-based delimiter detection."""
+    with open(path, encoding="utf-8") as f:
+        lines = f.readlines()
+    if not lines or lines[0].rstrip() != "---":
+        return None
+    fm_lines = []
+    for line in lines[1:]:
+        if line.rstrip() == "---":
+            return "".join(fm_lines)
+        fm_lines.append(line)
+    return None
+
+
+def main():
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    patterns = [
+        os.path.join(repo_root, "skills", "*", "SKILL.md"),
+        os.path.join(repo_root, "devops-agent", "*", "SKILL.md"),
+    ]
+
+    manifest_path = os.path.join(repo_root, "misc", "website", "static", "manifests", "skills.json")
+    manifest_by_name = {}
+    if not os.path.isfile(manifest_path):
+        print(f"ERROR: skills.json manifest not found at {manifest_path}")
+        sys.exit(1)
+    try:
+        with open(manifest_path, encoding="utf-8") as f:
+            for entry in json.load(f):
+                manifest_by_name[entry["name"]] = entry["description"]
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        print(f"ERROR: could not parse skills.json manifest ({e})")
+        sys.exit(1)
+
+    errors = []
+    warnings = []
+    count = 0
+
+    # M3: check manifest entries for over-length or invalid descriptions
+    for name, manifest_desc in manifest_by_name.items():
+        if not isinstance(manifest_desc, str):
+            errors.append(f"skills.json[{name}]: manifest description is not a string ({type(manifest_desc).__name__})")
+        elif len(manifest_desc) > 1024:
+            errors.append(f"skills.json[{name}]: manifest description too long ({len(manifest_desc)} chars, max 1024)")
+
+    for pattern in patterns:
+        for path in sorted(glob(pattern)):
+            count += 1
+            rel = os.path.relpath(path, repo_root)
+
+            try:
+                raw = extract_frontmatter(path)
+                if raw is None:
+                    errors.append(f"{rel}: no YAML frontmatter block found (missing closing '---')")
+                    continue
+
+                data = yaml.safe_load(raw)
+
+                if not isinstance(data, dict):
+                    errors.append(f"{rel}: frontmatter is not a mapping")
+                    continue
+
+                desc = data.get("description")
+                if desc is None:
+                    errors.append(f"{rel}: missing 'description' key")
+                    continue
+
+                if not isinstance(desc, str):
+                    errors.append(f"{rel}: 'description' must be a string, got {type(desc).__name__}")
+                    continue
+
+                if len(desc) > 1024:
+                    errors.append(f"{rel}: description too long ({len(desc)} chars, max 1024)")
+
+                name = data.get("name")
+                if not name or not isinstance(name, str):
+                    errors.append(f"{rel}: missing or invalid 'name' key")
+                    continue
+                is_devops_agent = rel.startswith("devops-agent/")
+
+                if not is_devops_agent and name in manifest_by_name:
+                    if desc != manifest_by_name[name]:
+                        errors.append(f"{rel}: description does not match skills.json manifest (run update-pages.sh)")
+                elif not is_devops_agent and name not in manifest_by_name:
+                    warnings.append(f"{rel}: no manifest entry for '{name}' (not in skills.json)")
+
+            except yaml.YAMLError as e:
+                errors.append(f"{rel}: YAML parse error: {e}")
+            except Exception as e:
+                errors.append(f"{rel}: unexpected error: {e}")
+
+    for w in warnings:
+        print(f"WARN: {w}")
+    for e in errors:
+        print(f"ERROR: {e}")
+
+    if errors:
+        print(f"\n{count} skills checked, {len(errors)} error(s)")
+        sys.exit(1)
+    else:
+        print(f"\n{count} skills validated, 0 errors")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/misc/validate-frontmatter.py
+++ b/misc/validate-frontmatter.py
@@ -9,6 +9,27 @@ from glob import glob
 import yaml
 
 
+class DuplicateKeyError(yaml.YAMLError):
+    """Raised when a YAML mapping declares the same key twice."""
+
+
+class StrictLoader(yaml.SafeLoader):
+    """SafeLoader that rejects duplicate mapping keys instead of last-wins.
+
+    yaml.safe_load silently keeps the last value for a duplicated key, but
+    stricter spec-conformant consumers (e.g. js-yaml >= 4) reject the file.
+    """
+
+    def construct_mapping(self, node, deep=False):
+        seen = set()
+        for key_node, _ in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            if key in seen:
+                raise DuplicateKeyError(f"duplicate frontmatter key: {key}")
+            seen.add(key)
+        return super().construct_mapping(node, deep=deep)
+
+
 def extract_frontmatter(path):
     """Extract frontmatter YAML string using line-based delimiter detection."""
     with open(path, encoding="utf-8") as f:
@@ -70,7 +91,7 @@ def main():
                     errors.append(f"{rel}: no YAML frontmatter block found (missing closing '---')")
                     continue
 
-                data = yaml.safe_load(raw)
+                data = yaml.load(raw, Loader=StrictLoader)
 
                 if not isinstance(data, dict):
                     errors.append(f"{rel}: frontmatter is not a mapping")
@@ -108,6 +129,8 @@ def main():
                 elif not is_devops_agent and name not in manifest_by_name:
                     warnings.append(f"{rel}: no manifest entry for '{name}' (not in skills.json)")
 
+            except DuplicateKeyError as e:
+                errors.append(f"{rel}: {e}")
             except yaml.YAMLError as e:
                 errors.append(f"{rel}: YAML parse error: {e}")
             except (OSError, UnicodeDecodeError) as e:

--- a/misc/validate-frontmatter.py
+++ b/misc/validate-frontmatter.py
@@ -30,6 +30,10 @@ def main():
         os.path.join(repo_root, "devops-agent", "*", "SKILL.md"),
     ]
 
+    errors = []
+    warnings = []
+    count = 0
+
     manifest_path = os.path.join(repo_root, "misc", "website", "static", "manifests", "skills.json")
     manifest_by_name = {}
     if not os.path.isfile(manifest_path):
@@ -38,14 +42,12 @@ def main():
     try:
         with open(manifest_path, encoding="utf-8") as f:
             for entry in json.load(f):
+                if entry["name"] in manifest_by_name:
+                    errors.append(f"skills.json: duplicate name '{entry['name']}'")
                 manifest_by_name[entry["name"]] = entry["description"]
     except (json.JSONDecodeError, KeyError, TypeError) as e:
         print(f"ERROR: could not parse skills.json manifest ({e})")
         sys.exit(1)
-
-    errors = []
-    warnings = []
-    count = 0
 
     # M3: check manifest entries for over-length or invalid descriptions
     for name, manifest_desc in manifest_by_name.items():
@@ -55,6 +57,9 @@ def main():
             errors.append(f"skills.json[{name}]: manifest description too long ({len(manifest_desc)} chars, max 1024)")
 
     for pattern in patterns:
+        # devops-agent/ and skills/ are separate namespaces — a name may
+        # legitimately appear in both. Only flag duplicates within one scope.
+        seen_names = {}
         for path in sorted(glob(pattern)):
             count += 1
             rel = os.path.relpath(path, repo_root)
@@ -83,10 +88,18 @@ def main():
                 if len(desc) > 1024:
                     errors.append(f"{rel}: description too long ({len(desc)} chars, max 1024)")
 
+                if desc == "":
+                    warnings.append(f"{rel}: description is empty")
+
                 name = data.get("name")
                 if not name or not isinstance(name, str):
                     errors.append(f"{rel}: missing or invalid 'name' key")
                     continue
+
+                if name in seen_names:
+                    errors.append(f"{rel}: duplicate name '{name}' (also declared by {seen_names[name]})")
+                else:
+                    seen_names[name] = rel
                 is_devops_agent = rel.startswith("devops-agent/")
 
                 if not is_devops_agent and name in manifest_by_name:
@@ -97,6 +110,8 @@ def main():
 
             except yaml.YAMLError as e:
                 errors.append(f"{rel}: YAML parse error: {e}")
+            except (OSError, UnicodeDecodeError) as e:
+                errors.append(f"{rel}: cannot read file: {e}")
             except Exception as e:
                 errors.append(f"{rel}: unexpected error: {e}")
 

--- a/misc/website/docs/devops-agent/eks-cost-intelligence/index.md
+++ b/misc/website/docs/devops-agent/eks-cost-intelligence/index.md
@@ -1,6 +1,6 @@
 ---
 title: "eks-cost-intelligence"
-description: "EKS cost efficiency assessment — 6-dimension analysis, weighted 0-100 Cost Score, and dollar-quantified remediation report."
+description: "EKS cost efficiency assessment — 6-dimension analysis, weighted 0-100 Cost Score, and dollar-quantified remediation report. Analyzes compute efficiency, Spot/Graviton adoption, networking, storage, observability, and idle resources. Triggers on cost audit, cost review, cost driver analysis, FinOps assessment, spending efficiency, waste identification, over-provisioned workloads, or cost attribution by namespace. Combines live Cost Explorer data, CloudWatch utilization metrics, and Kubernetes resource analysis."
 custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/devops-agent/eks-cost-intelligence/SKILL.md
 format: md
 ---

--- a/misc/website/docs/devops-agent/eks-operation-review/index.md
+++ b/misc/website/docs/devops-agent/eks-operation-review/index.md
@@ -1,6 +1,6 @@
 ---
 title: "eks-operation-review"
-description: "Run a structured EKS operational excellence assessment across 10 areas"
+description: "Run a structured EKS operational excellence assessment across 10 areas (networking, autoscaling, observability, access & identity, add-ons, workload config, deployments, cluster lifecycle, IaC, operational processes) producing a rated report with GREEN/AMBER/RED findings and prioritized recommendations."
 custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/devops-agent/eks-operation-review/SKILL.md
 format: md
 ---

--- a/misc/website/docs/devops-agent/eks-security/index.md
+++ b/misc/website/docs/devops-agent/eks-security/index.md
@@ -1,6 +1,6 @@
 ---
 title: "eks-security"
-description: "EKS security and compliance assessment — 7-layer hardening stack, CIS/HIPAA/PCI/FedRAMP/SOC2/GDPR audit prep, and 30/60/90 roadmap."
+description: "EKS security and compliance assessment — 7-layer hardening stack, CIS/HIPAA/PCI/FedRAMP/SOC2/GDPR audit prep, and 30/60/90 roadmap. Covers OS/AMI selection (Bottlerocket, AL2023, RHEL, Ubuntu), identity (EKS Pod Identity vs IRSA, Access Entries vs aws-auth), workload security (Pod Security Admission, Kyverno/OPA, NetworkPolicy, Security Groups for Pods), image supply chain (ECR scanning, Cosign/Notation signing), runtime detection (GuardDuty, Falco), audit logging, etcd / secrets encryption, and compliance accelerators (Audit Manager, Config, Security Hub). Triggers on CIS Benchmark, HIPAA, PCI-DSS, FedRAMP, SOC 2, GDPR compliance, cluster hardening, audit-prep, or any regulated-workload assessment. Does not cover non-EKS platforms (ECS/ROSA), account-level security with no EKS angle, or GenAI-workload security."
 custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/devops-agent/eks-security/SKILL.md
 format: md
 ---

--- a/misc/website/docs/devops-agent/eks-upgrade-check/index.md
+++ b/misc/website/docs/devops-agent/eks-upgrade-check/index.md
@@ -1,6 +1,6 @@
 ---
 title: "eks-upgrade-check"
-description: "Assess EKS cluster upgrade readiness by running automated checks across"
+description: "Assess EKS cluster upgrade readiness by running automated checks across 8 areas (version validation, breaking changes, deprecated APIs, add-on compatibility, node readiness, workload risks, AWS Upgrade Insights, upgrade plan), calculate a readiness score (0-100%), and generate a detailed report with remediation steps."
 custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/devops-agent/eks-upgrade-check/SKILL.md
 format: md
 ---

--- a/misc/website/docs/devops-agent/index.md
+++ b/misc/website/docs/devops-agent/index.md
@@ -13,7 +13,7 @@ A subset of APEX skills ported for the [AWS DevOps Agent](https://docs.aws.amazo
 <table>
 <tr><th>Skill</th><th>Status</th><th>Description</th></tr>
 <tr><td><a href="./eks-cost-intelligence/"><b>eks-cost-intelligence</b></a></td><td>Active</td><td>EKS cost efficiency assessment — 6-dimension analysis, weighted 0-100 Cost Score, and dollar-quantified remediation report.</td></tr>
-<tr><td><a href="./eks-operation-review/"><b>eks-operation-review</b></a></td><td>Placeholder</td><td>Run a structured EKS operational excellence assessment across 10 areas</td></tr>
+<tr><td><a href="./eks-operation-review/"><b>eks-operation-review</b></a></td><td>Placeholder</td><td>Run a structured EKS operational excellence assessment across 10 areas (networking, autoscaling, observability, access & identity, add-ons, workload…</td></tr>
 <tr><td><a href="./eks-security/"><b>eks-security</b></a></td><td>Active</td><td>EKS security and compliance assessment — 7-layer hardening stack, CIS/HIPAA/PCI/FedRAMP/SOC2/GDPR audit prep, and 30/60/90 roadmap.</td></tr>
-<tr><td><a href="./eks-upgrade-check/"><b>eks-upgrade-check</b></a></td><td>Placeholder</td><td>Assess EKS cluster upgrade readiness by running automated checks across</td></tr>
+<tr><td><a href="./eks-upgrade-check/"><b>eks-upgrade-check</b></a></td><td>Placeholder</td><td>Assess EKS cluster upgrade readiness by running automated checks across 8 areas (version validation, breaking changes, deprecated APIs, add-on…</td></tr>
 </table>

--- a/misc/website/docs/skills/general/steering-workflow-creator/assets/workflow-skeleton.md
+++ b/misc/website/docs/skills/general/steering-workflow-creator/assets/workflow-skeleton.md
@@ -1,6 +1,6 @@
 ---
-title: "<workflow-name>"
-description: "<Day N {intent} workflow. Front-load the lifecycle phase and the concrete verbs users will type — e.g., \"Day 2 cost review workflow. Discovers compute posture, scores hygiene against defaults, emits recommendations.\">"
+title: "<Workflow Title>"
+description: ""
 custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/skills/steering-workflow-creator/assets/workflow-skeleton.md
 format: md
 ---

--- a/misc/website/docusaurus.config.ts
+++ b/misc/website/docusaurus.config.ts
@@ -30,8 +30,9 @@ const config: Config = {
     // READMEs an explicit non-index slug instead of dropping the page.
     parseFrontMatter: async (params) => {
       const result = await params.defaultParseFrontMatter(params);
-      const posixPath = params.filePath.split(path.sep).join('/');
-      const match = posixPath.match(/\/docs\/(.+)\/README\.md$/);
+      const docsRoot = path.join(__dirname, 'docs');
+      const relPath = path.relative(docsRoot, params.filePath).split(path.sep).join('/');
+      const match = !relPath.startsWith('..') && relPath.match(/^(.+)\/README\.md$/);
       if (
         match &&
         !result.frontMatter.slug &&

--- a/misc/website/docusaurus.config.ts
+++ b/misc/website/docusaurus.config.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
@@ -19,6 +21,25 @@ const config: Config = {
     format: 'detect',
     hooks: {
       onBrokenMarkdownLinks: 'warn',
+    },
+    // Docusaurus treats README.md as a directory-index doc, so a generated
+    // README.md wrapper sitting next to an index.md (e.g. the
+    // eks-cost-intelligence contributor README next to its SKILL.md wrapper)
+    // would claim the same route — "Duplicate routes found!" — and make
+    // plugin-client-redirects emit the same redirect twice. Give such
+    // READMEs an explicit non-index slug instead of dropping the page.
+    parseFrontMatter: async (params) => {
+      const result = await params.defaultParseFrontMatter(params);
+      const posixPath = params.filePath.split(path.sep).join('/');
+      const match = posixPath.match(/\/docs\/(.+)\/README\.md$/);
+      if (
+        match &&
+        !result.frontMatter.slug &&
+        fs.existsSync(path.join(path.dirname(params.filePath), 'index.md'))
+      ) {
+        result.frontMatter.slug = `/${match[1]}/README`;
+      }
+      return result;
     },
   },
 

--- a/skills/steering-workflow-creator/scripts/quick_validate.py
+++ b/skills/steering-workflow-creator/scripts/quick_validate.py
@@ -126,6 +126,13 @@ def check_frontmatter(lines: List[str]) -> List[Finding]:
             "frontmatter missing: file must open with '---'",
         ))
         return findings
+    if idx != 0:
+        findings.append(Finding(
+            "W006", idx + 1,
+            "frontmatter not at line 1 — the docs pipeline "
+            "(update-steering-references.sh) will skip this file; "
+            "remove anything above the opening '---'",
+        ))
     start = idx
     end = -1
     for j in range(idx + 1, len(lines)):
@@ -623,7 +630,7 @@ def group_findings(findings: List[Finding]) -> dict:
     buckets: dict = {}
     code_section = {
         "E001": "Frontmatter", "E002": "Frontmatter", "E003": "Frontmatter",
-        "E004": "Frontmatter", "E005": "Frontmatter",
+        "E004": "Frontmatter", "E005": "Frontmatter", "W006": "Frontmatter",
         "E010": "Title/Header", "E011": "Title/Header", "E012": "Title/Header",
         "E013": "Title/Header", "E014": "Title/Header", "E015": "Title/Header",
         "E020": "Required sections", "E021": "Required sections",

--- a/skills/steering-workflow-creator/scripts/quick_validate.py
+++ b/skills/steering-workflow-creator/scripts/quick_validate.py
@@ -126,12 +126,12 @@ def check_frontmatter(lines: List[str]) -> List[Finding]:
             "frontmatter missing: file must open with '---'",
         ))
         return findings
-    if idx != 0:
+    if idx != 0 or lines[0].rstrip() != "---":
         findings.append(Finding(
             "W006", idx + 1,
             "frontmatter not at line 1 — the docs pipeline "
             "(update-steering-references.sh) will skip this file; "
-            "remove anything above the opening '---'",
+            "remove anything above (or before) the opening '---'",
         ))
     start = idx
     end = -1


### PR DESCRIPTION
## What

Closes #131 across **all three surfaces** the incidents shipped on (skills.json, Docusaurus wrappers, skills/README.md) — not just the manifest.

### Commit 1 — CI validator (`bb5de7a`)
- `misc/validate-frontmatter.py`: strict-parses every `skills/*/SKILL.md` + `devops-agent/*/SKILL.md` frontmatter with `yaml.safe_load` — valid mapping, `name` + `description` required (string), description ≤ 1024 chars, and (for `skills/`) byte-match against the generated `skills.json`; per-entry manifest length/type checks; per-file error isolation (one bad file never hides another)
- `build_manifest` in `update-pages.sh` switched from naive regex to `yaml.safe_load` — the manifest is now correct-by-construction; validator is the drift guard
- Wired as the first step of docs-sync (validate → regen `--check`)

### Commit 2 — pipeline-wide expansion (`085e9f1`)
- `parse_frontmatter()` in **all 5** `misc/update-*.sh` generators now YAML-parses (was naive awk that truncated folded scalars at line 1 and leaked quoting artifacts) — this is what protects the wrapper + README surfaces
- Examples manifest parser converted; both manifest heredocs fail with a clean one-line error on malformed input; pyyaml preflight guard in every generator
- Validator hardening: per-scope duplicate-name detection, empty-description warning, dedicated unreadable-file handler
- `docs-sync.yml`: self-trigger path, pinned `pyyaml>=6,<7`, split validator/regen failure summaries, `head_ref` via env, absolute CONTRIBUTING link
- `vendor-update.yml`: setup-python + pinned pyyaml, removed `|| true` so regen failures fail the job instead of shipping stale docs
- Docs: CONTRIBUTING.md + misc/README.md cover the gate and the local pyyaml prerequisite
- Regen fallout (intentional): 4 devops-agent wrapper pages now show their **full** descriptions (old awk truncated at line 1 — live bug on the site today); workflow-skeleton wrapper description is empty by design (its `---` block is template body, not frontmatter)

## Verification

Four adversarial review rounds + empirical incident replay:
- All 3 historical incidents (`>-` block scalar, escaped-quote 1037/1006 divergence, escaped-quote corruption) replayed end-to-end — now caught or rendered correctly on **all three surfaces**
- 27/27 skills validate, zero-diff idempotent regen, Docusaurus production build passes
- Old-vs-new parser differential-tested over every real input file: only intentional diffs
- Workflow failure paths traced (validator-fail vs regen-fail summaries are mutually exclusive); fork-PR safe (`pull_request`, `contents: read`, no secrets)

## Notes for reviewers
- `ecs-build`'s description parses to 1017 chars — 7 under the cap; the next edit to it may need trimming
- Full regen wall clock is ~76s (~64s update-pages.sh) due to per-file python spawns — acceptable in CI, noted for awareness

### Commit 3 (`95b16df`) — fail-fast + parser convergence
- Invalid YAML in a present frontmatter block now aborts every generator with the file named (exit 2, `inherit_errexit`) — no more silent empty-description wrappers or stray `.tmp` on broken input
- `run_triggering.py` (evals) now uses the canonical YAML parse (regex fallback kept for no-pyyaml envs); old parser leaked surrounding quotes into 6 descriptions
- steering-workflow-creator `quick_validate.py`: new W006 warning when frontmatter isn't at line 1 (the docs pipeline would silently skip such a file)
- Remaining known divergence: `skills/skill-creator` (vendored, upstream-owned) — upstream-sync material only

### Commits 4–6 — post-review hardening (`5182f32`, `7091eaf`, `c0a14e7`)
- `5182f32`: W006 also catches an indented opening `---`; regex-fallback quote-leak divergence documented in the `run_triggering.py` docstring
- `7091eaf`: dedupe eks-cost-intelligence Docusaurus route/redirect (kills the duplicate-route build warning); SIGPIPE guards on dry-run previews
- `c0a14e7`: README slug hook anchored to the docs root via `path.relative` — old regex matched the **first** `/docs/` in the absolute checkout path, producing wrong slugs when the checkout path contains a `docs` segment (hostile-path build-tested)

### Commit 7 — merge-readiness panel fixes (`bb4fc70`)
6-lens adversarial panel findings, folded in rather than deferred:
- **Unclosed frontmatter fails fast** in all 6 parsers (was: silently dropped from generated output with green CI — a regression the strict parsers introduced vs the old lenient ones); unreadable files that open frontmatter also error
- **Validator rejects duplicate frontmatter keys** via a strict SafeLoader subclass (`yaml.safe_load` silently last-wins; spec-conformant js-yaml ≥4 consumers reject — exactly the malformed-input class this gate exists for)
- `vendor-update.yml`: capture-first `ls-remote` + empty-SHA guard (transient failure could overwrite `.vendor-sha` with an empty string, corrupting change detection); regen scripts invoked unconditionally via `bash` (the `[ -x ]` guard skip-greened on a lost exec bit)
- dry-run previews capture-first instead of `| head || true` (the `|| true` masked a broken devops-agent/examples skill's exit 2 in preview mode; CI `--check` was unaffected)

Panel residuals accepted (documented, non-blocking): local regen on broken input can leave a stray `.tmp` from an earlier pipeline stage (CI unaffected); StrictLoader also rejects YAML merge keys (`<<:`) that generators accept — validator-stricter, no repo file uses them; validator globs one level (`skills/*/SKILL.md`) — flat layout only, matches current repo; fork-PR fix-link points at base repo (404 for fork branches, guidance-only).
