### PR TITLE
fix(ecs-recon): follow-ups from #137 review

### DIFF
--- a/misc/website/docs/skills/ecs/ecs-recon/index.md
+++ b/misc/website/docs/skills/ecs/ecs-recon/index.md
@@ -97,7 +97,7 @@ Load only the references needed for the user's request — this keeps context fo
 
 | Module | Intent / When to Use | Reference File |
 |--------|---------------------|----------------|
-| Overview | Always loaded first — account-wide inventory of clusters, services, tasks | [overview.md](references/overview) |
+| Overview | Always loaded first — account-wide inventory of clusters, services, and their tasks (standalone/scheduled tasks not discovered) | [overview.md](references/overview) |
 | Compute | Capacity providers, launch types, task counts, Fargate vs EC2 | [compute.md](references/compute) |
 | Task Definitions | Container images, CPU/memory, family and revision | [task-definitions.md](references/task-definitions) |
 | Deployment | Rolling update, CodeDeploy, circuit breaker, min/max percent | [deployment.md](references/deployment) |

--- a/misc/website/docs/skills/ecs/ecs-recon/references/iac.md
+++ b/misc/website/docs/skills/ecs/ecs-recon/references/iac.md
@@ -54,7 +54,7 @@ Run detections in this order — each step adds evidence and confidence:
 ```
 
 **Why this order matters:**
-- Tags are the strongest single-call signal for the tools that DO tag: CloudFormation always applies `aws:cloudformation:*` tags (CDK and Copilot deploy through CloudFormation, so their resources carry them too), some CDK constructs emit `aws-cdk:*` tags (e.g. `aws-cdk:auto-delete-objects`), and Copilot adds `copilot-*` tags. Note: CDK's construct path (`aws:cdk:path`) is recorded in the CloudFormation template `Metadata` attribute, NOT as a resource tag — the `aws:` tag prefix is reserved for AWS services, so nothing can apply it as a tag. CDK detection relies on `aws-cdk:*` tags, `aws:cloudformation:*` tags plus stack association, and CDK-pattern logical IDs/metadata resources
+- Tags are the strongest single-call signal for the tools that DO tag: CloudFormation applies stack-level `aws:cloudformation:*` tags (propagation varies by resource type, but ECS clusters, services, and task definitions receive them — and CDK and Copilot deploy through CloudFormation, so their resources carry them too), some CDK constructs emit `aws-cdk:*` tags (e.g. `aws-cdk:auto-delete-objects` — emitted on some resource types such as S3 buckets, rarely present on ECS resources), and Copilot adds `copilot-*` tags. Note: CDK's construct path (`aws:cdk:path`) is recorded in the CloudFormation template `Metadata` attribute, NOT as a resource tag — the `aws:` tag prefix is reserved for AWS services, so no user or third-party tool can apply it as a tag. CDK detection relies on `aws:cloudformation:*` tags plus stack association, CDK-pattern logical IDs/metadata resources, and `aws-cdk:*` tags when present
 - **Terraform is the critical exception: Terraform applies NO default tags.** Unless the team configured `default_tags` on the AWS provider or tagged resources explicitly, a fully Terraform-managed estate is invisible to tag-based detection. Expect `undetermined: true` to frequently mean "Terraform or console-managed" — do not read it as "no IaC"
 - Stack association confirms CloudFormation-family tools (CDK, Copilot, raw CloudFormation) with high confidence
 - Naming patterns provide supporting evidence when tags are stripped or absent, but carry lower confidence alone
@@ -106,16 +106,22 @@ aws ecs list-tags-for-resource \
 {
   "tags": [
     {
-      "key": "aws-cdk:auto-delete-objects",
-      "value": "true"
-    },
-    {
       "key": "aws:cloudformation:stack-name",
       "value": "CdkEcsStack"
+    },
+    {
+      "key": "aws:cloudformation:stack-id",
+      "value": "arn:aws:cloudformation:us-east-1:123456789012:stack/CdkEcsStack/def456"
+    },
+    {
+      "key": "aws:cloudformation:logical-id",
+      "value": "ApiServiceE2A5697D"
     }
   ]
 }
 ```
