### PR TITLE
security: load YAML frontmatter safely and harden CI

### DIFF
--- a/.github/workflows/devops-agent-validate.yml
+++ b/.github/workflows/devops-agent-validate.yml
@@ -16,7 +16,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Validate devops-agent skill structure
         run: |

--- a/.github/workflows/devops-agent-validate.yml
+++ b/.github/workflows/devops-agent-validate.yml
@@ -16,7 +16,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Validate devops-agent skill structure
         run: |

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -50,6 +50,10 @@ jobs:
           - the frontmatter is valid YAML (a mapping between `---` delimiters — watch unquoted `:` and stray quotes)
           - `name` and `description` keys are present
           - `description` is at most 1024 characters
+          - only expected top-level keys are used: `name`, `description`, `license`, `metadata`, `allowed-tools`
+          - no YAML anchors or aliases (`&`/`*`)
+          - the frontmatter block is under 64KB
+          - nesting depth is at most 8
           - for `skills/*/SKILL.md` only: `description` matches the generated `skills.json` manifest (`devops-agent/` is exempt; a missing manifest entry is only a warning) — if you changed a description, regenerate:
 
           ```bash

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -27,8 +27,8 @@ jobs:
     name: docs auto-gen blocks are in sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.x'
       - name: Validate SKILL.md frontmatter

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -27,7 +27,7 @@ jobs:
     name: docs auto-gen blocks are in sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.x'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,8 +16,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -26,10 +24,12 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: npm
@@ -41,16 +41,19 @@ jobs:
       - run: npm run build
         working-directory: misc/website
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: misc/website/build
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: misc/installer
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.release.tag_name }}
 

--- a/.github/workflows/vendor-update.yml
+++ b/.github/workflows/vendor-update.yml
@@ -58,7 +58,7 @@ jobs:
           inputs.skill != matrix.skill.name
         run: echo "Skipping ${{ matrix.skill.name }} (not selected)" && exit 0
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         if: >-
           github.event_name != 'workflow_dispatch' ||
           inputs.skill == 'all' ||

--- a/.github/workflows/vendor-update.yml
+++ b/.github/workflows/vendor-update.yml
@@ -25,7 +25,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  issues: write
 
 jobs:
   check-updates:
@@ -59,7 +58,7 @@ jobs:
           inputs.skill != matrix.skill.name
         run: echo "Skipping ${{ matrix.skill.name }} (not selected)" && exit 0
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         if: >-
           github.event_name != 'workflow_dispatch' ||
           inputs.skill == 'all' ||
@@ -116,7 +115,7 @@ jobs:
         run: |
           echo "${{ steps.check.outputs.upstream_sha }}" > "${{ matrix.skill.path }}/.vendor-sha"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         if: steps.sync.outcome == 'success'
         with:
           python-version: '3.x'
@@ -143,7 +142,7 @@ jobs:
 
       - name: Create pull request
         if: steps.diff.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           branch: chore/vendor-update-${{ matrix.skill.name }}
           delete-branch: true
@@ -176,7 +175,7 @@ jobs:
 
       - name: Create PR on sync failure
         if: steps.sync.outcome == 'failure'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           branch: chore/vendor-update-${{ matrix.skill.name }}
           delete-branch: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -359,7 +359,16 @@ The generator scripts (including `./misc/update-pages.sh`) parse frontmatter wit
 
 **CI enforcement.** The `docs-sync` job in `.github/workflows/docs-sync.yml` runs `./misc/update-all-references.sh --check` and `./misc/update-pages.sh --check` on every PR. If the rendered blocks or Docusaurus wrappers diverge from frontmatter, the job fails and prints the exact diff. The fix is always the same: run both commands locally, commit the result.
 
-CI also strict-parses `SKILL.md` frontmatter via `misc/validate-frontmatter.py` before regenerating: the frontmatter must be a valid YAML mapping, `name` and `description` are required, `description` is capped at 1024 characters, and for `skills/` each description must match the generated `skills.json` manifest (`devops-agent/` is exempt from the manifest check; a missing manifest entry is only a warning). If validation fails, fix the frontmatter YAML and rerun the regeneration commands above.
+CI also strict-parses `SKILL.md` frontmatter via `misc/validate-frontmatter.py` before regenerating. The frontmatter must satisfy all of these rules:
+
+- it is a valid YAML mapping between `---` delimiters
+- `name` and `description` are present, and `description` is at most 1024 characters
+- only these top-level keys are allowed: `name`, `description`, `license`, `metadata`, `allowed-tools`
+- no YAML anchors or aliases (`&name` / `*name`)
+- the frontmatter block is under 64KB
+- nesting depth is at most 8
+
+For `skills/` each description must also match the generated `skills.json` manifest (`devops-agent/` is exempt from the manifest check; a missing manifest entry is only a warning). If validation fails, fix the frontmatter YAML and rerun the regeneration commands above.
 
 ## Creating a New Example
 

--- a/misc/evals/scripts/artifact_validation.py
+++ b/misc/evals/scripts/artifact_validation.py
@@ -283,6 +283,15 @@ def _eval_yaml_valid(root: Path, assertion: dict) -> ArtifactAssertionResult:
     for f in all_files:
         try:
             content = f.read_text(errors="replace")
+            if len(content.encode("utf-8")) > 1024 * 1024:
+                rel = f.relative_to(root)
+                return ArtifactAssertionResult(
+                    assertion=assertion,
+                    status="failed",
+                    evidence=f"Artifact too large to parse safely: {rel}",
+                    failure_class="artifact_invalid",
+                    file_matched=str(rel),
+                )
             list(yaml.safe_load_all(content))
         except yaml.YAMLError as e:
             rel = f.relative_to(root)

--- a/misc/evals/scripts/check_hygiene.py
+++ b/misc/evals/scripts/check_hygiene.py
@@ -201,8 +201,15 @@ def main() -> int:
         else:
             try:
                 import yaml
-                skilleval_raw = yaml.safe_load(skilleval_path.read_text()) or {}
-                if not isinstance(skilleval_raw, dict):
+                skilleval_text = skilleval_path.read_text()
+                if len(skilleval_text.encode("utf-8")) > 256 * 1024:
+                    warnings.append(".skilleval.yaml exceeds maximum allowed size")
+                    skilleval_raw = None
+                else:
+                    skilleval_raw = yaml.safe_load(skilleval_text) or {}
+                if skilleval_raw is None:
+                    pass  # oversize; already reported
+                elif not isinstance(skilleval_raw, dict):
                     warnings.append(".skilleval.yaml must be a YAML mapping")
                 else:
                     if "skill_name" not in skilleval_raw:

--- a/misc/evals/scripts/run_triggering.py
+++ b/misc/evals/scripts/run_triggering.py
@@ -373,6 +373,8 @@ def read_skill_meta(skill_dir: Path) -> tuple[str, str]:
     if not m:
         raise RuntimeError(f"SKILL.md has no YAML frontmatter: {skill_dir}")
     fm = m.group(1)
+    if len(fm.encode("utf-8")) > 256 * 1024:
+        raise RuntimeError(f"SKILL.md frontmatter exceeds maximum allowed size: {skill_dir}")
 
     if yaml is not None:
         try:

--- a/misc/evals/scripts/skilleval_config.py
+++ b/misc/evals/scripts/skilleval_config.py
@@ -12,6 +12,9 @@ except ImportError:
 
 EVALS_ROOT = Path(__file__).resolve().parent.parent
 
+# Upfront size guard before YAML parsing (config files are small).
+_MAX_CONFIG_BYTES = 256 * 1024
+
 DEFAULT_WEIGHTS = {
     "triggering": 0.20,
     "process": 0.15,
@@ -128,7 +131,10 @@ def load_config(skill: str, cli_overrides: Optional[dict[str, Any]] = None) -> S
 
     merged: dict[str, Any] = {}
     for config_path in configs:
-        raw = yaml.safe_load(config_path.read_text()) or {}
+        text = config_path.read_text()
+        if len(text.encode("utf-8")) > _MAX_CONFIG_BYTES:
+            raise RuntimeError(f"config file exceeds maximum allowed size: {config_path}")
+        raw = yaml.safe_load(text) or {}
         merged = _merge_configs(merged, raw)
 
     if cli_overrides:

--- a/misc/safe_frontmatter.py
+++ b/misc/safe_frontmatter.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Load SKILL.md YAML frontmatter safely.
+
+This module centralizes how untrusted frontmatter is parsed so every caller
+gets the same conservative behavior:
+
+  * frontmatter is bounded in size before it is parsed,
+  * YAML anchors and aliases are rejected (they let a small document expand
+    into a very large object graph),
+  * duplicate keys are rejected (stricter YAML consumers reject them too),
+  * only an expected set of top-level keys is allowed, and
+  * deeply nested structures are rejected.
+
+Callers use the single public entry point ``load_frontmatter``. Any problem
+raises ``FrontmatterError`` with a short, generic message; the offending input
+is never echoed back.
+"""
+
+import collections.abc
+
+import yaml
+
+# Maximum size, in bytes, of a frontmatter block we are willing to parse.
+MAX_FRONTMATTER_BYTES = 64 * 1024
+
+# Maximum number of parse events before we treat the document as pathological.
+MAX_EVENTS = 10_000
+
+# The only top-level keys we expect in SKILL.md frontmatter.
+ALLOWED_TOP_LEVEL_KEYS = frozenset(
+    {"name", "description", "license", "metadata", "allowed-tools"}
+)
+
+# Maximum allowed nesting depth of the loaded structure.
+MAX_NESTING_DEPTH = 8
+
+
+class FrontmatterError(Exception):
+    """Raised when frontmatter fails a safety or structural check.
+
+    The message is intentionally generic and never includes the raw input.
+    """
+
+
+def _check_size(raw):
+    """Reject frontmatter larger than the byte cap."""
+    if len(raw.encode("utf-8")) > MAX_FRONTMATTER_BYTES:
+        raise FrontmatterError(
+            f"frontmatter exceeds maximum size of {MAX_FRONTMATTER_BYTES} bytes"
+        )
+
+
+def _check_no_anchors(raw):
+    """Reject anchors/aliases, cap parse events, and gate nesting depth.
+
+    Anchors (``&name``) and aliases (``*name``) allow a small document to
+    reference and expand shared structure, which can blow up memory. We walk
+    the event stream and reject any event that declares an anchor, and bound
+    the total event count as a cheap guard against structural explosion.
+
+    The event stream is also the early gate for nesting depth: we track the
+    current collection depth (incrementing on each mapping/sequence start and
+    decrementing on each end) and reject the document before ``compose`` or
+    ``safe_load`` ever recurse. This is what keeps a deeply-nested flow
+    document (e.g. hundreds of nested ``[``) from crashing the recursive
+    composer/loader with a ``RecursionError``. ``yaml.parse`` itself does not
+    recurse in Python, so it is safe to iterate here first.
+    """
+    try:
+        events = 0
+        depth = 0
+        for event in yaml.parse(raw, Loader=yaml.SafeLoader):
+            events += 1
+            if events > MAX_EVENTS:
+                raise FrontmatterError("frontmatter has too many parse events")
+            if getattr(event, "anchor", None) is not None:
+                raise FrontmatterError("frontmatter uses YAML anchors or aliases")
+            if isinstance(event, (yaml.MappingStartEvent, yaml.SequenceStartEvent)):
+                depth += 1
+                if depth > MAX_NESTING_DEPTH:
+                    raise FrontmatterError(
+                        "frontmatter nesting exceeds maximum depth"
+                    )
+            elif isinstance(event, (yaml.MappingEndEvent, yaml.SequenceEndEvent)):
+                depth -= 1
+    except yaml.YAMLError as e:
+        raise FrontmatterError(f"frontmatter is not valid YAML: {e}") from e
+
+
+def _check_no_duplicate_keys(raw):
+    """Reject any mapping that declares the same key twice.
+
+    ``yaml.safe_load`` silently keeps the last value for a duplicated key, but
+    stricter consumers reject the document, so we do too. We inspect the
+    composed node tree rather than the loaded object because duplicates are
+    already collapsed by the time loading finishes.
+    """
+    try:
+        node = yaml.compose(raw, Loader=yaml.SafeLoader)
+    except (yaml.YAMLError, RecursionError) as e:
+        raise FrontmatterError("frontmatter is not valid YAML") from e
+    if node is None:
+        return
+    loader = yaml.SafeLoader("")
+    try:
+        _walk_for_duplicates(node, loader)
+    finally:
+        loader.dispose()
+
+
+def _walk_for_duplicates(node, loader):
+    """Recursively check every MappingNode for duplicate keys.
+
+    Constructing a key can fail if the document uses a complex/unhashable key
+    (e.g. ``? [a, b]``) or a merge key (``<<:``). Both are rejected with a
+    generic ``FrontmatterError`` so that no raw input is echoed back and so
+    the caller never sees an uncaught ``yaml`` exception.
+    """
+    if isinstance(node, yaml.MappingNode):
+        seen = set()
+        for key_node, value_node in node.value:
+            try:
+                key = loader.construct_object(key_node, deep=True)
+            except (yaml.YAMLError, RecursionError) as e:
+                raise FrontmatterError("frontmatter is not valid YAML") from e
+            if not isinstance(key, collections.abc.Hashable):
+                raise FrontmatterError("frontmatter has an unsupported complex key")
+            if key in seen:
+                raise FrontmatterError("frontmatter declares a duplicate key")
+            seen.add(key)
+            _walk_for_duplicates(value_node, loader)
+    elif isinstance(node, yaml.SequenceNode):
+        for child in node.value:
+            _walk_for_duplicates(child, loader)
+
+
+def _depth(obj):
+    """Return the maximum nesting depth of a loaded object."""
+    if isinstance(obj, dict):
+        if not obj:
+            return 1
+        return 1 + max(_depth(v) for v in obj.values())
+    if isinstance(obj, (list, tuple)):
+        if not obj:
+            return 1
+        return 1 + max(_depth(v) for v in obj)
+    return 0
+
+
+def load_frontmatter(raw, *, source="<frontmatter>"):
+    """Parse a frontmatter string and return it as a dict.
+
+    Runs a fixed sequence of safety and structural checks and raises
+    ``FrontmatterError`` on the first violation. ``source`` is accepted for
+    caller-side context but is not embedded in error messages.
+    """
+    _check_size(raw)
+    _check_no_anchors(raw)
+    _check_no_duplicate_keys(raw)
+
+    try:
+        data = yaml.safe_load(raw)
+    except (yaml.YAMLError, RecursionError) as e:
+        raise FrontmatterError("frontmatter is not valid YAML") from e
+
+    if not isinstance(data, dict):
+        raise FrontmatterError("frontmatter is not a mapping")
+
+    unexpected = set(data) - ALLOWED_TOP_LEVEL_KEYS
+    if unexpected:
+        raise FrontmatterError(
+            "frontmatter has unexpected top-level key(s); allowed keys are "
+            f"{sorted(ALLOWED_TOP_LEVEL_KEYS)}"
+        )
+
+    if _depth(data) > MAX_NESTING_DEPTH:
+        raise FrontmatterError(
+            f"frontmatter nesting exceeds maximum depth of {MAX_NESTING_DEPTH}"
+        )
+
+    return data

--- a/misc/tests/test_safe_frontmatter.py
+++ b/misc/tests/test_safe_frontmatter.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Tests for the safe frontmatter loader.
+
+Run directly with:
+
+    python3 misc/tests/test_safe_frontmatter.py
+"""
+
+import os
+import sys
+import unittest
+from glob import glob
+
+# Make the sibling misc/ directory importable regardless of CWD.
+MISC_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+REPO_ROOT = os.path.dirname(MISC_DIR)
+sys.path.insert(0, MISC_DIR)
+
+from safe_frontmatter import (  # noqa: E402
+    ALLOWED_TOP_LEVEL_KEYS,
+    MAX_FRONTMATTER_BYTES,
+    MAX_NESTING_DEPTH,
+    FrontmatterError,
+    load_frontmatter,
+)
+
+
+def _extract_frontmatter(path):
+    """Return the frontmatter string between the first two --- delimiters."""
+    with open(path, encoding="utf-8") as f:
+        lines = f.readlines()
+    if not lines or lines[0].rstrip() != "---":
+        return None
+    fm_lines = []
+    for line in lines[1:]:
+        if line.rstrip() == "---":
+            return "".join(fm_lines)
+        fm_lines.append(line)
+    return None
+
+
+class PositiveCases(unittest.TestCase):
+    def test_all_allowed_keys(self):
+        raw = (
+            "name: my-skill\n"
+            "description: A helpful skill.\n"
+            "license: Apache-2.0\n"
+            "allowed-tools: Read, Bash\n"
+            "metadata:\n"
+            "  category: general\n"
+            "  version: 1\n"
+        )
+        data = load_frontmatter(raw)
+        self.assertEqual(data["name"], "my-skill")
+        self.assertEqual(data["description"], "A helpful skill.")
+        self.assertEqual(data["license"], "Apache-2.0")
+        self.assertEqual(data["allowed-tools"], "Read, Bash")
+        self.assertEqual(data["metadata"]["category"], "general")
+
+    def test_nested_metadata_mapping(self):
+        raw = "name: s\ndescription: d\nmetadata:\n  a:\n    b: c\n"
+        data = load_frontmatter(raw)
+        self.assertEqual(data["metadata"]["a"]["b"], "c")
+
+    def test_minimal_name_description(self):
+        raw = "name: s\ndescription: d\n"
+        data = load_frontmatter(raw)
+        self.assertEqual(data, {"name": "s", "description": "d"})
+
+    def test_constants_match_spec(self):
+        self.assertEqual(MAX_FRONTMATTER_BYTES, 64 * 1024)
+        self.assertEqual(MAX_NESTING_DEPTH, 8)
+        self.assertEqual(
+            ALLOWED_TOP_LEVEL_KEYS,
+            frozenset({"name", "description", "license", "metadata", "allowed-tools"}),
+        )
+
+
+class NegativeCases(unittest.TestCase):
+    def test_oversized_input(self):
+        raw = "name: s\ndescription: " + ("x" * (MAX_FRONTMATTER_BYTES + 1)) + "\n"
+        with self.assertRaises(FrontmatterError):
+            load_frontmatter(raw)
+
+    def test_anchor_alias(self):
+        raw = "name: &a s\ndescription: *a\n"
+        with self.assertRaises(FrontmatterError):
+            load_frontmatter(raw)
+
+    def test_billion_laughs(self):
+        raw = (
+            "name: &a bomb\n"
+            "description: &b [*a, *a, *a, *a, *a, *a, *a, *a, *a]\n"
+            "metadata: [*b, *b, *b, *b, *b, *b, *b, *b, *b]\n"
+        )
+        with self.assertRaises(FrontmatterError):
+            load_frontmatter(raw)
+
+    def test_duplicate_key(self):
+        raw = "name: one\nname: two\ndescription: d\n"
+        with self.assertRaises(FrontmatterError):
+            load_frontmatter(raw)
+
+    def test_non_mapping_list(self):
+        raw = "- a\n- b\n"
+        with self.assertRaises(FrontmatterError):
+            load_frontmatter(raw)
+
+    def test_non_mapping_scalar(self):
+        raw = "just a string\n"
+        with self.assertRaises(FrontmatterError):
+            load_frontmatter(raw)
+
+    def test_unexpected_top_level_key(self):
+        raw = "name: s\ndescription: d\nevil: x\n"
+        with self.assertRaises(FrontmatterError):
+            load_frontmatter(raw)
+
+    def test_excessive_nesting(self):
+        # Build a mapping nested deeper than MAX_NESTING_DEPTH under metadata.
+        lines = ["name: s", "description: d", "metadata:"]
+        indent = "  "
+        for i in range(MAX_NESTING_DEPTH + 3):
+            lines.append(f"{indent * (i + 1)}k{i}:")
+        lines.append(f"{indent * (MAX_NESTING_DEPTH + 4)}leaf: v")
+        raw = "\n".join(lines) + "\n"
+        with self.assertRaises(FrontmatterError):
+            load_frontmatter(raw)
+
+    def test_deep_flow_nesting_bomb(self):
+        # A deeply-nested flow sequence must be rejected cleanly, not crash
+        # the recursive composer/loader with a RecursionError.
+        raw = "description: " + ("[" * 600) + ("]" * 600) + "\n"
+        with self.assertRaises(FrontmatterError):
+            load_frontmatter(raw)
+
+    def test_python_object_tag(self):
+        # SafeLoader refuses the tag; it must surface as FrontmatterError.
+        raw = "description: !!python/object/apply:os.system ['echo hi']\n"
+        with self.assertRaises(FrontmatterError):
+            load_frontmatter(raw)
+
+    def test_complex_unhashable_key(self):
+        raw = "? [a, b]\n: 1\n"
+        with self.assertRaises(FrontmatterError):
+            load_frontmatter(raw)
+
+    def test_merge_key(self):
+        raw = "name: s\ndescription: d\nmetadata:\n  <<: {a: 1}\n"
+        with self.assertRaises(FrontmatterError):
+            load_frontmatter(raw)
+
+
+class RealSkillsRegression(unittest.TestCase):
+    def test_all_repo_skills_parse(self):
+        patterns = [
+            os.path.join(REPO_ROOT, "skills", "*", "SKILL.md"),
+            os.path.join(REPO_ROOT, "devops-agent", "*", "SKILL.md"),
+        ]
+        paths = []
+        for pattern in patterns:
+            paths.extend(sorted(glob(pattern)))
+        self.assertTrue(paths, "expected to find at least one SKILL.md")
+        for path in paths:
+            raw = _extract_frontmatter(path)
+            self.assertIsNotNone(raw, f"no frontmatter block in {path}")
+            try:
+                load_frontmatter(raw, source=path)
+            except FrontmatterError as e:
+                self.fail(f"{path} failed load_frontmatter: {e}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/misc/update-devops-agent-references.sh
+++ b/misc/update-devops-agent-references.sh
@@ -40,7 +40,7 @@ parse_frontmatter() {
   local file="$1"
   local key="$2"
   python3 - "$file" "$key" <<'PY'
-import os, sys, yaml
+import sys, yaml
 path, key = sys.argv[1], sys.argv[2]
 try:
     with open(path, encoding="utf-8") as f:

--- a/misc/update-devops-agent-references.sh
+++ b/misc/update-devops-agent-references.sh
@@ -40,7 +40,7 @@ parse_frontmatter() {
   local file="$1"
   local key="$2"
   python3 - "$file" "$key" <<'PY'
-import sys, yaml
+import os, sys, yaml
 path, key = sys.argv[1], sys.argv[2]
 try:
     with open(path, encoding="utf-8") as f:
@@ -57,6 +57,9 @@ for line in lines[1:]:
     fm.append(line)
 else:
     print(f"ERROR: {path}: unclosed frontmatter block (missing closing '---')", file=sys.stderr)
+    sys.exit(2)
+if len("".join(fm).encode("utf-8")) > 64 * 1024:
+    print(f"ERROR: {path}: frontmatter block too large to parse", file=sys.stderr)
     sys.exit(2)
 try:
     data = yaml.safe_load("".join(fm))

--- a/misc/update-examples-references.sh
+++ b/misc/update-examples-references.sh
@@ -40,7 +40,7 @@ parse_frontmatter() {
   local file="$1"
   local key="$2"
   python3 - "$file" "$key" <<'PY'
-import sys, yaml
+import os, sys, yaml
 path, key = sys.argv[1], sys.argv[2]
 try:
     with open(path, encoding="utf-8") as f:
@@ -57,6 +57,9 @@ for line in lines[1:]:
     fm.append(line)
 else:
     print(f"ERROR: {path}: unclosed frontmatter block (missing closing '---')", file=sys.stderr)
+    sys.exit(2)
+if len("".join(fm).encode("utf-8")) > 64 * 1024:
+    print(f"ERROR: {path}: frontmatter block too large to parse", file=sys.stderr)
     sys.exit(2)
 try:
     data = yaml.safe_load("".join(fm))
@@ -90,7 +93,7 @@ find_example_readmes() {
     if [[ -n "$name" ]]; then
       echo "$readme"
     fi
-  done < <(find "$EXAMPLES_DIR" -name 'README.md' -print0 | sort -z)
+  done < <(find "$EXAMPLES_DIR" -type d -name '.terraform' -prune -o -type d -name '.*' -prune -o -name 'README.md' -print0 | sort -z)
 }
 
 # --- Build the main README table ---

--- a/misc/update-examples-references.sh
+++ b/misc/update-examples-references.sh
@@ -40,7 +40,7 @@ parse_frontmatter() {
   local file="$1"
   local key="$2"
   python3 - "$file" "$key" <<'PY'
-import os, sys, yaml
+import sys, yaml
 path, key = sys.argv[1], sys.argv[2]
 try:
     with open(path, encoding="utf-8") as f:

--- a/misc/update-pages.sh
+++ b/misc/update-pages.sh
@@ -310,12 +310,15 @@ vendored_skill_admonition() {
   local notices="$REPO_ROOT/THIRD_PARTY_NOTICES.md"
   local author license_id source_url
   if [[ -f "$notices" ]]; then
-    source_url="$(awk -v name="$skill_name" '
-      $0 ~ "^## " name { found=1; next }
+    # Pass skill_name via ENVIRON (not -v, which escape-processes the value)
+    # and match with index()==1 (literal prefix) rather than a regex, so a
+    # name containing regex metacharacters cannot match the wrong section.
+    source_url="$(SKILL_NAME="$skill_name" awk '
+      index($0, "## " ENVIRON["SKILL_NAME"]) == 1 { found=1; next }
       found && /Source:/ { sub(/.*Source:[* ]*/, ""); sub(/[* ]*$/, ""); print; exit }
     ' "$notices")"
-    author="$(awk -v name="$skill_name" '
-      $0 ~ "^## " name { found=1; next }
+    author="$(SKILL_NAME="$skill_name" awk '
+      index($0, "## " ENVIRON["SKILL_NAME"]) == 1 { found=1; next }
       found && /Copyright:/ { sub(/.*Copyright:[* ]*/, ""); sub(/[* ]*$/, ""); print; exit }
     ' "$notices")"
   fi

--- a/misc/update-pages.sh
+++ b/misc/update-pages.sh
@@ -90,7 +90,7 @@ parse_frontmatter() {
   local file="$1"
   local key="$2"
   python3 - "$file" "$key" <<'PY'
-import sys, yaml
+import os, sys, yaml
 path, key = sys.argv[1], sys.argv[2]
 try:
     with open(path, encoding="utf-8") as f:
@@ -107,6 +107,9 @@ for line in lines[1:]:
     fm.append(line)
 else:
     print(f"ERROR: {path}: unclosed frontmatter block (missing closing '---')", file=sys.stderr)
+    sys.exit(2)
+if len("".join(fm).encode("utf-8")) > 64 * 1024:
+    print(f"ERROR: {path}: frontmatter block too large to parse", file=sys.stderr)
     sys.exit(2)
 try:
     data = yaml.safe_load("".join(fm))
@@ -549,6 +552,9 @@ def parse_fm(path):
     else:
         print(f"ERROR: {path}: unclosed frontmatter block (missing closing '---')", file=sys.stderr)
         sys.exit(2)
+    if len("".join(fm_lines).encode("utf-8")) > 64 * 1024:
+        print(f"ERROR: {path}: frontmatter block too large to parse", file=sys.stderr)
+        sys.exit(2)
     data = yaml.safe_load("".join(fm_lines))
     if not isinstance(data, dict):
         return {}
@@ -679,7 +685,7 @@ EOF
     echo ""
     echo "$description"
     echo ""
-  done < <(find "$EXAMPLES_DIR" -name 'README.md' -print0 | sort -z)
+  done < <(find "$EXAMPLES_DIR" -type d -name '.terraform' -prune -o -type d -name '.*' -prune -o -name 'README.md' -print0 | sort -z)
 }
 
 # --- Build examples.json manifest to stdout --------------------------------
@@ -704,6 +710,9 @@ def parse_fm(path):
     else:
         print(f"ERROR: {path}: unclosed frontmatter block (missing closing '---')", file=sys.stderr)
         sys.exit(2)
+    if len("".join(fm_lines).encode("utf-8")) > 64 * 1024:
+        print(f"ERROR: {path}: frontmatter block too large to parse", file=sys.stderr)
+        sys.exit(2)
     data = yaml.safe_load("".join(fm_lines))
     if not isinstance(data, dict):
         return {}
@@ -712,6 +721,9 @@ def parse_fm(path):
 
 out = []
 for root, dirs, files in sorted(os.walk(examples_dir)):
+    # Prune gitignored/hidden trees (e.g. examples/**/.terraform) so a large
+    # no-frontmatter README under them never aborts the generator.
+    dirs[:] = [d for d in dirs if d != ".terraform" and not d.startswith(".")]
     dirs.sort()
     if "README.md" not in files:
         continue

--- a/misc/update-skills-references.sh
+++ b/misc/update-skills-references.sh
@@ -40,7 +40,7 @@ parse_frontmatter() {
   local file="$1"
   local key="$2"
   python3 - "$file" "$key" <<'PY'
-import os, sys, yaml
+import sys, yaml
 path, key = sys.argv[1], sys.argv[2]
 try:
     with open(path, encoding="utf-8") as f:

--- a/misc/update-skills-references.sh
+++ b/misc/update-skills-references.sh
@@ -40,7 +40,7 @@ parse_frontmatter() {
   local file="$1"
   local key="$2"
   python3 - "$file" "$key" <<'PY'
-import sys, yaml
+import os, sys, yaml
 path, key = sys.argv[1], sys.argv[2]
 try:
     with open(path, encoding="utf-8") as f:
@@ -57,6 +57,9 @@ for line in lines[1:]:
     fm.append(line)
 else:
     print(f"ERROR: {path}: unclosed frontmatter block (missing closing '---')", file=sys.stderr)
+    sys.exit(2)
+if len("".join(fm).encode("utf-8")) > 64 * 1024:
+    print(f"ERROR: {path}: frontmatter block too large to parse", file=sys.stderr)
     sys.exit(2)
 try:
     data = yaml.safe_load("".join(fm))

--- a/misc/update-steering-references.sh
+++ b/misc/update-steering-references.sh
@@ -39,7 +39,7 @@ parse_frontmatter() {
   local file="$1"
   local key="$2"
   python3 - "$file" "$key" <<'PY'
-import sys, yaml
+import os, sys, yaml
 path, key = sys.argv[1], sys.argv[2]
 try:
     with open(path, encoding="utf-8") as f:
@@ -56,6 +56,9 @@ for line in lines[1:]:
     fm.append(line)
 else:
     print(f"ERROR: {path}: unclosed frontmatter block (missing closing '---')", file=sys.stderr)
+    sys.exit(2)
+if len("".join(fm).encode("utf-8")) > 64 * 1024:
+    print(f"ERROR: {path}: frontmatter block too large to parse", file=sys.stderr)
     sys.exit(2)
 try:
     data = yaml.safe_load("".join(fm))

--- a/misc/update-steering-references.sh
+++ b/misc/update-steering-references.sh
@@ -39,7 +39,7 @@ parse_frontmatter() {
   local file="$1"
   local key="$2"
   python3 - "$file" "$key" <<'PY'
-import os, sys, yaml
+import sys, yaml
 path, key = sys.argv[1], sys.argv[2]
 try:
     with open(path, encoding="utf-8") as f:

--- a/misc/validate-frontmatter.py
+++ b/misc/validate-frontmatter.py
@@ -8,26 +8,9 @@ from glob import glob
 
 import yaml
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-class DuplicateKeyError(yaml.YAMLError):
-    """Raised when a YAML mapping declares the same key twice."""
-
-
-class StrictLoader(yaml.SafeLoader):
-    """SafeLoader that rejects duplicate mapping keys instead of last-wins.
-
-    yaml.safe_load silently keeps the last value for a duplicated key, but
-    stricter spec-conformant consumers (e.g. js-yaml >= 4) reject the file.
-    """
-
-    def construct_mapping(self, node, deep=False):
-        seen = set()
-        for key_node, _ in node.value:
-            key = self.construct_object(key_node, deep=deep)
-            if key in seen:
-                raise DuplicateKeyError(f"duplicate frontmatter key: {key}")
-            seen.add(key)
-        return super().construct_mapping(node, deep=deep)
+from safe_frontmatter import FrontmatterError, load_frontmatter
 
 
 def extract_frontmatter(path):
@@ -91,11 +74,7 @@ def main():
                     errors.append(f"{rel}: no YAML frontmatter block found (missing closing '---')")
                     continue
 
-                data = yaml.load(raw, Loader=StrictLoader)
-
-                if not isinstance(data, dict):
-                    errors.append(f"{rel}: frontmatter is not a mapping")
-                    continue
+                data = load_frontmatter(raw, source=rel)
 
                 desc = data.get("description")
                 if desc is None:
@@ -129,7 +108,7 @@ def main():
                 elif not is_devops_agent and name not in manifest_by_name:
                     warnings.append(f"{rel}: no manifest entry for '{name}' (not in skills.json)")
 
-            except DuplicateKeyError as e:
+            except FrontmatterError as e:
                 errors.append(f"{rel}: {e}")
             except yaml.YAMLError as e:
                 errors.append(f"{rel}: YAML parse error: {e}")

--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -30,6 +30,10 @@ def validate_skill(skill_path):
 
     frontmatter_text = match.group(1)
 
+    # Upfront size guard before YAML parsing (frontmatter is small).
+    if len(frontmatter_text.encode("utf-8")) > 256 * 1024:
+        return False, "Frontmatter exceeds maximum allowed size"
+
     # Parse YAML frontmatter
     try:
         frontmatter = yaml.safe_load(frontmatter_text)


### PR DESCRIPTION
## Summary

Hardens how the repo loads and validates YAML frontmatter, and tightens the CI supply chain. Closes #140.

All `SKILL.md` frontmatter is now loaded through `yaml.safe_load` and validated **before** it is processed, and the CI workflows are pinned and scoped to least privilege.

## What changed

### Safe, validated frontmatter loading
- New shared helper `misc/safe_frontmatter.py` — the single entry point for parsing untrusted frontmatter. It loads with `yaml.safe_load` and, before returning, enforces:
  - a byte-size cap on the frontmatter block,
  - rejection of YAML anchors/aliases (prevents a small document expanding into a huge object graph),
  - rejection of duplicate keys and unsupported complex keys,
  - an allowlist of expected top-level keys (`name`, `description`, `license`, `metadata`, `allowed-tools`),
  - a maximum nesting depth.
  Any violation raises a single generic error that never echoes the input back.
- `misc/validate-frontmatter.py` now uses the helper (removes its custom loader class).
- The reference-generator scripts cap the frontmatter block they parse and skip generated/hidden directories so a large non-frontmatter file can't abort a run.
- `misc/evals/scripts/*` and the skill-creator validator bound input size before parsing.

### CI supply-chain and least privilege
- All GitHub Actions pinned to full commit SHAs (prevents a repointed tag from running unreviewed code).
- `docs.yml`: `pages`/`id-token` write scoped to the deploy job only; the build job that runs third-party JS is read-only.
- `vendor-update.yml`: removed an unused write permission.
- Generator `awk` calls pass values via the environment and match literally, so a name with regex metacharacters can't mis-match.

### Docs & tests
- `CONTRIBUTING.md` and the docs-sync failure message document the frontmatter rules a contributor could trip.
- New unit tests (`misc/tests/test_safe_frontmatter.py`) cover positive cases plus each rejection path, and a regression test parses every real `SKILL.md`.

## Verification
- `python3 misc/tests/test_safe_frontmatter.py` — all pass
- `python3 misc/validate-frontmatter.py` — 27 skills validated, 0 errors
- `./misc/update-all-references.sh --check` and `./misc/update-pages.sh --check` — in sync
- No `yaml.load` / `full_load` / `unsafe_load` remain in first-party code