+
+CDK-managed ECS resources typically carry only `aws:cloudformation:*` tags — distinguish CDK from raw CloudFormation via stack association (CDK-pattern logical IDs like `ApiServiceE2A5697D`, or an `AWS::CDK::Metadata` resource in the stack).
 
 **Example output (Copilot-managed resource):**
 ```json
@@ -175,7 +181,9 @@ aws ecs list-tags-for-resource \
 
 **Tag patterns to match:**
 
-> Facts verified 2026-07-14 against https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-resource-tags.html — CloudFormation automatically applies the stack-level tags `aws:cloudformation:logical-id`, `aws:cloudformation:stack-id`, and `aws:cloudformation:stack-name` (the `aws:` prefix is reserved for AWS use). Terraform's AWS provider applies NO tags by default — `terraform:*` / `tf-*` keys only exist when a team configured them deliberately. CDK's `aws:cdk:path` construct path lands in the template `Metadata` attribute, not in resource tags — do not look for it as a tag.
+> Facts verified 2026-07-14 against https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-resource-tags.html — CloudFormation automatically applies the stack-level tags `aws:cloudformation:logical-id`, `aws:cloudformation:stack-id`, and `aws:cloudformation:stack-name` (the `aws:` prefix is reserved for AWS use). Terraform's AWS provider applies NO tags by default — `terraform:*` / `tf-*` keys only exist when a team configured them deliberately.
+
+> Facts verified 2026-07-17 against https://docs.aws.amazon.com/cdk/v2/guide/ref-cli-cmd.html — CDK's `--path-metadata` option (default true) records the construct path as `aws:cdk:path` in the CloudFormation template's resource Metadata attribute, not as a resource tag.
 
 | Tool | Tag Key Pattern | Confidence | Origin |
 |------|----------------|------------|--------|
@@ -409,9 +417,9 @@ iac:
       confidence: "high"
       evidence:
         - type: "resource_tags"
-          detail: "Tag 'aws-cdk:auto-delete-objects' found on service 'api-service'"
+          detail: "Tags 'aws:cloudformation:stack-name=CdkEcsStack' and 'aws:cloudformation:logical-id=ApiServiceE2A5697D' found on service 'api-service'"
         - type: "stack_association"
-          detail: "Service belongs to CloudFormation stack 'CdkEcsStack' with CDK-pattern logical IDs"
+          detail: "Service belongs to CloudFormation stack 'CdkEcsStack' with CDK-pattern logical IDs and an AWS::CDK::Metadata resource"
     - tool: "terraform"
       confidence: "high"
       evidence:
@@ -532,7 +540,7 @@ Only three evidence types are valid: `"resource_tags"`, `"stack_association"`, a
 Both CDK and Copilot deploy resources via CloudFormation, so their resources will have `aws:cloudformation:*` tags in addition to their own tool-specific tags. This creates overlapping evidence.
 
 **How to handle:**
-- If CDK-specific tags (`aws-cdk:*`, e.g. `aws-cdk:auto-delete-objects`) are present alongside `aws:cloudformation:*` tags, or the owning stack shows CDK-pattern logical IDs or CDK metadata resources → report `"cdk"` (not `"cloudformation"`)
+- If CDK-specific tags (`aws-cdk:*`, e.g. `aws-cdk:auto-delete-objects` — emitted on some resource types such as S3 buckets, rarely present on ECS resources) are present alongside `aws:cloudformation:*` tags, or the owning stack shows CDK-pattern logical IDs or CDK metadata resources → report `"cdk"` (not `"cloudformation"`)
 - If Copilot-specific tags (`copilot-application`, `copilot-environment`, `copilot-service`) are present alongside `aws:cloudformation:*` tags → report `"copilot"` (not `"cloudformation"`)
 - Report `"cloudformation"` only when `aws:cloudformation:*` tags are present WITHOUT CDK or Copilot-specific tags
 - Priority: Copilot tags > CDK tags > plain CloudFormation tags (most specific tool wins)
@@ -545,9 +553,9 @@ iac:
       confidence: "high"
       evidence:
         - type: "resource_tags"
-          detail: "Tag 'aws-cdk:auto-delete-objects' found on service alongside 'aws:cloudformation:*' tags"
+          detail: "'aws:cloudformation:*' tags found on service (stack 'CdkEcsStack')"
         - type: "stack_association"
-          detail: "Service belongs to stack 'CdkEcsStack' (CDK-pattern logical IDs)"
+          detail: "Service belongs to stack 'CdkEcsStack' (CDK-pattern logical IDs and an AWS::CDK::Metadata resource)"
   undetermined: false
   error: null
 ```

--- a/misc/website/docs/skills/ecs/ecs-recon/references/iac.md
+++ b/misc/website/docs/skills/ecs/ecs-recon/references/iac.md
@@ -54,7 +54,7 @@ Run detections in this order — each step adds evidence and confidence:
 ```
 
 **Why this order matters:**
-- Tags are the strongest single-call signal for the tools that DO tag: CloudFormation always applies `aws:cloudformation:*` tags, CDK adds `aws:cdk:path` (when metadata is enabled), and Copilot adds `copilot-*` tags
+- Tags are the strongest single-call signal for the tools that DO tag: CloudFormation always applies `aws:cloudformation:*` tags (CDK and Copilot deploy through CloudFormation, so their resources carry them too), some CDK constructs emit `aws-cdk:*` tags (e.g. `aws-cdk:auto-delete-objects`), and Copilot adds `copilot-*` tags. Note: CDK's construct path (`aws:cdk:path`) is recorded in the CloudFormation template `Metadata` attribute, NOT as a resource tag — the `aws:` tag prefix is reserved for AWS services, so nothing can apply it as a tag. CDK detection relies on `aws-cdk:*` tags, `aws:cloudformation:*` tags plus stack association, and CDK-pattern logical IDs/metadata resources
 - **Terraform is the critical exception: Terraform applies NO default tags.** Unless the team configured `default_tags` on the AWS provider or tagged resources explicitly, a fully Terraform-managed estate is invisible to tag-based detection. Expect `undetermined: true` to frequently mean "Terraform or console-managed" — do not read it as "no IaC"
 - Stack association confirms CloudFormation-family tools (CDK, Copilot, raw CloudFormation) with high confidence
 - Naming patterns provide supporting evidence when tags are stripped or absent, but carry lower confidence alone
@@ -106,12 +106,12 @@ aws ecs list-tags-for-resource \
 {
   "tags": [
     {
-      "key": "aws:cdk:path",
-      "value": "MyStack/MyService/Service"
-    },
-    {
       "key": "aws-cdk:auto-delete-objects",
       "value": "true"
+    },
+    {
+      "key": "aws:cloudformation:stack-name",
+      "value": "CdkEcsStack"
     }
   ]
 }
@@ -175,14 +175,13 @@ aws ecs list-tags-for-resource \
 
 **Tag patterns to match:**
 
-> Facts verified 2026-07-14 against https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-resource-tags.html — CloudFormation automatically applies the stack-level tags `aws:cloudformation:logical-id`, `aws:cloudformation:stack-id`, and `aws:cloudformation:stack-name` (the `aws:` prefix is reserved for AWS use). Terraform's AWS provider applies NO tags by default — `terraform:*` / `tf-*` keys only exist when a team configured them deliberately.
+> Facts verified 2026-07-14 against https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-resource-tags.html — CloudFormation automatically applies the stack-level tags `aws:cloudformation:logical-id`, `aws:cloudformation:stack-id`, and `aws:cloudformation:stack-name` (the `aws:` prefix is reserved for AWS use). Terraform's AWS provider applies NO tags by default — `terraform:*` / `tf-*` keys only exist when a team configured them deliberately. CDK's `aws:cdk:path` construct path lands in the template `Metadata` attribute, not in resource tags — do not look for it as a tag.
 
 | Tool | Tag Key Pattern | Confidence | Origin |
 |------|----------------|------------|--------|
 | Terraform | Key starts with `terraform:` | High | Team convention (Terraform emits no default tags) |
 | Terraform | Key starts with `tf-` | High | Team convention (Terraform emits no default tags) |
-| CDK | Key is `aws:cdk:path` | High | Tool-emitted (when CDK path metadata is enabled) |
-| CDK | Key starts with `aws-cdk:` | High | Tool-emitted (specific constructs) |
+| CDK | Key starts with `aws-cdk:` (e.g. `aws-cdk:auto-delete-objects`) | High | Tool-emitted (specific constructs) |
 | Copilot | Key is `copilot-application` | High | Tool-emitted |
 | Copilot | Key is `copilot-environment` | High | Tool-emitted |
 | Copilot | Key is `copilot-service` | High | Tool-emitted |
@@ -353,8 +352,7 @@ If evidence IS found for one or more tools:
 |----------------|-----------|-------------|
 | Tag: `terraform:*` prefix | Terraform state management tags | `terraform` |
 | Tag: `tf-*` prefix | Terraform workspace/module tags | `terraform` |
-| Tag: `aws:cdk:path` | CDK construct path tag | `cdk` |
-| Tag: `aws-cdk:*` prefix | CDK metadata tags | `cdk` |
+| Tag: `aws-cdk:*` prefix | CDK construct-emitted tags | `cdk` |
 | Tag: `copilot-application` | Copilot application tag | `copilot` |
 | Tag: `copilot-environment` | Copilot environment tag | `copilot` |
 | Tag: `copilot-service` | Copilot service tag | `copilot` |
@@ -411,9 +409,9 @@ iac:
       confidence: "high"
       evidence:
         - type: "resource_tags"
-          detail: "Tag 'aws:cdk:path' found on service 'api-service' with value 'MyStack/ApiService/Service'"
+          detail: "Tag 'aws-cdk:auto-delete-objects' found on service 'api-service'"
         - type: "stack_association"
-          detail: "Service belongs to CloudFormation stack 'CdkEcsStack' with CDK-pattern naming"
+          detail: "Service belongs to CloudFormation stack 'CdkEcsStack' with CDK-pattern logical IDs"
     - tool: "terraform"
       confidence: "high"
       evidence:
@@ -534,7 +532,7 @@ Only three evidence types are valid: `"resource_tags"`, `"stack_association"`, a
 Both CDK and Copilot deploy resources via CloudFormation, so their resources will have `aws:cloudformation:*` tags in addition to their own tool-specific tags. This creates overlapping evidence.
 
 **How to handle:**
-- If CDK-specific tags (`aws:cdk:path`, `aws-cdk:*`) are present alongside `aws:cloudformation:*` tags → report `"cdk"` (not `"cloudformation"`)
+- If CDK-specific tags (`aws-cdk:*`, e.g. `aws-cdk:auto-delete-objects`) are present alongside `aws:cloudformation:*` tags, or the owning stack shows CDK-pattern logical IDs or CDK metadata resources → report `"cdk"` (not `"cloudformation"`)
 - If Copilot-specific tags (`copilot-application`, `copilot-environment`, `copilot-service`) are present alongside `aws:cloudformation:*` tags → report `"copilot"` (not `"cloudformation"`)
 - Report `"cloudformation"` only when `aws:cloudformation:*` tags are present WITHOUT CDK or Copilot-specific tags
 - Priority: Copilot tags > CDK tags > plain CloudFormation tags (most specific tool wins)
@@ -547,9 +545,9 @@ iac:
       confidence: "high"
       evidence:
         - type: "resource_tags"
-          detail: "Tag 'aws:cdk:path' found on service with value 'MyStack/Service/Resource'"
+          detail: "Tag 'aws-cdk:auto-delete-objects' found on service alongside 'aws:cloudformation:*' tags"
         - type: "stack_association"
-          detail: "Service belongs to stack 'CdkEcsStack' (CDK-generated)"
+          detail: "Service belongs to stack 'CdkEcsStack' (CDK-pattern logical IDs)"
   undetermined: false
   error: null
 ```

--- a/misc/website/docs/skills/ecs/ecs-recon/references/networking.md
+++ b/misc/website/docs/skills/ecs/ecs-recon/references/networking.md
@@ -510,7 +510,7 @@ networking:
 
 `DescribeTargetGroups` returns an empty `LoadBalancerArns` list in two common scenarios:
 
-1. **ECS-native blue/green deployments** — the target groups attach to the load balancer via listener rules managed by the ECS deployment controller (returned in `loadBalancers[].advancedConfiguration`), not via direct association.
+1. **ECS-native blue/green deployments** — the target groups attach to the load balancer via listener rules (ALB) or listeners (NLB) managed by the ECS deployment controller (returned in `loadBalancers[].advancedConfiguration`), not via direct association.
 2. **Orphaned target groups** — the target group was detached from its load balancer or never attached.
 
 In both cases the `DescribeTargetGroups` → `DescribeLoadBalancers` path cannot determine the LB type.

--- a/misc/website/docs/skills/ecs/ecs-recon/references/networking.md
+++ b/misc/website/docs/skills/ecs/ecs-recon/references/networking.md
@@ -162,7 +162,9 @@ aws ecs describe-services \
 ]
 ```
 
-**Note on ECS-native blue/green services:** When the service uses ECS-native blue/green deployment (`deploymentConfiguration.strategy: BLUE_GREEN`), the `loadBalancers` entry may also include `advancedConfiguration` with `productionListenerRule`, `testListenerRule`, `alternateTargetGroupArn`, and `roleArn`. If `DescribeTargetGroups` returns empty `LoadBalancerArns` for such a service, extract the load balancer ARN from the listener-rule ARN (`arn:...:listener-rule/<lb-arn-segment>/...`) or fall back to `type: "unknown"`. See [Target group with empty LoadBalancerArns](#target-group-with-empty-loadbalancerarns).
+**Note on ECS-native blue/green services:** When the service uses ECS-native blue/green deployment (`deploymentConfiguration.strategy: BLUE_GREEN`), the `loadBalancers` entry may also include `advancedConfiguration` with `productionListenerRule`, `testListenerRule`, `alternateTargetGroupArn`, and `roleArn`. Despite the field name, `productionListenerRule` holds a listener-**rule** ARN for an Application Load Balancer but a plain **listener** ARN for a Network Load Balancer. If `DescribeTargetGroups` returns empty `LoadBalancerArns` for such a service, derive the load balancer ARN from that ARN (both shapes) or fall back to `type: "unknown"`. See [Target group with empty LoadBalancerArns](#target-group-with-empty-loadbalancerarns).
+
+> Facts verified 2026-07-17 against https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_AdvancedConfiguration.html — `productionListenerRule` / `testListenerRule` identify "the production listener rule (in the case of an Application Load Balancer) or listener (in the case for an Network Load Balancer)".
 
 **Step 3b: Describe target group to get load balancer ARNs**
 
@@ -513,9 +515,12 @@ networking:
 
 In both cases the `DescribeTargetGroups` → `DescribeLoadBalancers` path cannot determine the LB type.
 
+> Facts verified 2026-07-17 against https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_AdvancedConfiguration.html — `productionListenerRule` identifies a listener rule for an Application Load Balancer but a listener for a Network Load Balancer.
+
 **How to handle:**
-- If `LoadBalancerArns` is empty, check whether the service uses `advancedConfiguration` (present on ECS-native blue/green services). If `advancedConfiguration.productionListenerRule` exists, derive the load balancer ARN from the listener-rule ARN and resolve the type with `DescribeLoadBalancers`.
-- **ARN derivation:** a listener-rule ARN has the form `arn:aws:elasticloadbalancing:<region>:<account>:listener-rule/<lb-type>/<lb-name>/<lb-id>/<listener-id>/<rule-id>`. Replace the `listener-rule` resource token with `loadbalancer` and keep only the first three path segments: `arn:aws:elasticloadbalancing:<region>:<account>:loadbalancer/<lb-type>/<lb-name>/<lb-id>`.
+- If `LoadBalancerArns` is empty, check whether the service uses `advancedConfiguration` (present on ECS-native blue/green services). If `advancedConfiguration.productionListenerRule` exists, derive the load balancer ARN from it and resolve the type with `DescribeLoadBalancers`. Per the API reference, this field holds a listener-**rule** ARN for an ALB but a plain **listener** ARN for an NLB — branch on the ARN's resource token:
+- **ARN derivation (`listener-rule` token — ALB):** a listener-rule ARN has the form `arn:aws:elasticloadbalancing:<region>:<account>:listener-rule/<lb-type>/<lb-name>/<lb-id>/<listener-id>/<rule-id>`. Replace the `listener-rule` resource token with `loadbalancer` and keep only the first three path segments: `arn:aws:elasticloadbalancing:<region>:<account>:loadbalancer/<lb-type>/<lb-name>/<lb-id>`.
+- **ARN derivation (`listener` token — NLB):** a listener ARN has the form `arn:aws:elasticloadbalancing:<region>:<account>:listener/<lb-type>/<lb-name>/<lb-id>/<listener-id>` (no rule segment, `<lb-type>` is `net`). Replace the `listener` resource token with `loadbalancer` and keep only the first three path segments: `arn:aws:elasticloadbalancing:<region>:<account>:loadbalancer/net/<lb-name>/<lb-id>`.
 - If `DescribeLoadBalancers` on the derived ARN returns `LoadBalancerNotFound`, the reference is stale (the load balancer was deleted after the service's last deployment) — set `type` to `"unknown"` and note the stale reference in the service's `error` field.
 - If `advancedConfiguration` is absent or the derivation is impractical, set `type` to `"unknown"`.
 - Always report the entry with the target group ARN, container name, and port regardless.
@@ -546,3 +551,4 @@ load_balancers:
 - Service Connect (configuration lives on the deployment): https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html
 - Service discovery (`serviceRegistries`): https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html
 - AWS App Mesh overview and end-of-support announcement (2026-09-30): https://docs.aws.amazon.com/app-mesh/latest/userguide/what-is-app-mesh.html
+- Blue/green `advancedConfiguration` fields (`productionListenerRule` is a listener rule for ALB, a listener for NLB): https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_AdvancedConfiguration.html

--- a/misc/website/docs/skills/ecs/ecs-recon/references/overview.md
+++ b/misc/website/docs/skills/ecs/ecs-recon/references/overview.md
@@ -191,6 +191,8 @@ aws ecs describe-clusters --clusters prod-api staging-web batch-processing --inc
 }
 ```
 
+> Facts verified 2026-07-17 against https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeClusters.html — `DescribeClusters` accepts up to 100 cluster names per call.
+
 **Batch limits:** `DescribeClusters` accepts up to 100 cluster names per call. If you have more than 100 clusters, batch them into groups of 100.
 
 **Interpretation:**

--- a/skills/ecs-recon/SKILL.md
+++ b/skills/ecs-recon/SKILL.md
@@ -90,7 +90,7 @@ Load only the references needed for the user's request — this keeps context fo
 
 | Module | Intent / When to Use | Reference File |
 |--------|---------------------|----------------|
-| Overview | Always loaded first — account-wide inventory of clusters, services, tasks | [overview.md](references/overview.md) |
+| Overview | Always loaded first — account-wide inventory of clusters, services, and their tasks (standalone/scheduled tasks not discovered) | [overview.md](references/overview.md) |
 | Compute | Capacity providers, launch types, task counts, Fargate vs EC2 | [compute.md](references/compute.md) |
 | Task Definitions | Container images, CPU/memory, family and revision | [task-definitions.md](references/task-definitions.md) |
 | Deployment | Rolling update, CodeDeploy, circuit breaker, min/max percent | [deployment.md](references/deployment.md) |

--- a/skills/ecs-recon/references/iac.md
+++ b/skills/ecs-recon/references/iac.md
@@ -43,7 +43,7 @@ Run detections in this order — each step adds evidence and confidence:
 ```
 
 **Why this order matters:**
-- Tags are the strongest single-call signal for the tools that DO tag: CloudFormation always applies `aws:cloudformation:*` tags, CDK adds `aws:cdk:path` (when metadata is enabled), and Copilot adds `copilot-*` tags
+- Tags are the strongest single-call signal for the tools that DO tag: CloudFormation always applies `aws:cloudformation:*` tags (CDK and Copilot deploy through CloudFormation, so their resources carry them too), some CDK constructs emit `aws-cdk:*` tags (e.g. `aws-cdk:auto-delete-objects`), and Copilot adds `copilot-*` tags. Note: CDK's construct path (`aws:cdk:path`) is recorded in the CloudFormation template `Metadata` attribute, NOT as a resource tag — the `aws:` tag prefix is reserved for AWS services, so nothing can apply it as a tag. CDK detection relies on `aws-cdk:*` tags, `aws:cloudformation:*` tags plus stack association, and CDK-pattern logical IDs/metadata resources
 - **Terraform is the critical exception: Terraform applies NO default tags.** Unless the team configured `default_tags` on the AWS provider or tagged resources explicitly, a fully Terraform-managed estate is invisible to tag-based detection. Expect `undetermined: true` to frequently mean "Terraform or console-managed" — do not read it as "no IaC"
 - Stack association confirms CloudFormation-family tools (CDK, Copilot, raw CloudFormation) with high confidence
 - Naming patterns provide supporting evidence when tags are stripped or absent, but carry lower confidence alone
@@ -95,12 +95,12 @@ aws ecs list-tags-for-resource \
 {
   "tags": [
     {
-      "key": "aws:cdk:path",
-      "value": "MyStack/MyService/Service"
-    },
-    {
       "key": "aws-cdk:auto-delete-objects",
       "value": "true"
+    },
+    {
+      "key": "aws:cloudformation:stack-name",
+      "value": "CdkEcsStack"
     }
   ]
 }
@@ -164,14 +164,13 @@ aws ecs list-tags-for-resource \
 
 **Tag patterns to match:**
 
-> Facts verified 2026-07-14 against https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-resource-tags.html — CloudFormation automatically applies the stack-level tags `aws:cloudformation:logical-id`, `aws:cloudformation:stack-id`, and `aws:cloudformation:stack-name` (the `aws:` prefix is reserved for AWS use). Terraform's AWS provider applies NO tags by default — `terraform:*` / `tf-*` keys only exist when a team configured them deliberately.
+> Facts verified 2026-07-14 against https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-resource-tags.html — CloudFormation automatically applies the stack-level tags `aws:cloudformation:logical-id`, `aws:cloudformation:stack-id`, and `aws:cloudformation:stack-name` (the `aws:` prefix is reserved for AWS use). Terraform's AWS provider applies NO tags by default — `terraform:*` / `tf-*` keys only exist when a team configured them deliberately. CDK's `aws:cdk:path` construct path lands in the template `Metadata` attribute, not in resource tags — do not look for it as a tag.
 
 | Tool | Tag Key Pattern | Confidence | Origin |
 |------|----------------|------------|--------|
 | Terraform | Key starts with `terraform:` | High | Team convention (Terraform emits no default tags) |
 | Terraform | Key starts with `tf-` | High | Team convention (Terraform emits no default tags) |
-| CDK | Key is `aws:cdk:path` | High | Tool-emitted (when CDK path metadata is enabled) |
-| CDK | Key starts with `aws-cdk:` | High | Tool-emitted (specific constructs) |
+| CDK | Key starts with `aws-cdk:` (e.g. `aws-cdk:auto-delete-objects`) | High | Tool-emitted (specific constructs) |
 | Copilot | Key is `copilot-application` | High | Tool-emitted |
 | Copilot | Key is `copilot-environment` | High | Tool-emitted |
 | Copilot | Key is `copilot-service` | High | Tool-emitted |
@@ -342,8 +341,7 @@ If evidence IS found for one or more tools:
 |----------------|-----------|-------------|
 | Tag: `terraform:*` prefix | Terraform state management tags | `terraform` |
 | Tag: `tf-*` prefix | Terraform workspace/module tags | `terraform` |
-| Tag: `aws:cdk:path` | CDK construct path tag | `cdk` |
-| Tag: `aws-cdk:*` prefix | CDK metadata tags | `cdk` |
+| Tag: `aws-cdk:*` prefix | CDK construct-emitted tags | `cdk` |
 | Tag: `copilot-application` | Copilot application tag | `copilot` |
 | Tag: `copilot-environment` | Copilot environment tag | `copilot` |
 | Tag: `copilot-service` | Copilot service tag | `copilot` |
@@ -400,9 +398,9 @@ iac:
       confidence: "high"
       evidence:
         - type: "resource_tags"
-          detail: "Tag 'aws:cdk:path' found on service 'api-service' with value 'MyStack/ApiService/Service'"
+          detail: "Tag 'aws-cdk:auto-delete-objects' found on service 'api-service'"
         - type: "stack_association"
-          detail: "Service belongs to CloudFormation stack 'CdkEcsStack' with CDK-pattern naming"
+          detail: "Service belongs to CloudFormation stack 'CdkEcsStack' with CDK-pattern logical IDs"
     - tool: "terraform"
       confidence: "high"
       evidence:
@@ -523,7 +521,7 @@ Only three evidence types are valid: `"resource_tags"`, `"stack_association"`, a
 Both CDK and Copilot deploy resources via CloudFormation, so their resources will have `aws:cloudformation:*` tags in addition to their own tool-specific tags. This creates overlapping evidence.
 
 **How to handle:**
-- If CDK-specific tags (`aws:cdk:path`, `aws-cdk:*`) are present alongside `aws:cloudformation:*` tags → report `"cdk"` (not `"cloudformation"`)
+- If CDK-specific tags (`aws-cdk:*`, e.g. `aws-cdk:auto-delete-objects`) are present alongside `aws:cloudformation:*` tags, or the owning stack shows CDK-pattern logical IDs or CDK metadata resources → report `"cdk"` (not `"cloudformation"`)
 - If Copilot-specific tags (`copilot-application`, `copilot-environment`, `copilot-service`) are present alongside `aws:cloudformation:*` tags → report `"copilot"` (not `"cloudformation"`)
 - Report `"cloudformation"` only when `aws:cloudformation:*` tags are present WITHOUT CDK or Copilot-specific tags
 - Priority: Copilot tags > CDK tags > plain CloudFormation tags (most specific tool wins)
@@ -536,9 +534,9 @@ iac:
       confidence: "high"
       evidence:
         - type: "resource_tags"
-          detail: "Tag 'aws:cdk:path' found on service with value 'MyStack/Service/Resource'"
+          detail: "Tag 'aws-cdk:auto-delete-objects' found on service alongside 'aws:cloudformation:*' tags"
         - type: "stack_association"
-          detail: "Service belongs to stack 'CdkEcsStack' (CDK-generated)"
+          detail: "Service belongs to stack 'CdkEcsStack' (CDK-pattern logical IDs)"
   undetermined: false
   error: null
 ```

--- a/skills/ecs-recon/references/iac.md
+++ b/skills/ecs-recon/references/iac.md
@@ -43,7 +43,7 @@ Run detections in this order — each step adds evidence and confidence:
 ```
 
 **Why this order matters:**
-- Tags are the strongest single-call signal for the tools that DO tag: CloudFormation always applies `aws:cloudformation:*` tags (CDK and Copilot deploy through CloudFormation, so their resources carry them too), some CDK constructs emit `aws-cdk:*` tags (e.g. `aws-cdk:auto-delete-objects`), and Copilot adds `copilot-*` tags. Note: CDK's construct path (`aws:cdk:path`) is recorded in the CloudFormation template `Metadata` attribute, NOT as a resource tag — the `aws:` tag prefix is reserved for AWS services, so nothing can apply it as a tag. CDK detection relies on `aws-cdk:*` tags, `aws:cloudformation:*` tags plus stack association, and CDK-pattern logical IDs/metadata resources
+- Tags are the strongest single-call signal for the tools that DO tag: CloudFormation applies stack-level `aws:cloudformation:*` tags (propagation varies by resource type, but ECS clusters, services, and task definitions receive them — and CDK and Copilot deploy through CloudFormation, so their resources carry them too), some CDK constructs emit `aws-cdk:*` tags (e.g. `aws-cdk:auto-delete-objects` — emitted on some resource types such as S3 buckets, rarely present on ECS resources), and Copilot adds `copilot-*` tags. Note: CDK's construct path (`aws:cdk:path`) is recorded in the CloudFormation template `Metadata` attribute, NOT as a resource tag — the `aws:` tag prefix is reserved for AWS services, so no user or third-party tool can apply it as a tag. CDK detection relies on `aws:cloudformation:*` tags plus stack association, CDK-pattern logical IDs/metadata resources, and `aws-cdk:*` tags when present
 - **Terraform is the critical exception: Terraform applies NO default tags.** Unless the team configured `default_tags` on the AWS provider or tagged resources explicitly, a fully Terraform-managed estate is invisible to tag-based detection. Expect `undetermined: true` to frequently mean "Terraform or console-managed" — do not read it as "no IaC"
 - Stack association confirms CloudFormation-family tools (CDK, Copilot, raw CloudFormation) with high confidence
 - Naming patterns provide supporting evidence when tags are stripped or absent, but carry lower confidence alone
@@ -95,16 +95,22 @@ aws ecs list-tags-for-resource \
 {
   "tags": [
     {
-      "key": "aws-cdk:auto-delete-objects",
-      "value": "true"
-    },
-    {
       "key": "aws:cloudformation:stack-name",
       "value": "CdkEcsStack"
+    },
+    {
+      "key": "aws:cloudformation:stack-id",
+      "value": "arn:aws:cloudformation:us-east-1:123456789012:stack/CdkEcsStack/def456"
+    },
+    {
+      "key": "aws:cloudformation:logical-id",
+      "value": "ApiServiceE2A5697D"
     }
   ]
 }
 ```
+
+CDK-managed ECS resources typically carry only `aws:cloudformation:*` tags — distinguish CDK from raw CloudFormation via stack association (CDK-pattern logical IDs like `ApiServiceE2A5697D`, or an `AWS::CDK::Metadata` resource in the stack).
 
 **Example output (Copilot-managed resource):**
 ```json
@@ -164,7 +170,9 @@ aws ecs list-tags-for-resource \
 
 **Tag patterns to match:**
 
-> Facts verified 2026-07-14 against https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-resource-tags.html — CloudFormation automatically applies the stack-level tags `aws:cloudformation:logical-id`, `aws:cloudformation:stack-id`, and `aws:cloudformation:stack-name` (the `aws:` prefix is reserved for AWS use). Terraform's AWS provider applies NO tags by default — `terraform:*` / `tf-*` keys only exist when a team configured them deliberately. CDK's `aws:cdk:path` construct path lands in the template `Metadata` attribute, not in resource tags — do not look for it as a tag.
+> Facts verified 2026-07-14 against https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-resource-tags.html — CloudFormation automatically applies the stack-level tags `aws:cloudformation:logical-id`, `aws:cloudformation:stack-id`, and `aws:cloudformation:stack-name` (the `aws:` prefix is reserved for AWS use). Terraform's AWS provider applies NO tags by default — `terraform:*` / `tf-*` keys only exist when a team configured them deliberately.
+
+> Facts verified 2026-07-17 against https://docs.aws.amazon.com/cdk/v2/guide/ref-cli-cmd.html — CDK's `--path-metadata` option (default true) records the construct path as `aws:cdk:path` in the CloudFormation template's resource Metadata attribute, not as a resource tag.
 
 | Tool | Tag Key Pattern | Confidence | Origin |
 |------|----------------|------------|--------|
@@ -398,9 +406,9 @@ iac:
       confidence: "high"
       evidence:
         - type: "resource_tags"
-          detail: "Tag 'aws-cdk:auto-delete-objects' found on service 'api-service'"
+          detail: "Tags 'aws:cloudformation:stack-name=CdkEcsStack' and 'aws:cloudformation:logical-id=ApiServiceE2A5697D' found on service 'api-service'"
         - type: "stack_association"
-          detail: "Service belongs to CloudFormation stack 'CdkEcsStack' with CDK-pattern logical IDs"
+          detail: "Service belongs to CloudFormation stack 'CdkEcsStack' with CDK-pattern logical IDs and an AWS::CDK::Metadata resource"
     - tool: "terraform"
       confidence: "high"
       evidence:
@@ -521,7 +529,7 @@ Only three evidence types are valid: `"resource_tags"`, `"stack_association"`, a
 Both CDK and Copilot deploy resources via CloudFormation, so their resources will have `aws:cloudformation:*` tags in addition to their own tool-specific tags. This creates overlapping evidence.
 
 **How to handle:**
-- If CDK-specific tags (`aws-cdk:*`, e.g. `aws-cdk:auto-delete-objects`) are present alongside `aws:cloudformation:*` tags, or the owning stack shows CDK-pattern logical IDs or CDK metadata resources → report `"cdk"` (not `"cloudformation"`)
+- If CDK-specific tags (`aws-cdk:*`, e.g. `aws-cdk:auto-delete-objects` — emitted on some resource types such as S3 buckets, rarely present on ECS resources) are present alongside `aws:cloudformation:*` tags, or the owning stack shows CDK-pattern logical IDs or CDK metadata resources → report `"cdk"` (not `"cloudformation"`)
 - If Copilot-specific tags (`copilot-application`, `copilot-environment`, `copilot-service`) are present alongside `aws:cloudformation:*` tags → report `"copilot"` (not `"cloudformation"`)
 - Report `"cloudformation"` only when `aws:cloudformation:*` tags are present WITHOUT CDK or Copilot-specific tags
 - Priority: Copilot tags > CDK tags > plain CloudFormation tags (most specific tool wins)
@@ -534,9 +542,9 @@ iac:
       confidence: "high"
       evidence:
         - type: "resource_tags"
-          detail: "Tag 'aws-cdk:auto-delete-objects' found on service alongside 'aws:cloudformation:*' tags"
+          detail: "'aws:cloudformation:*' tags found on service (stack 'CdkEcsStack')"
         - type: "stack_association"
-          detail: "Service belongs to stack 'CdkEcsStack' (CDK-pattern logical IDs)"
+          detail: "Service belongs to stack 'CdkEcsStack' (CDK-pattern logical IDs and an AWS::CDK::Metadata resource)"
   undetermined: false
   error: null
 ```

--- a/skills/ecs-recon/references/networking.md
+++ b/skills/ecs-recon/references/networking.md
@@ -499,7 +499,7 @@ networking:
 
 `DescribeTargetGroups` returns an empty `LoadBalancerArns` list in two common scenarios:
 
-1. **ECS-native blue/green deployments** — the target groups attach to the load balancer via listener rules managed by the ECS deployment controller (returned in `loadBalancers[].advancedConfiguration`), not via direct association.
+1. **ECS-native blue/green deployments** — the target groups attach to the load balancer via listener rules (ALB) or listeners (NLB) managed by the ECS deployment controller (returned in `loadBalancers[].advancedConfiguration`), not via direct association.
 2. **Orphaned target groups** — the target group was detached from its load balancer or never attached.
 
 In both cases the `DescribeTargetGroups` → `DescribeLoadBalancers` path cannot determine the LB type.

--- a/skills/ecs-recon/references/networking.md
+++ b/skills/ecs-recon/references/networking.md
@@ -151,7 +151,9 @@ aws ecs describe-services \
 ]
 ```
 
-**Note on ECS-native blue/green services:** When the service uses ECS-native blue/green deployment (`deploymentConfiguration.strategy: BLUE_GREEN`), the `loadBalancers` entry may also include `advancedConfiguration` with `productionListenerRule`, `testListenerRule`, `alternateTargetGroupArn`, and `roleArn`. If `DescribeTargetGroups` returns empty `LoadBalancerArns` for such a service, extract the load balancer ARN from the listener-rule ARN (`arn:...:listener-rule/<lb-arn-segment>/...`) or fall back to `type: "unknown"`. See [Target group with empty LoadBalancerArns](#target-group-with-empty-loadbalancerarns).
+**Note on ECS-native blue/green services:** When the service uses ECS-native blue/green deployment (`deploymentConfiguration.strategy: BLUE_GREEN`), the `loadBalancers` entry may also include `advancedConfiguration` with `productionListenerRule`, `testListenerRule`, `alternateTargetGroupArn`, and `roleArn`. Despite the field name, `productionListenerRule` holds a listener-**rule** ARN for an Application Load Balancer but a plain **listener** ARN for a Network Load Balancer. If `DescribeTargetGroups` returns empty `LoadBalancerArns` for such a service, derive the load balancer ARN from that ARN (both shapes) or fall back to `type: "unknown"`. See [Target group with empty LoadBalancerArns](#target-group-with-empty-loadbalancerarns).
+
+> Facts verified 2026-07-17 against https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_AdvancedConfiguration.html — `productionListenerRule` / `testListenerRule` identify "the production listener rule (in the case of an Application Load Balancer) or listener (in the case for an Network Load Balancer)".
 
 **Step 3b: Describe target group to get load balancer ARNs**
 
@@ -502,9 +504,12 @@ networking:
 
 In both cases the `DescribeTargetGroups` → `DescribeLoadBalancers` path cannot determine the LB type.
 
+> Facts verified 2026-07-17 against https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_AdvancedConfiguration.html — `productionListenerRule` identifies a listener rule for an Application Load Balancer but a listener for a Network Load Balancer.
+
 **How to handle:**
-- If `LoadBalancerArns` is empty, check whether the service uses `advancedConfiguration` (present on ECS-native blue/green services). If `advancedConfiguration.productionListenerRule` exists, derive the load balancer ARN from the listener-rule ARN and resolve the type with `DescribeLoadBalancers`.
-- **ARN derivation:** a listener-rule ARN has the form `arn:aws:elasticloadbalancing:<region>:<account>:listener-rule/<lb-type>/<lb-name>/<lb-id>/<listener-id>/<rule-id>`. Replace the `listener-rule` resource token with `loadbalancer` and keep only the first three path segments: `arn:aws:elasticloadbalancing:<region>:<account>:loadbalancer/<lb-type>/<lb-name>/<lb-id>`.
+- If `LoadBalancerArns` is empty, check whether the service uses `advancedConfiguration` (present on ECS-native blue/green services). If `advancedConfiguration.productionListenerRule` exists, derive the load balancer ARN from it and resolve the type with `DescribeLoadBalancers`. Per the API reference, this field holds a listener-**rule** ARN for an ALB but a plain **listener** ARN for an NLB — branch on the ARN's resource token:
+- **ARN derivation (`listener-rule` token — ALB):** a listener-rule ARN has the form `arn:aws:elasticloadbalancing:<region>:<account>:listener-rule/<lb-type>/<lb-name>/<lb-id>/<listener-id>/<rule-id>`. Replace the `listener-rule` resource token with `loadbalancer` and keep only the first three path segments: `arn:aws:elasticloadbalancing:<region>:<account>:loadbalancer/<lb-type>/<lb-name>/<lb-id>`.
+- **ARN derivation (`listener` token — NLB):** a listener ARN has the form `arn:aws:elasticloadbalancing:<region>:<account>:listener/<lb-type>/<lb-name>/<lb-id>/<listener-id>` (no rule segment, `<lb-type>` is `net`). Replace the `listener` resource token with `loadbalancer` and keep only the first three path segments: `arn:aws:elasticloadbalancing:<region>:<account>:loadbalancer/net/<lb-name>/<lb-id>`.
 - If `DescribeLoadBalancers` on the derived ARN returns `LoadBalancerNotFound`, the reference is stale (the load balancer was deleted after the service's last deployment) — set `type` to `"unknown"` and note the stale reference in the service's `error` field.
 - If `advancedConfiguration` is absent or the derivation is impractical, set `type` to `"unknown"`.
 - Always report the entry with the target group ARN, container name, and port regardless.
@@ -535,3 +540,4 @@ load_balancers:
 - Service Connect (configuration lives on the deployment): https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html
 - Service discovery (`serviceRegistries`): https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html
 - AWS App Mesh overview and end-of-support announcement (2026-09-30): https://docs.aws.amazon.com/app-mesh/latest/userguide/what-is-app-mesh.html
+- Blue/green `advancedConfiguration` fields (`productionListenerRule` is a listener rule for ALB, a listener for NLB): https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_AdvancedConfiguration.html

--- a/skills/ecs-recon/references/overview.md
+++ b/skills/ecs-recon/references/overview.md
@@ -180,6 +180,8 @@ aws ecs describe-clusters --clusters prod-api staging-web batch-processing --inc
 }
 ```
 
+> Facts verified 2026-07-17 against https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeClusters.html — `DescribeClusters` accepts up to 100 cluster names per call.
+
 **Batch limits:** `DescribeClusters` accepts up to 100 cluster names per call. If you have more than 100 clusters, batch them into groups of 100.
 
 **Interpretation:**


### PR DESCRIPTION
Non-blocking follow-ups flagged in the APPROVE review on #137, plus fixes from an adversarial review of this PR's own first commit (second commit).

## Fixes

1. **CDK tag detection — remove `aws:cdk:path` as a tag signal** (`references/iac.md`). CDK's construct path is recorded in the CloudFormation template `Metadata` attribute, not as a resource tag, and the `aws:` tag prefix is reserved for AWS use so no user or third-party tool can apply it as a tag (the file's own verified note at the tag table already states this rule). CDK detection on ECS resources now leads with `aws:cloudformation:*` tags + stack association (CDK-pattern logical IDs, `AWS::CDK::Metadata` resource); `aws-cdk:*` construct tags (e.g. `aws-cdk:auto-delete-objects`) remain a valid signal when present but are emitted on few resource types (e.g. S3 buckets) and rarely appear on ECS resources. Refs: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-resource-tags.html, https://docs.aws.amazon.com/cdk/v2/guide/ref-cli-cmd.html

2. **NLB blue/green load balancer derivation** (`references/networking.md`). Per the ECS API reference, `advancedConfiguration.productionListenerRule` holds a listener-rule ARN for an ALB but a plain listener ARN for an NLB. The derivation previously only handled the `listener-rule` ARN shape, so NLB blue/green services degraded to `type: "unknown"` unnecessarily. Added the `listener` token branch (replace `listener` with `loadbalancer`, keep `net/<lb-name>/<lb-id>`); stale-LB fallback semantics unchanged. Ref: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_AdvancedConfiguration.html

3. **Sourcing for blue/green content** (`references/networking.md`). The `advancedConfiguration` content had no source citation or dated freshness gate, unlike the rest of the file. Added API_AdvancedConfiguration.html to the Sources section and "Facts verified 2026-07-17" gates adjacent to the blue/green content, matching the file's existing gate style.

## Second commit (review follow-ups on this PR)

An adversarial review of the first commit surfaced four refinements, applied in the second commit:

- Softened "CloudFormation **always** applies `aws:cloudformation:*` tags" — stack-level tag propagation varies by resource type per the CloudFormation docs; ECS clusters, services, and task definitions do receive them.
- Scoped "nothing can apply it as a tag" to "no user or third-party tool" (AWS services themselves do apply `aws:`-prefixed tags).
- Reworked the three ECS-resource examples that depicted `aws-cdk:auto-delete-objects` on an ECS service (that tag is emitted on S3 buckets) to use the realistic CDK-on-ECS evidence: `aws:cloudformation:*` tags + stack association.
- Split the `aws:cdk:path`-in-Metadata claim into its own dated gate citing the CDK CLI reference (the previous gate's CloudFormation URL didn't cover it), and fixed an ALB-only wording in networking.md's target-group attachment description ("listener rules (ALB) or listeners (NLB)").

## Also included (minor)

- `SKILL.md` module table: qualified "account-wide inventory of clusters, services, tasks" to match the module's `scope_note` (standalone `run-task` / scheduled tasks are not discovered).
- `references/overview.md`: added a dated freshness gate for the DescribeClusters 100-name cap (verified 2026-07-17 against https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeClusters.html).

Docusaurus mirrors regenerated via `misc/update-all-references.sh` + `misc/update-pages.sh`; `validate-frontmatter.py` passes (28 skills, 0 errors).
