### PR TITLE
improve(eks-cost-intelligence): default time window + Fargate detection (#114)

### DIFF
--- a/devops-agent/eks-cost-intelligence/SKILL.md
+++ b/devops-agent/eks-cost-intelligence/SKILL.md
@@ -30,6 +30,8 @@ The following permissions are included:
 - `eks:ListNodegroups`
 - `eks:DescribeNodegroup`
 - `eks:ListAddons`
+- `eks:ListFargateProfiles`
+- `eks:DescribeFargateProfile`
 
 **EC2 (required):**
 - `ec2:DescribeInstances`
@@ -128,6 +130,7 @@ Collect the following using AWS and Kubernetes APIs:
 - Kubernetes version and platform version (from DescribeCluster response)
 - Node groups: use EKS ListNodegroups and DescribeNodegroup APIs for instance types, scaling config, capacity type (ON_DEMAND/SPOT)
 - Add-ons: use EKS ListAddons API
+- Fargate profiles: use EKS ListFargateProfiles API — if any profiles exist, use DescribeFargateProfile for each, note which namespaces/label selectors are Fargate-scheduled, and read `references/fargate-costs.md`. Fargate pods are billed on rounded-up pod requests (not node capacity), so exclude them from node-based checks and add the Fargate-specific checks to Steps 1–2.
 - Node inventory: use Kubernetes API to list nodes with labels and capacity info
 - Namespace list: use Kubernetes API to list namespaces
 
@@ -145,6 +148,7 @@ Checks:
 - Low-utilization nodes indicating consolidation opportunities
 - Karpenter consolidation effectiveness (where installed)
 - Workloads without resource requests or limits
+- Fargate pod request right-sizing against Fargate's vCPU/memory combinations — only when Step 0 found Fargate profiles (read `references/fargate-costs.md`, Check F1)
 
 Data collection uses:
 - Kubernetes API to list pods with resource requests/limits per namespace
@@ -165,6 +169,7 @@ Checks:
 - Stateless multi-replica workloads on On-Demand only
 - Instance type diversity for Spot availability
 - Node Termination Handler or Karpenter interruption handling
+- Interruption-tolerant workloads running on Fargate (EKS has no Fargate Spot) — only when Step 0 found Fargate profiles (read `references/fargate-costs.md`, Check F2)
 
 Data collection uses:
 - Kubernetes API to list nodes (labels: `kubernetes.io/arch`, `karpenter.sh/capacity-type`, `eks.amazonaws.com/capacityType`)
@@ -303,6 +308,10 @@ The skill calculates a weighted cost efficiency score:
 
 If Cost Explorer is unavailable, the skill falls back to node-based cost estimation (see `references/cost-estimation-fallback.md`).
 
+### Default Time Window
+
+Cost Explorer queries use a **7-day lookback by default** (matching the 7-day window used for CloudWatch utilization checks). If the request names a different window (e.g., "last 30 days"), apply the requested window to all Cost Explorer queries. Whichever window is used, record it in the report metadata (`Analysis Window` field) so findings are reproducible and comparable across runs.
+
 ---
 
 ## Out of Scope (v1)
@@ -342,6 +351,7 @@ Before executing checks for any dimension, read the corresponding reference file
 | Storage costs / gp2 / PVC / EBS | `references/storage-costs.md` |
 | Observability / logging / metrics / cardinality | `references/observability-costs.md` |
 | Idle resources / unused / orphaned / zero-scale | `references/idle-resources.md` |
+| Fargate profiles / Fargate pod pricing / request rounding | `references/fargate-costs.md` |
 | Score calculation / scoring algorithm | `references/report-generation.md` |
 | Generate report / produce report | `references/report-generation.md` |
 | Cost data collection / API calls | `references/cost-data-collection.md` |

--- a/devops-agent/eks-cost-intelligence/references/cost-data-collection.md
+++ b/devops-agent/eks-cost-intelligence/references/cost-data-collection.md
@@ -33,7 +33,11 @@ This reference documents the exact API calls needed to collect cost and utilizat
 - IAM permission: `ce:GetCostAndUsage`, `ce:GetSavingsPlansCoverage`
 - Cost Explorer API is only available in `us-east-1` regardless of cluster region
 
-### 1.1 Total EKS Spend by Service (Last 30 Days)
+### Time Window
+
+All Cost Explorer queries in this reference use a **7-day lookback by default**, matching the 7-day window used for CloudWatch utilization metrics. If the request names a different window (e.g., "last 30 days"), apply the override consistently to every Cost Explorer query in the assessment and record the window used in the report metadata (`Analysis Window` field). The examples below show a 30-day window for illustration; substitute the active analysis window.
+
+### 1.1 Total EKS Spend by Service
 
 **Via Cost Explorer GetCostAndUsage API:**
 

--- a/devops-agent/eks-cost-intelligence/references/cost-estimation-fallback.md
+++ b/devops-agent/eks-cost-intelligence/references/cost-estimation-fallback.md
@@ -107,7 +107,7 @@ Use the Kubernetes API to list all Nodes. Extract metadata.labels for instance-t
 > ⚠️ **Last verified: June 2026.** This table is a fallback for when the Price List API (Option B) is unavailable. Prices may drift. Always prefer Option B for production assessments.
 
 Use this table ONLY when:
-- `pricing:GetProducts` permission is not available
+- `pricing:GetProducts` permission is not available (it is not in the skill's baseline IAM policy — using the Price List API requires adding `pricing:GetProducts` to `references/iam-policy.json`)
 - Network-restricted environment cannot reach the Price List API endpoint
 - Quick directional estimate needed (mark all findings as Low confidence)
 

--- a/devops-agent/eks-cost-intelligence/references/fargate-costs.md
+++ b/devops-agent/eks-cost-intelligence/references/fargate-costs.md
@@ -27,12 +27,12 @@ EKS Fargate has a fundamentally different cost model from EC2 nodes:
 
 **Via Kubernetes API:**
 
-- List nodes with label `eks.amazonaws.com/compute-type=fargate` to identify Fargate-backed nodes.
+- List nodes with label `eks.amazonaws.com/compute-type=fargate` to identify Fargate-backed nodes. Fallback: Fargate node names start with `fargate-` (e.g., filter the node list for names beginning with `fargate-`).
 - List pods and read the `CapacityProvisioned` annotation on Fargate-scheduled pods — it shows the billed vCPU/memory combination for each pod. Compare it against the pod's aggregate container requests.
 
 **Detection outcome:**
 
-- If no Fargate profiles exist → skip this reference entirely; note "Fargate: not used" in the report.
+- If no Fargate profiles exist → skip this reference entirely; note "Fargate Profiles: none" in the report.
 - If profiles exist → record which namespaces (and label selectors) are Fargate-scheduled, exclude Fargate pods from node-based checks (idle nodes, consolidation, node-based estimation), and run checks F1 and F2 below. List the Fargate-scheduled namespaces in the report metadata.
 
 A profile selector always contains a namespace and may include labels (up to 5 selectors per profile; `*` and `?` wildcards are allowed in selector criteria).
@@ -132,7 +132,8 @@ Also surface Compute Savings Plans coverage for clusters with significant steady
 
 | Condition | Severity |
 |-----------|----------|
-| Spot-eligible Fargate workloads with monthly savings > $200 | HIGH |
+| Spot-eligible Fargate workloads with monthly savings > $500 | CRITICAL |
+| Spot-eligible Fargate workloads with monthly savings $200–$500 | HIGH |
 | Spot-eligible Fargate workloads with monthly savings $50–$200 | MEDIUM |
 | Below $50/month or migration blocked (e.g., isolation requirement drove the Fargate choice) | LOW |
 

--- a/devops-agent/eks-cost-intelligence/references/fargate-costs.md
+++ b/devops-agent/eks-cost-intelligence/references/fargate-costs.md
@@ -1,0 +1,186 @@
+# Fargate Cost Checks
+
+> **Part of:** [eks-cost-intelligence](../SKILL.md)
+> **Purpose:** Fargate profile detection for Step 0, plus Fargate-specific cost checks — pod request right-sizing against Fargate's vCPU/memory combinations, and capacity strategy for interruption-tolerant Fargate workloads
+>
+> Facts verified 2026-07-17 against https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html, https://docs.aws.amazon.com/eks/latest/userguide/fargate.html, and https://docs.aws.amazon.com/savingsplans/latest/userguide/sp-services.html
+
+---
+
+## Why Fargate Needs Its Own Checks
+
+EKS Fargate has a fundamentally different cost model from EC2 nodes:
+
+- **Billing is per pod, based on provisioned vCPU/memory** — not on node capacity. Fargate rounds each pod's resource requests **up** to the nearest valid vCPU/memory combination and bills for that provisioned capacity (visible in the pod's `CapacityProvisioned` annotation), regardless of actual utilization.
+- **One pod per Fargate node.** There is no bin-packing, no idle-node concept, and no consolidation. Node-based checks (idle nodes, Karpenter consolidation, node-based cost estimation) do NOT apply to Fargate-scheduled pods — exclude them from those checks.
+- **Requests equal limits.** All Fargate pods run with Guaranteed QoS, so over-stated requests translate directly into over-billed capacity.
+- **No Spot tier.** As of 2026-07-17, Amazon EKS does not support Fargate Spot (Fargate Spot exists for ECS only). Savings levers for Fargate on EKS are request right-sizing, Compute Savings Plans (Fargate is eligible), or migrating interruption-tolerant workloads to EC2 Spot capacity.
+
+---
+
+## Detection (runs in Step 0 pre-flight)
+
+**Via EKS APIs:**
+
+- Use the EKS ListFargateProfiles API for the target cluster.
+- For each profile returned, use the EKS DescribeFargateProfile API and extract: profile name, status, selectors (namespace + optional labels), and subnets.
+
+**Via Kubernetes API:**
+
+- List nodes with label `eks.amazonaws.com/compute-type=fargate` to identify Fargate-backed nodes.
+- List pods and read the `CapacityProvisioned` annotation on Fargate-scheduled pods — it shows the billed vCPU/memory combination for each pod. Compare it against the pod's aggregate container requests.
+
+**Detection outcome:**
+
+- If no Fargate profiles exist → skip this reference entirely; note "Fargate: not used" in the report.
+- If profiles exist → record which namespaces (and label selectors) are Fargate-scheduled, exclude Fargate pods from node-based checks (idle nodes, consolidation, node-based estimation), and run checks F1 and F2 below. List the Fargate-scheduled namespaces in the report metadata.
+
+A profile selector always contains a namespace and may include labels (up to 5 selectors per profile; `*` and `?` wildcards are allowed in selector criteria).
+
+---
+
+## Check F1: Right-Size Pod Requests to Fargate Combinations
+
+### What it detects
+
+Fargate pods whose requests round up into a larger billed combination than the workload needs. You pay for the rounded-up combination, not the raw request — so a request sitting just above a combination boundary wastes the entire gap to the next tier.
+
+### Fargate vCPU/memory combinations
+
+Fargate provisions the smallest combination that fits the pod's aggregate request **plus 256 MB** of memory overhead reserved for Kubernetes components (kubelet, kube-proxy, containerd). If no requests are specified, the smallest combination (.25 vCPU / 0.5 GB) is used.
+
+> Facts verified 2026-07-17 against https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html
+
+| vCPU value | Memory values |
+|-----------|---------------|
+| .25 vCPU | 0.5 GB, 1 GB, 2 GB |
+| .5 vCPU | 1 GB, 2 GB, 3 GB, 4 GB |
+| 1 vCPU | 2–8 GB in 1-GB increments |
+| 2 vCPU | 4–16 GB in 1-GB increments |
+| 4 vCPU | 8–30 GB in 1-GB increments |
+| 8 vCPU | 16–60 GB in 4-GB increments |
+| 16 vCPU | 32–120 GB in 8-GB increments |
+
+The 256 MB overhead can bump a pod into a larger tier: per the AWS docs example, a request of 1 vCPU / 8 GB becomes 8 GB + 256 MB, which doesn't fit any 1-vCPU combination — Fargate provisions **2 vCPU / 9 GB**.
+
+### Analysis logic
+
+```
+For each Fargate-scheduled pod:
+  billed = parse CapacityProvisioned annotation (e.g., "0.5vCPU 2GB")
+  requested = sum of container requests (+ init-container max rule)
+
+  # Boundary waste: request lands just above a combination boundary
+  If (requested + 256MB) marginally exceeds a smaller combination:
+    → Finding: trimming requests slightly would drop the pod a full tier
+    monthly_waste = (billed_tier_cost - smaller_tier_cost) × 730h × replica_count
+
+  # Utilization waste: billed capacity far above P95 usage (when metrics available)
+  If P95 usage < 50% of billed capacity:
+    → Finding: right-size requests toward P95 + headroom, re-check tier fit
+```
+
+Use Fargate per-vCPU-hour and per-GB-hour rates from the AWS Price List API or https://aws.amazon.com/fargate/pricing/ — do not hardcode rates.
+
+### Severity classification
+
+Severity follows the standard monthly-waste thresholds (see `findings-format.md`): >$500 CRITICAL, $200–$500 HIGH, $50–$200 MEDIUM, <$50 LOW.
+
+### Remediation
+
+```yaml
+# Right-size requests so (requests + 256MB) fits the intended combination
+# Example: fit into the 0.5 vCPU / 1 GB tier
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "768Mi"   # 768Mi + 256MB overhead ≈ 1 GB tier
+          limits:
+            cpu: "500m"       # Fargate enforces requests == limits (Guaranteed QoS)
+            memory: "768Mi"
+```
+
+---
+
+## Check F2: Interruption-Tolerant Workloads on Fargate
+
+### What it detects
+
+Workloads that meet the Spot-eligibility criteria (stateless Deployment, replicas ≥ 2, PDB present — see Check 5 in `spot-graviton-adoption.md`) but run on Fargate. As of 2026-07-17, **Amazon EKS does not support Fargate Spot**, so these workloads cannot get a Spot discount while staying on Fargate.
+
+### Analysis logic
+
+```
+For each Spot-eligible workload scheduled on Fargate:
+  → Finding: interruption-tolerant workload on Fargate (no Spot tier available on EKS)
+  Options, in savings order:
+    1. Migrate to EC2 Spot capacity (Karpenter NodePool or Spot node group)
+       — up to 90% discount vs On-Demand; use ~60% for conservative estimates
+    2. Cover steady Fargate usage with a Compute Savings Plan
+       — Fargate is eligible for Compute Savings Plans
+  monthly_savings (option 1) ≈ fargate_monthly_cost × 0.60 (conservative)
+```
+
+Also surface Compute Savings Plans coverage for clusters with significant steady Fargate spend even when workloads are not Spot-eligible (informational, consistent with the SP/RI out-of-scope rule — coverage notes only, not scored).
+
+### Severity classification
+
+| Condition | Severity |
+|-----------|----------|
+| Spot-eligible Fargate workloads with monthly savings > $200 | HIGH |
+| Spot-eligible Fargate workloads with monthly savings $50–$200 | MEDIUM |
+| Below $50/month or migration blocked (e.g., isolation requirement drove the Fargate choice) | LOW |
+
+### Remediation
+
+```yaml
+# Karpenter NodePool for migrating interruption-tolerant Fargate workloads to EC2 Spot
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: spot-migration
+spec:
+  template:
+    spec:
+      requirements:
+      - key: karpenter.sh/capacity-type
+        operator: In
+        values: ["spot", "on-demand"]
+      - key: karpenter.k8s.aws/instance-category
+        operator: In
+        values: ["m", "c", "r"]
+```
+
+Then remove (or narrow) the Fargate profile selector matching the workload's namespace/labels so pods schedule onto EC2 nodes. Note: Fargate profiles are immutable — create a replacement profile without the selector, then delete the old one.
+
+---
+
+## Scoring Contribution
+
+Fargate findings feed **existing dimensions** — no new dimension is added:
+
+- Check F1 findings → **Compute Efficiency** (dimension `compute`)
+- Check F2 findings → **Spot/Graviton Adoption** (dimension `spot_graviton`)
+
+Severity-weighted deductions and caps follow the standard rules in `report-generation.md`.
+
+---
+
+## Sources
+
+- [Fargate Pod vCPU and memory configuration](https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html) — combination table, 256 MB overhead, rounding behavior, `CapacityProvisioned` annotation
+- [AWS Fargate considerations for Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html) — one pod per compute boundary, "Amazon EKS doesn't support Fargate Spot", DaemonSet/EBS limitations
+- [Define which Pods use AWS Fargate when launched](https://docs.aws.amazon.com/eks/latest/userguide/fargate-profile.html) — profile selectors (namespace + labels, up to 5, wildcards), profile immutability
+- [Services eligible for Savings Plans benefits](https://docs.aws.amazon.com/savingsplans/latest/userguide/sp-services.html) — Fargate is eligible for Compute Savings Plans
+- [AWS Fargate Pricing](https://aws.amazon.com/fargate/pricing/) — per-vCPU-hour and per-GB-hour rates
+
+---
+
+*This reference file is part of the eks-cost-intelligence skill, provided as sample code
+for educational and demonstration purposes only. See the project's README and LICENSE
+for full terms.*

--- a/devops-agent/eks-cost-intelligence/references/iam-policy.json
+++ b/devops-agent/eks-cost-intelligence/references/iam-policy.json
@@ -10,7 +10,8 @@
         "eks:ListNodegroups",
         "eks:DescribeNodegroup",
         "eks:ListAddons",
-        "eks:ListFargateProfiles"
+        "eks:ListFargateProfiles",
+        "eks:DescribeFargateProfile"
       ],
       "Resource": "*"
     },

--- a/devops-agent/eks-cost-intelligence/references/report-generation.md
+++ b/devops-agent/eks-cost-intelligence/references/report-generation.md
@@ -161,8 +161,10 @@ Recommendations in the report are sorted by:
 | Cluster | {cluster_name} |
 | Region | {region} |
 | Assessment Date | {YYYY-MM-DD HH:MM} |
+| Analysis Window | {lookback_window, e.g. "7 days (default)" or "30 days (user-specified)"} |
 | Total Estimated Spend | ${total_spend}/month |
 | Data Sources | {data_sources_list} |
+| Fargate Profiles | {none | list of profiles with Fargate-scheduled namespaces} |
 
 ---
 

--- a/misc/website/docs/devops-agent/eks-cost-intelligence/index.md
+++ b/misc/website/docs/devops-agent/eks-cost-intelligence/index.md
@@ -32,6 +32,8 @@ The following permissions are included:
 - `eks:ListNodegroups`
 - `eks:DescribeNodegroup`
 - `eks:ListAddons`
+- `eks:ListFargateProfiles`
+- `eks:DescribeFargateProfile`
 
 **EC2 (required):**
 - `ec2:DescribeInstances`
@@ -130,6 +132,7 @@ Collect the following using AWS and Kubernetes APIs:
 - Kubernetes version and platform version (from DescribeCluster response)
 - Node groups: use EKS ListNodegroups and DescribeNodegroup APIs for instance types, scaling config, capacity type (ON_DEMAND/SPOT)
 - Add-ons: use EKS ListAddons API
+- Fargate profiles: use EKS ListFargateProfiles API — if any profiles exist, use DescribeFargateProfile for each, note which namespaces/label selectors are Fargate-scheduled, and read `references/fargate-costs.md`. Fargate pods are billed on rounded-up pod requests (not node capacity), so exclude them from node-based checks and add the Fargate-specific checks to Steps 1–2.
 - Node inventory: use Kubernetes API to list nodes with labels and capacity info
 - Namespace list: use Kubernetes API to list namespaces
 
@@ -147,6 +150,7 @@ Checks:
 - Low-utilization nodes indicating consolidation opportunities
 - Karpenter consolidation effectiveness (where installed)
 - Workloads without resource requests or limits
+- Fargate pod request right-sizing against Fargate's vCPU/memory combinations — only when Step 0 found Fargate profiles (read `references/fargate-costs.md`, Check F1)
 
 Data collection uses:
 - Kubernetes API to list pods with resource requests/limits per namespace
@@ -167,6 +171,7 @@ Checks:
 - Stateless multi-replica workloads on On-Demand only
 - Instance type diversity for Spot availability
 - Node Termination Handler or Karpenter interruption handling
+- Interruption-tolerant workloads running on Fargate (EKS has no Fargate Spot) — only when Step 0 found Fargate profiles (read `references/fargate-costs.md`, Check F2)
 
 Data collection uses:
 - Kubernetes API to list nodes (labels: `kubernetes.io/arch`, `karpenter.sh/capacity-type`, `eks.amazonaws.com/capacityType`)
@@ -305,6 +310,10 @@ The skill calculates a weighted cost efficiency score:
 
 If Cost Explorer is unavailable, the skill falls back to node-based cost estimation (see `references/cost-estimation-fallback.md`).
 
+### Default Time Window
+
+Cost Explorer queries use a **7-day lookback by default** (matching the 7-day window used for CloudWatch utilization checks). If the request names a different window (e.g., "last 30 days"), apply the requested window to all Cost Explorer queries. Whichever window is used, record it in the report metadata (`Analysis Window` field) so findings are reproducible and comparable across runs.
+
 ---
 
 ## Out of Scope (v1)
@@ -344,6 +353,7 @@ Before executing checks for any dimension, read the corresponding reference file
 | Storage costs / gp2 / PVC / EBS | `references/storage-costs.md` |
 | Observability / logging / metrics / cardinality | `references/observability-costs.md` |
 | Idle resources / unused / orphaned / zero-scale | `references/idle-resources.md` |
+| Fargate profiles / Fargate pod pricing / request rounding | `references/fargate-costs.md` |
 | Score calculation / scoring algorithm | `references/report-generation.md` |
 | Generate report / produce report | `references/report-generation.md` |
 | Cost data collection / API calls | `references/cost-data-collection.md` |

--- a/misc/website/docs/devops-agent/eks-cost-intelligence/references/cost-data-collection.md
+++ b/misc/website/docs/devops-agent/eks-cost-intelligence/references/cost-data-collection.md
@@ -44,7 +44,11 @@ This reference documents the exact API calls needed to collect cost and utilizat
 - IAM permission: `ce:GetCostAndUsage`, `ce:GetSavingsPlansCoverage`
 - Cost Explorer API is only available in `us-east-1` regardless of cluster region
 
-### 1.1 Total EKS Spend by Service (Last 30 Days)
+### Time Window
+
+All Cost Explorer queries in this reference use a **7-day lookback by default**, matching the 7-day window used for CloudWatch utilization metrics. If the request names a different window (e.g., "last 30 days"), apply the override consistently to every Cost Explorer query in the assessment and record the window used in the report metadata (`Analysis Window` field). The examples below show a 30-day window for illustration; substitute the active analysis window.
+
+### 1.1 Total EKS Spend by Service
 
 **Via Cost Explorer GetCostAndUsage API:**
 

--- a/misc/website/docs/devops-agent/eks-cost-intelligence/references/cost-estimation-fallback.md
+++ b/misc/website/docs/devops-agent/eks-cost-intelligence/references/cost-estimation-fallback.md
@@ -118,7 +118,7 @@ Use the Kubernetes API to list all Nodes. Extract metadata.labels for instance-t
 > ⚠️ **Last verified: June 2026.** This table is a fallback for when the Price List API (Option B) is unavailable. Prices may drift. Always prefer Option B for production assessments.
 
 Use this table ONLY when:
-- `pricing:GetProducts` permission is not available
+- `pricing:GetProducts` permission is not available (it is not in the skill's baseline IAM policy — using the Price List API requires adding `pricing:GetProducts` to `references/iam-policy.json`)
 - Network-restricted environment cannot reach the Price List API endpoint
 - Quick directional estimate needed (mark all findings as Low confidence)
 

--- a/misc/website/docs/devops-agent/eks-cost-intelligence/references/fargate-costs.md
+++ b/misc/website/docs/devops-agent/eks-cost-intelligence/references/fargate-costs.md
@@ -1,0 +1,197 @@
+---
+title: "Fargate Cost Checks"
+description: ""
+custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/devops-agent/eks-cost-intelligence/references/fargate-costs.md
+format: md
+---
+
+:::info[Source]
+This page is generated from [devops-agent/eks-cost-intelligence/references/fargate-costs.md](https://github.com/aws-samples/sample-apex-skills/blob/main/devops-agent/eks-cost-intelligence/references/fargate-costs.md). Edit the source, not this page.
+:::
+
+# Fargate Cost Checks
+
+> **Part of:** [eks-cost-intelligence](../)
+> **Purpose:** Fargate profile detection for Step 0, plus Fargate-specific cost checks — pod request right-sizing against Fargate's vCPU/memory combinations, and capacity strategy for interruption-tolerant Fargate workloads
+>
+> Facts verified 2026-07-17 against https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html, https://docs.aws.amazon.com/eks/latest/userguide/fargate.html, and https://docs.aws.amazon.com/savingsplans/latest/userguide/sp-services.html
+
+---
+
+## Why Fargate Needs Its Own Checks
+
+EKS Fargate has a fundamentally different cost model from EC2 nodes:
+
+- **Billing is per pod, based on provisioned vCPU/memory** — not on node capacity. Fargate rounds each pod's resource requests **up** to the nearest valid vCPU/memory combination and bills for that provisioned capacity (visible in the pod's `CapacityProvisioned` annotation), regardless of actual utilization.
+- **One pod per Fargate node.** There is no bin-packing, no idle-node concept, and no consolidation. Node-based checks (idle nodes, Karpenter consolidation, node-based cost estimation) do NOT apply to Fargate-scheduled pods — exclude them from those checks.
+- **Requests equal limits.** All Fargate pods run with Guaranteed QoS, so over-stated requests translate directly into over-billed capacity.
+- **No Spot tier.** As of 2026-07-17, Amazon EKS does not support Fargate Spot (Fargate Spot exists for ECS only). Savings levers for Fargate on EKS are request right-sizing, Compute Savings Plans (Fargate is eligible), or migrating interruption-tolerant workloads to EC2 Spot capacity.
+
+---
+
+## Detection (runs in Step 0 pre-flight)
+
+**Via EKS APIs:**
+
+- Use the EKS ListFargateProfiles API for the target cluster.
+- For each profile returned, use the EKS DescribeFargateProfile API and extract: profile name, status, selectors (namespace + optional labels), and subnets.
+
+**Via Kubernetes API:**
+
+- List nodes with label `eks.amazonaws.com/compute-type=fargate` to identify Fargate-backed nodes.
+- List pods and read the `CapacityProvisioned` annotation on Fargate-scheduled pods — it shows the billed vCPU/memory combination for each pod. Compare it against the pod's aggregate container requests.
+
+**Detection outcome:**
+
+- If no Fargate profiles exist → skip this reference entirely; note "Fargate: not used" in the report.
+- If profiles exist → record which namespaces (and label selectors) are Fargate-scheduled, exclude Fargate pods from node-based checks (idle nodes, consolidation, node-based estimation), and run checks F1 and F2 below. List the Fargate-scheduled namespaces in the report metadata.
+
+A profile selector always contains a namespace and may include labels (up to 5 selectors per profile; `*` and `?` wildcards are allowed in selector criteria).
+
+---
+
+## Check F1: Right-Size Pod Requests to Fargate Combinations
+
+### What it detects
+
+Fargate pods whose requests round up into a larger billed combination than the workload needs. You pay for the rounded-up combination, not the raw request — so a request sitting just above a combination boundary wastes the entire gap to the next tier.
+
+### Fargate vCPU/memory combinations
+
+Fargate provisions the smallest combination that fits the pod's aggregate request **plus 256 MB** of memory overhead reserved for Kubernetes components (kubelet, kube-proxy, containerd). If no requests are specified, the smallest combination (.25 vCPU / 0.5 GB) is used.
+
+> Facts verified 2026-07-17 against https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html
+
+| vCPU value | Memory values |
+|-----------|---------------|
+| .25 vCPU | 0.5 GB, 1 GB, 2 GB |
+| .5 vCPU | 1 GB, 2 GB, 3 GB, 4 GB |
+| 1 vCPU | 2–8 GB in 1-GB increments |
+| 2 vCPU | 4–16 GB in 1-GB increments |
+| 4 vCPU | 8–30 GB in 1-GB increments |
+| 8 vCPU | 16–60 GB in 4-GB increments |
+| 16 vCPU | 32–120 GB in 8-GB increments |
+
+The 256 MB overhead can bump a pod into a larger tier: per the AWS docs example, a request of 1 vCPU / 8 GB becomes 8 GB + 256 MB, which doesn't fit any 1-vCPU combination — Fargate provisions **2 vCPU / 9 GB**.
+
+### Analysis logic
+
+```
+For each Fargate-scheduled pod:
+  billed = parse CapacityProvisioned annotation (e.g., "0.5vCPU 2GB")
+  requested = sum of container requests (+ init-container max rule)
+
+  # Boundary waste: request lands just above a combination boundary
+  If (requested + 256MB) marginally exceeds a smaller combination:
+    → Finding: trimming requests slightly would drop the pod a full tier
+    monthly_waste = (billed_tier_cost - smaller_tier_cost) × 730h × replica_count
+
+  # Utilization waste: billed capacity far above P95 usage (when metrics available)
+  If P95 usage < 50% of billed capacity:
+    → Finding: right-size requests toward P95 + headroom, re-check tier fit
+```
+
+Use Fargate per-vCPU-hour and per-GB-hour rates from the AWS Price List API or https://aws.amazon.com/fargate/pricing/ — do not hardcode rates.
+
+### Severity classification
+
+Severity follows the standard monthly-waste thresholds (see `findings-format.md`): >$500 CRITICAL, $200–$500 HIGH, $50–$200 MEDIUM, <$50 LOW.
+
+### Remediation
+
+```yaml
+# Right-size requests so (requests + 256MB) fits the intended combination
+# Example: fit into the 0.5 vCPU / 1 GB tier
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "768Mi"   # 768Mi + 256MB overhead ≈ 1 GB tier
+          limits:
+            cpu: "500m"       # Fargate enforces requests == limits (Guaranteed QoS)
+            memory: "768Mi"
+```
+
+---
+
+## Check F2: Interruption-Tolerant Workloads on Fargate
+
+### What it detects
+
+Workloads that meet the Spot-eligibility criteria (stateless Deployment, replicas ≥ 2, PDB present — see Check 5 in `spot-graviton-adoption.md`) but run on Fargate. As of 2026-07-17, **Amazon EKS does not support Fargate Spot**, so these workloads cannot get a Spot discount while staying on Fargate.
+
+### Analysis logic
+
+```
+For each Spot-eligible workload scheduled on Fargate:
+  → Finding: interruption-tolerant workload on Fargate (no Spot tier available on EKS)
+  Options, in savings order:
+    1. Migrate to EC2 Spot capacity (Karpenter NodePool or Spot node group)
+       — up to 90% discount vs On-Demand; use ~60% for conservative estimates
+    2. Cover steady Fargate usage with a Compute Savings Plan
+       — Fargate is eligible for Compute Savings Plans
+  monthly_savings (option 1) ≈ fargate_monthly_cost × 0.60 (conservative)
+```
+
+Also surface Compute Savings Plans coverage for clusters with significant steady Fargate spend even when workloads are not Spot-eligible (informational, consistent with the SP/RI out-of-scope rule — coverage notes only, not scored).
+
+### Severity classification
+
+| Condition | Severity |
+|-----------|----------|
+| Spot-eligible Fargate workloads with monthly savings > $200 | HIGH |
+| Spot-eligible Fargate workloads with monthly savings $50–$200 | MEDIUM |
+| Below $50/month or migration blocked (e.g., isolation requirement drove the Fargate choice) | LOW |
+
+### Remediation
+
+```yaml
+# Karpenter NodePool for migrating interruption-tolerant Fargate workloads to EC2 Spot
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: spot-migration
+spec:
+  template:
+    spec:
+      requirements:
+      - key: karpenter.sh/capacity-type
+        operator: In
+        values: ["spot", "on-demand"]
+      - key: karpenter.k8s.aws/instance-category
+        operator: In
+        values: ["m", "c", "r"]
+```
+
+Then remove (or narrow) the Fargate profile selector matching the workload's namespace/labels so pods schedule onto EC2 nodes. Note: Fargate profiles are immutable — create a replacement profile without the selector, then delete the old one.
+
+---
+
+## Scoring Contribution
+
+Fargate findings feed **existing dimensions** — no new dimension is added:
+
+- Check F1 findings → **Compute Efficiency** (dimension `compute`)
+- Check F2 findings → **Spot/Graviton Adoption** (dimension `spot_graviton`)
+
+Severity-weighted deductions and caps follow the standard rules in `report-generation.md`.
+
+---
+
+## Sources
+
+- [Fargate Pod vCPU and memory configuration](https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html) — combination table, 256 MB overhead, rounding behavior, `CapacityProvisioned` annotation
+- [AWS Fargate considerations for Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html) — one pod per compute boundary, "Amazon EKS doesn't support Fargate Spot", DaemonSet/EBS limitations
+- [Define which Pods use AWS Fargate when launched](https://docs.aws.amazon.com/eks/latest/userguide/fargate-profile.html) — profile selectors (namespace + labels, up to 5, wildcards), profile immutability
+- [Services eligible for Savings Plans benefits](https://docs.aws.amazon.com/savingsplans/latest/userguide/sp-services.html) — Fargate is eligible for Compute Savings Plans
+- [AWS Fargate Pricing](https://aws.amazon.com/fargate/pricing/) — per-vCPU-hour and per-GB-hour rates
+
+---
+
+*This reference file is part of the eks-cost-intelligence skill, provided as sample code
+for educational and demonstration purposes only. See the project's README and LICENSE
+for full terms.*

--- a/misc/website/docs/devops-agent/eks-cost-intelligence/references/fargate-costs.md
+++ b/misc/website/docs/devops-agent/eks-cost-intelligence/references/fargate-costs.md
@@ -38,12 +38,12 @@ EKS Fargate has a fundamentally different cost model from EC2 nodes:
 
 **Via Kubernetes API:**
 
-- List nodes with label `eks.amazonaws.com/compute-type=fargate` to identify Fargate-backed nodes.
+- List nodes with label `eks.amazonaws.com/compute-type=fargate` to identify Fargate-backed nodes. Fallback: Fargate node names start with `fargate-` (e.g., filter the node list for names beginning with `fargate-`).
 - List pods and read the `CapacityProvisioned` annotation on Fargate-scheduled pods — it shows the billed vCPU/memory combination for each pod. Compare it against the pod's aggregate container requests.
 
 **Detection outcome:**
 
-- If no Fargate profiles exist → skip this reference entirely; note "Fargate: not used" in the report.
+- If no Fargate profiles exist → skip this reference entirely; note "Fargate Profiles: none" in the report.
 - If profiles exist → record which namespaces (and label selectors) are Fargate-scheduled, exclude Fargate pods from node-based checks (idle nodes, consolidation, node-based estimation), and run checks F1 and F2 below. List the Fargate-scheduled namespaces in the report metadata.
 
 A profile selector always contains a namespace and may include labels (up to 5 selectors per profile; `*` and `?` wildcards are allowed in selector criteria).
@@ -143,7 +143,8 @@ Also surface Compute Savings Plans coverage for clusters with significant steady
 
 | Condition | Severity |
 |-----------|----------|
-| Spot-eligible Fargate workloads with monthly savings > $200 | HIGH |
+| Spot-eligible Fargate workloads with monthly savings > $500 | CRITICAL |
+| Spot-eligible Fargate workloads with monthly savings $200–$500 | HIGH |
 | Spot-eligible Fargate workloads with monthly savings $50–$200 | MEDIUM |
 | Below $50/month or migration blocked (e.g., isolation requirement drove the Fargate choice) | LOW |
 

--- a/misc/website/docs/devops-agent/eks-cost-intelligence/references/report-generation.md
+++ b/misc/website/docs/devops-agent/eks-cost-intelligence/references/report-generation.md
@@ -172,8 +172,10 @@ Recommendations in the report are sorted by:
 | Cluster | {cluster_name} |
 | Region | {region} |
 | Assessment Date | {YYYY-MM-DD HH:MM} |
+| Analysis Window | {lookback_window, e.g. "7 days (default)" or "30 days (user-specified)"} |
 | Total Estimated Spend | ${total_spend}/month |
 | Data Sources | {data_sources_list} |
+| Fargate Profiles | {none | list of profiles with Fargate-scheduled namespaces} |
 
 ---
 

--- a/misc/website/docs/skills/eks/eks-cost-intelligence/README.md
+++ b/misc/website/docs/skills/eks/eks-cost-intelligence/README.md
@@ -47,6 +47,7 @@ skills/eks-cost-intelligence/
 │   ├── storage-costs.md                  # Dimension 4 checks
 │   ├── observability-costs.md            # Dimension 5 checks
 │   ├── idle-resources.md                 # Dimension 6 checks
+│   ├── fargate-costs.md                  # Fargate detection + Fargate-specific checks
 │   ├── report-generation.md              # Scoring algorithm + report template
 │   ├── cost-data-collection.md           # API calls for data sources
 │   ├── waste-calculation.md              # Dollar waste formulas

--- a/misc/website/docs/skills/eks/eks-cost-intelligence/index.md
+++ b/misc/website/docs/skills/eks/eks-cost-intelligence/index.md
@@ -52,7 +52,7 @@ This skill is focused on **live cost assessment** — answering the question: "W
 1. **AWS credentials configured** — `aws configure` or `~/.aws/credentials` with EKS access
 2. **kubectl access** to the target cluster (for Kubernetes API queries)
 3. **Required AWS Permissions (minimum):**
-   - `eks:DescribeCluster`, `eks:ListClusters`, `eks:ListNodegroups`, `eks:DescribeNodegroup`
+   - `eks:DescribeCluster`, `eks:ListClusters`, `eks:ListNodegroups`, `eks:DescribeNodegroup`, `eks:ListFargateProfiles`, `eks:DescribeFargateProfile`
    - `ec2:DescribeInstances`, `ec2:DescribeVolumes`, `ec2:DescribeSubnets`, `ec2:DescribeVpcEndpoints`
    - `elasticloadbalancing:DescribeLoadBalancers`, `elasticloadbalancing:DescribeTargetHealth`
 4. **Optional permissions (enable richer analysis):**
@@ -69,6 +69,10 @@ This skill is focused on **live cost assessment** — answering the question: "W
 | **EC2 API** | `aws ec2 describe-instances` | Instance types, pricing tier, Spot vs On-Demand |
 
 If Cost Explorer is unavailable, the skill falls back to node-based cost estimation (see `references/cost-estimation-fallback.md`).
+
+### Default Time Window
+
+Cost Explorer queries use a **7-day lookback by default** (matching the 7-day window used for CloudWatch utilization checks). The user can override the window by asking — e.g., *"use the last 30 days"* — in which case apply the requested window to all Cost Explorer queries. Whichever window is used, record it in the report metadata (`Analysis Window` field) so findings are reproducible and comparable across runs.
 
 ### MCP Server Setup
 
@@ -121,6 +125,7 @@ Collect:
 - Node groups: `aws eks list-nodegroups --cluster-name <cluster>`
 - Node group details: instance types, scaling config, capacity type (ON_DEMAND/SPOT)
 - Add-ons: `aws eks list-addons --cluster-name <cluster>`
+- Fargate profiles: `aws eks list-fargate-profiles --cluster-name <cluster>` — if any profiles exist, describe each one, note which namespaces/label selectors are Fargate-scheduled, and read `references/fargate-costs.md`. Fargate pods are billed on rounded-up pod requests (not node capacity), so exclude them from node-based checks and add the Fargate-specific checks to Steps 1–2.
 - Node inventory: `kubectl get nodes -o wide`
 
 **Action 5 — Confirm and proceed**
@@ -139,6 +144,7 @@ Checks:
 - Low-utilization nodes indicating consolidation opportunities
 - Karpenter consolidation effectiveness (where installed)
 - Workloads without resource requests or limits
+- Fargate pod request right-sizing against Fargate's vCPU/memory combinations — only when Step 0 found Fargate profiles (read `references/fargate-costs.md`, Check F1)
 
 If metrics-server or Container Insights is unavailable, mark utilization checks as SKIPPED and proceed with request-only analysis.
 
@@ -154,6 +160,7 @@ Checks:
 - Stateless multi-replica workloads on On-Demand only
 - Instance type diversity for Spot availability
 - Node Termination Handler or Karpenter interruption handling
+- Interruption-tolerant workloads running on Fargate (EKS has no Fargate Spot) — only when Step 0 found Fargate profiles (read `references/fargate-costs.md`, Check F2)
 
 ### Step 3: Networking Cost Assessment
 
@@ -283,6 +290,7 @@ Before executing checks for any dimension, read the corresponding reference file
 | Storage costs / gp2 / PVC / EBS | `references/storage-costs.md` |
 | Observability / logging / metrics / cardinality | `references/observability-costs.md` |
 | Idle resources / unused / orphaned / zero-scale | `references/idle-resources.md` |
+| Fargate profiles / Fargate pod pricing / request rounding | `references/fargate-costs.md` |
 | Score calculation / scoring algorithm | `references/report-generation.md` |
 | Generate report / produce report | `references/report-generation.md` |
 | Cost data collection / API calls | `references/cost-data-collection.md` |

--- a/misc/website/docs/skills/eks/eks-cost-intelligence/references/cost-data-collection.md
+++ b/misc/website/docs/skills/eks/eks-cost-intelligence/references/cost-data-collection.md
@@ -45,7 +45,11 @@ This reference documents the exact API calls needed to collect cost and utilizat
 - IAM permission: `ce:GetCostAndUsage`, `ce:GetSavingsPlansCoverage`
 - Cost Explorer API is only available in `us-east-1` regardless of cluster region
 
-### 1.1 Total EKS Spend by Service (Last 30 Days)
+### Time Window
+
+All Cost Explorer queries in this reference use a **7-day lookback by default**, matching the 7-day window used for CloudWatch utilization metrics. The user can override the window (e.g., "last 30 days") — apply the override consistently to every Cost Explorer query in the assessment and record the window used in the report metadata (`Analysis Window` field). The examples below show a 30-day window for illustration; substitute the active analysis window.
+
+### 1.1 Total EKS Spend by Service
 
 **Via EKS MCP Server:**
 ```

--- a/misc/website/docs/skills/eks/eks-cost-intelligence/references/fargate-costs.md
+++ b/misc/website/docs/skills/eks/eks-cost-intelligence/references/fargate-costs.md
@@ -1,0 +1,213 @@
+---
+title: "Fargate Cost Checks"
+description: ""
+custom_edit_url: https://github.com/aws-samples/sample-apex-skills/blob/main/skills/eks-cost-intelligence/references/fargate-costs.md
+format: md
+---
+
+:::info[Source]
+This page is generated from [skills/eks-cost-intelligence/references/fargate-costs.md](https://github.com/aws-samples/sample-apex-skills/blob/main/skills/eks-cost-intelligence/references/fargate-costs.md). Edit the source, not this page.
+:::
+
+# Fargate Cost Checks
+
+> **Part of:** [eks-cost-intelligence](../)
+> **Purpose:** Fargate profile detection for Step 0, plus Fargate-specific cost checks — pod request right-sizing against Fargate's vCPU/memory combinations, and capacity strategy for interruption-tolerant Fargate workloads
+>
+> Facts verified 2026-07-17 against https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html, https://docs.aws.amazon.com/eks/latest/userguide/fargate.html, and https://docs.aws.amazon.com/savingsplans/latest/userguide/sp-services.html
+
+---
+
+## Why Fargate Needs Its Own Checks
+
+EKS Fargate has a fundamentally different cost model from EC2 nodes:
+
+- **Billing is per pod, based on provisioned vCPU/memory** — not on node capacity. Fargate rounds each pod's resource requests **up** to the nearest valid vCPU/memory combination and bills for that provisioned capacity (visible in the pod's `CapacityProvisioned` annotation), regardless of actual utilization.
+- **One pod per Fargate node.** There is no bin-packing, no idle-node concept, and no consolidation. Node-based checks (idle nodes, Karpenter consolidation, node-based cost estimation) do NOT apply to Fargate-scheduled pods — exclude them from those checks.
+- **Requests equal limits.** All Fargate pods run with Guaranteed QoS, so over-stated requests translate directly into over-billed capacity.
+- **No Spot tier.** As of 2026-07-17, Amazon EKS does not support Fargate Spot (Fargate Spot exists for ECS only). Savings levers for Fargate on EKS are request right-sizing, Compute Savings Plans (Fargate is eligible), or migrating interruption-tolerant workloads to EC2 Spot capacity.
+
+---
+
+## Detection (runs in Step 0 pre-flight)
+
+**Via AWS CLI:**
+
+```bash
+# List Fargate profiles for the cluster
+aws eks list-fargate-profiles --cluster-name <cluster>
+
+# For each profile, capture its selectors (namespace + optional labels)
+aws eks describe-fargate-profile \
+  --cluster-name <cluster> \
+  --fargate-profile-name <profile> \
+  --query '{name: fargateProfile.fargateProfileName, status: fargateProfile.status, selectors: fargateProfile.selectors, subnets: fargateProfile.subnets}'
+```
+
+**Via kubectl (identify running Fargate pods and their provisioned capacity):**
+
+```bash
+# Fargate nodes carry the compute-type label
+kubectl get nodes -l eks.amazonaws.com/compute-type=fargate -o wide
+
+# The CapacityProvisioned annotation on a Fargate pod shows the billed combination
+kubectl get pods --all-namespaces -o json | \
+  jq -r '.items[] |
+    select(.metadata.annotations["CapacityProvisioned"] != null) |
+    "\(.metadata.namespace)/\(.metadata.name): requested cpu=\([.spec.containers[].resources.requests.cpu // "0"] | join("+")) mem=\([.spec.containers[].resources.requests.memory // "0"] | join("+")) → billed \(.metadata.annotations["CapacityProvisioned"])"'
+```
+
+**Detection outcome:**
+
+- If no Fargate profiles exist → skip this reference entirely; note "Fargate: not used" in the report.
+- If profiles exist → record which namespaces (and label selectors) are Fargate-scheduled, exclude Fargate pods from node-based checks (idle nodes, consolidation, node-based estimation), and run checks F1 and F2 below. List the Fargate-scheduled namespaces in the report metadata.
+
+A profile selector always contains a namespace and may include labels (up to 5 selectors per profile; `*` and `?` wildcards are allowed in selector criteria).
+
+---
+
+## Check F1: Right-Size Pod Requests to Fargate Combinations
+
+### What it detects
+
+Fargate pods whose requests round up into a larger billed combination than the workload needs. You pay for the rounded-up combination, not the raw request — so a request sitting just above a combination boundary wastes the entire gap to the next tier.
+
+### Fargate vCPU/memory combinations
+
+Fargate provisions the smallest combination that fits the pod's aggregate request **plus 256 MB** of memory overhead reserved for Kubernetes components (kubelet, kube-proxy, containerd). If no requests are specified, the smallest combination (.25 vCPU / 0.5 GB) is used.
+
+> Facts verified 2026-07-17 against https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html
+
+| vCPU value | Memory values |
+|-----------|---------------|
+| .25 vCPU | 0.5 GB, 1 GB, 2 GB |
+| .5 vCPU | 1 GB, 2 GB, 3 GB, 4 GB |
+| 1 vCPU | 2–8 GB in 1-GB increments |
+| 2 vCPU | 4–16 GB in 1-GB increments |
+| 4 vCPU | 8–30 GB in 1-GB increments |
+| 8 vCPU | 16–60 GB in 4-GB increments |
+| 16 vCPU | 32–120 GB in 8-GB increments |
+
+The 256 MB overhead can bump a pod into a larger tier: per the AWS docs example, a request of 1 vCPU / 8 GB becomes 8 GB + 256 MB, which doesn't fit any 1-vCPU combination — Fargate provisions **2 vCPU / 9 GB**.
+
+### Analysis logic
+
+```
+For each Fargate-scheduled pod:
+  billed = parse CapacityProvisioned annotation (e.g., "0.5vCPU 2GB")
+  requested = sum of container requests (+ init-container max rule)
+
+  # Boundary waste: request lands just above a combination boundary
+  If (requested + 256MB) marginally exceeds a smaller combination:
+    → Finding: trimming requests slightly would drop the pod a full tier
+    monthly_waste = (billed_tier_cost - smaller_tier_cost) × 730h × replica_count
+
+  # Utilization waste: billed capacity far above P95 usage (when metrics available)
+  If P95 usage < 50% of billed capacity:
+    → Finding: right-size requests toward P95 + headroom, re-check tier fit
+```
+
+Use Fargate per-vCPU-hour and per-GB-hour rates from the AWS Price List API (`pricing:GetProducts`) or https://aws.amazon.com/fargate/pricing/ — do not hardcode rates.
+
+### Severity classification
+
+Severity follows the standard monthly-waste thresholds (see `findings-format.md`): >$500 CRITICAL, $200–$500 HIGH, $50–$200 MEDIUM, <$50 LOW.
+
+### Remediation
+
+```yaml
+# Right-size requests so (requests + 256MB) fits the intended combination
+# Example: fit into the 0.5 vCPU / 1 GB tier
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "768Mi"   # 768Mi + 256MB overhead ≈ 1 GB tier
+          limits:
+            cpu: "500m"       # Fargate enforces requests == limits (Guaranteed QoS)
+            memory: "768Mi"
+```
+
+---
+
+## Check F2: Interruption-Tolerant Workloads on Fargate
+
+### What it detects
+
+Workloads that meet the Spot-eligibility criteria (stateless Deployment, replicas ≥ 2, PDB present — see Check 5 in `spot-graviton-adoption.md`) but run on Fargate. As of 2026-07-17, **Amazon EKS does not support Fargate Spot**, so these workloads cannot get a Spot discount while staying on Fargate.
+
+### Analysis logic
+
+```
+For each Spot-eligible workload scheduled on Fargate:
+  → Finding: interruption-tolerant workload on Fargate (no Spot tier available on EKS)
+  Options, in savings order:
+    1. Migrate to EC2 Spot capacity (Karpenter NodePool or Spot node group)
+       — up to 90% discount vs On-Demand; use ~60% for conservative estimates
+    2. Cover steady Fargate usage with a Compute Savings Plan
+       — Fargate is eligible for Compute Savings Plans
+  monthly_savings (option 1) ≈ fargate_monthly_cost × 0.60 (conservative)
+```
+
+Also surface Compute Savings Plans coverage for clusters with significant steady Fargate spend even when workloads are not Spot-eligible (informational, consistent with the SP/RI out-of-scope rule — coverage notes only, not scored).
+
+### Severity classification
+
+| Condition | Severity |
+|-----------|----------|
+| Spot-eligible Fargate workloads with monthly savings > $200 | HIGH |
+| Spot-eligible Fargate workloads with monthly savings $50–$200 | MEDIUM |
+| Below $50/month or migration blocked (e.g., isolation requirement drove the Fargate choice) | LOW |
+
+### Remediation
+
+```yaml
+# Karpenter NodePool for migrating interruption-tolerant Fargate workloads to EC2 Spot
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: spot-migration
+spec:
+  template:
+    spec:
+      requirements:
+      - key: karpenter.sh/capacity-type
+        operator: In
+        values: ["spot", "on-demand"]
+      - key: karpenter.k8s.aws/instance-category
+        operator: In
+        values: ["m", "c", "r"]
+```
+
+Then remove (or narrow) the Fargate profile selector matching the workload's namespace/labels so pods schedule onto EC2 nodes. Note: Fargate profiles are immutable — create a replacement profile without the selector, then delete the old one.
+
+---
+
+## Scoring Contribution
+
+Fargate findings feed **existing dimensions** — no new dimension is added:
+
+- Check F1 findings → **Compute Efficiency** (dimension `compute`)
+- Check F2 findings → **Spot/Graviton Adoption** (dimension `spot_graviton`)
+
+Severity-weighted deductions and caps follow the standard rules in `report-generation.md`.
+
+---
+
+## Sources
+
+- [Fargate Pod vCPU and memory configuration](https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html) — combination table, 256 MB overhead, rounding behavior, `CapacityProvisioned` annotation
+- [AWS Fargate considerations for Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html) — one pod per compute boundary, "Amazon EKS doesn't support Fargate Spot", DaemonSet/EBS limitations
+- [Define which Pods use AWS Fargate when launched](https://docs.aws.amazon.com/eks/latest/userguide/fargate-profile.html) — profile selectors (namespace + labels, up to 5, wildcards), profile immutability
+- [Services eligible for Savings Plans benefits](https://docs.aws.amazon.com/savingsplans/latest/userguide/sp-services.html) — Fargate is eligible for Compute Savings Plans
+- [AWS Fargate Pricing](https://aws.amazon.com/fargate/pricing/) — per-vCPU-hour and per-GB-hour rates
+
+---
+
+*This reference file is part of the eks-cost-intelligence skill, provided as sample code
+for educational and demonstration purposes only. See the project's README and LICENSE
+for full terms.*

--- a/misc/website/docs/skills/eks/eks-cost-intelligence/references/fargate-costs.md
+++ b/misc/website/docs/skills/eks/eks-cost-intelligence/references/fargate-costs.md
@@ -50,6 +50,9 @@ aws eks describe-fargate-profile \
 # Fargate nodes carry the compute-type label
 kubectl get nodes -l eks.amazonaws.com/compute-type=fargate -o wide
 
+# Fallback: Fargate node names start with "fargate-"
+kubectl get nodes | grep ^fargate-
+
 # The CapacityProvisioned annotation on a Fargate pod shows the billed combination
 kubectl get pods --all-namespaces -o json | \
   jq -r '.items[] |
@@ -59,7 +62,7 @@ kubectl get pods --all-namespaces -o json | \
 
 **Detection outcome:**
 
-- If no Fargate profiles exist → skip this reference entirely; note "Fargate: not used" in the report.
+- If no Fargate profiles exist → skip this reference entirely; note "Fargate Profiles: none" in the report.
 - If profiles exist → record which namespaces (and label selectors) are Fargate-scheduled, exclude Fargate pods from node-based checks (idle nodes, consolidation, node-based estimation), and run checks F1 and F2 below. List the Fargate-scheduled namespaces in the report metadata.
 
 A profile selector always contains a namespace and may include labels (up to 5 selectors per profile; `*` and `?` wildcards are allowed in selector criteria).
@@ -159,7 +162,8 @@ Also surface Compute Savings Plans coverage for clusters with significant steady
 
 | Condition | Severity |
 |-----------|----------|
-| Spot-eligible Fargate workloads with monthly savings > $200 | HIGH |
+| Spot-eligible Fargate workloads with monthly savings > $500 | CRITICAL |
+| Spot-eligible Fargate workloads with monthly savings $200–$500 | HIGH |
 | Spot-eligible Fargate workloads with monthly savings $50–$200 | MEDIUM |
 | Below $50/month or migration blocked (e.g., isolation requirement drove the Fargate choice) | LOW |
 

--- a/misc/website/docs/skills/eks/eks-cost-intelligence/references/report-generation.md
+++ b/misc/website/docs/skills/eks/eks-cost-intelligence/references/report-generation.md
@@ -172,8 +172,10 @@ Recommendations in the report are sorted by:
 | Cluster | {cluster_name} |
 | Region | {region} |
 | Assessment Date | {YYYY-MM-DD HH:MM} |
+| Analysis Window | {lookback_window, e.g. "7 days (default)" or "30 days (user-specified)"} |
 | Total Estimated Spend | ${total_spend}/month |
 | Data Sources | {data_sources_list} |
+| Fargate Profiles | {none | list of profiles with Fargate-scheduled namespaces} |
 
 ---
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -86,6 +86,7 @@ Run a live EKS cluster cost efficiency assessment — analyze spending across 6 
 | [compute-efficiency.md](./eks-cost-intelligence/references/compute-efficiency.md) | Compute efficiency |
 | [cost-data-collection.md](./eks-cost-intelligence/references/cost-data-collection.md) | Cost data collection |
 | [cost-estimation-fallback.md](./eks-cost-intelligence/references/cost-estimation-fallback.md) | Cost estimation fallback |
+| [fargate-costs.md](./eks-cost-intelligence/references/fargate-costs.md) | Fargate costs |
 | [findings-format.md](./eks-cost-intelligence/references/findings-format.md) | Findings format |
 | [idle-resources.md](./eks-cost-intelligence/references/idle-resources.md) | Idle resources |
 | [networking-costs.md](./eks-cost-intelligence/references/networking-costs.md) | Networking costs |

--- a/skills/eks-cost-intelligence/README.md
+++ b/skills/eks-cost-intelligence/README.md
@@ -36,6 +36,7 @@ skills/eks-cost-intelligence/
 │   ├── storage-costs.md                  # Dimension 4 checks
 │   ├── observability-costs.md            # Dimension 5 checks
 │   ├── idle-resources.md                 # Dimension 6 checks
+│   ├── fargate-costs.md                  # Fargate detection + Fargate-specific checks
 │   ├── report-generation.md              # Scoring algorithm + report template
 │   ├── cost-data-collection.md           # API calls for data sources
 │   ├── waste-calculation.md              # Dollar waste formulas

--- a/skills/eks-cost-intelligence/SKILL.md
+++ b/skills/eks-cost-intelligence/SKILL.md
@@ -45,7 +45,7 @@ This skill is focused on **live cost assessment** — answering the question: "W
 1. **AWS credentials configured** — `aws configure` or `~/.aws/credentials` with EKS access
 2. **kubectl access** to the target cluster (for Kubernetes API queries)
 3. **Required AWS Permissions (minimum):**
-   - `eks:DescribeCluster`, `eks:ListClusters`, `eks:ListNodegroups`, `eks:DescribeNodegroup`
+   - `eks:DescribeCluster`, `eks:ListClusters`, `eks:ListNodegroups`, `eks:DescribeNodegroup`, `eks:ListFargateProfiles`, `eks:DescribeFargateProfile`
    - `ec2:DescribeInstances`, `ec2:DescribeVolumes`, `ec2:DescribeSubnets`, `ec2:DescribeVpcEndpoints`
    - `elasticloadbalancing:DescribeLoadBalancers`, `elasticloadbalancing:DescribeTargetHealth`
 4. **Optional permissions (enable richer analysis):**
@@ -62,6 +62,10 @@ This skill is focused on **live cost assessment** — answering the question: "W
 | **EC2 API** | `aws ec2 describe-instances` | Instance types, pricing tier, Spot vs On-Demand |
 
 If Cost Explorer is unavailable, the skill falls back to node-based cost estimation (see `references/cost-estimation-fallback.md`).
+
+### Default Time Window
+
+Cost Explorer queries use a **7-day lookback by default** (matching the 7-day window used for CloudWatch utilization checks). The user can override the window by asking — e.g., *"use the last 30 days"* — in which case apply the requested window to all Cost Explorer queries. Whichever window is used, record it in the report metadata (`Analysis Window` field) so findings are reproducible and comparable across runs.
 
 ### MCP Server Setup
 
@@ -114,6 +118,7 @@ Collect:
 - Node groups: `aws eks list-nodegroups --cluster-name <cluster>`
 - Node group details: instance types, scaling config, capacity type (ON_DEMAND/SPOT)
 - Add-ons: `aws eks list-addons --cluster-name <cluster>`
+- Fargate profiles: `aws eks list-fargate-profiles --cluster-name <cluster>` — if any profiles exist, describe each one, note which namespaces/label selectors are Fargate-scheduled, and read `references/fargate-costs.md`. Fargate pods are billed on rounded-up pod requests (not node capacity), so exclude them from node-based checks and add the Fargate-specific checks to Steps 1–2.
 - Node inventory: `kubectl get nodes -o wide`
 
 **Action 5 — Confirm and proceed**
@@ -132,6 +137,7 @@ Checks:
 - Low-utilization nodes indicating consolidation opportunities
 - Karpenter consolidation effectiveness (where installed)
 - Workloads without resource requests or limits
+- Fargate pod request right-sizing against Fargate's vCPU/memory combinations — only when Step 0 found Fargate profiles (read `references/fargate-costs.md`, Check F1)
 
 If metrics-server or Container Insights is unavailable, mark utilization checks as SKIPPED and proceed with request-only analysis.
 
@@ -147,6 +153,7 @@ Checks:
 - Stateless multi-replica workloads on On-Demand only
 - Instance type diversity for Spot availability
 - Node Termination Handler or Karpenter interruption handling
+- Interruption-tolerant workloads running on Fargate (EKS has no Fargate Spot) — only when Step 0 found Fargate profiles (read `references/fargate-costs.md`, Check F2)
 
 ### Step 3: Networking Cost Assessment
 
@@ -276,6 +283,7 @@ Before executing checks for any dimension, read the corresponding reference file
 | Storage costs / gp2 / PVC / EBS | `references/storage-costs.md` |
 | Observability / logging / metrics / cardinality | `references/observability-costs.md` |
 | Idle resources / unused / orphaned / zero-scale | `references/idle-resources.md` |
+| Fargate profiles / Fargate pod pricing / request rounding | `references/fargate-costs.md` |
 | Score calculation / scoring algorithm | `references/report-generation.md` |
 | Generate report / produce report | `references/report-generation.md` |
 | Cost data collection / API calls | `references/cost-data-collection.md` |

--- a/skills/eks-cost-intelligence/references/cost-data-collection.md
+++ b/skills/eks-cost-intelligence/references/cost-data-collection.md
@@ -34,7 +34,11 @@ This reference documents the exact API calls needed to collect cost and utilizat
 - IAM permission: `ce:GetCostAndUsage`, `ce:GetSavingsPlansCoverage`
 - Cost Explorer API is only available in `us-east-1` regardless of cluster region
 
-### 1.1 Total EKS Spend by Service (Last 30 Days)
+### Time Window
+
+All Cost Explorer queries in this reference use a **7-day lookback by default**, matching the 7-day window used for CloudWatch utilization metrics. The user can override the window (e.g., "last 30 days") — apply the override consistently to every Cost Explorer query in the assessment and record the window used in the report metadata (`Analysis Window` field). The examples below show a 30-day window for illustration; substitute the active analysis window.
+
+### 1.1 Total EKS Spend by Service
 
 **Via EKS MCP Server:**
 ```

--- a/skills/eks-cost-intelligence/references/fargate-costs.md
+++ b/skills/eks-cost-intelligence/references/fargate-costs.md
@@ -1,0 +1,202 @@
+# Fargate Cost Checks
+
+> **Part of:** [eks-cost-intelligence](../SKILL.md)
+> **Purpose:** Fargate profile detection for Step 0, plus Fargate-specific cost checks — pod request right-sizing against Fargate's vCPU/memory combinations, and capacity strategy for interruption-tolerant Fargate workloads
+>
+> Facts verified 2026-07-17 against https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html, https://docs.aws.amazon.com/eks/latest/userguide/fargate.html, and https://docs.aws.amazon.com/savingsplans/latest/userguide/sp-services.html
+
+---
+
+## Why Fargate Needs Its Own Checks
+
+EKS Fargate has a fundamentally different cost model from EC2 nodes:
+
+- **Billing is per pod, based on provisioned vCPU/memory** — not on node capacity. Fargate rounds each pod's resource requests **up** to the nearest valid vCPU/memory combination and bills for that provisioned capacity (visible in the pod's `CapacityProvisioned` annotation), regardless of actual utilization.
+- **One pod per Fargate node.** There is no bin-packing, no idle-node concept, and no consolidation. Node-based checks (idle nodes, Karpenter consolidation, node-based cost estimation) do NOT apply to Fargate-scheduled pods — exclude them from those checks.
+- **Requests equal limits.** All Fargate pods run with Guaranteed QoS, so over-stated requests translate directly into over-billed capacity.
+- **No Spot tier.** As of 2026-07-17, Amazon EKS does not support Fargate Spot (Fargate Spot exists for ECS only). Savings levers for Fargate on EKS are request right-sizing, Compute Savings Plans (Fargate is eligible), or migrating interruption-tolerant workloads to EC2 Spot capacity.
+
+---
+
+## Detection (runs in Step 0 pre-flight)
+
+**Via AWS CLI:**
+
+```bash
+# List Fargate profiles for the cluster
+aws eks list-fargate-profiles --cluster-name <cluster>
+
+# For each profile, capture its selectors (namespace + optional labels)
+aws eks describe-fargate-profile \
+  --cluster-name <cluster> \
+  --fargate-profile-name <profile> \
+  --query '{name: fargateProfile.fargateProfileName, status: fargateProfile.status, selectors: fargateProfile.selectors, subnets: fargateProfile.subnets}'
+```
+
+**Via kubectl (identify running Fargate pods and their provisioned capacity):**
+
+```bash
+# Fargate nodes carry the compute-type label
+kubectl get nodes -l eks.amazonaws.com/compute-type=fargate -o wide
+
+# The CapacityProvisioned annotation on a Fargate pod shows the billed combination
+kubectl get pods --all-namespaces -o json | \
+  jq -r '.items[] |
+    select(.metadata.annotations["CapacityProvisioned"] != null) |
+    "\(.metadata.namespace)/\(.metadata.name): requested cpu=\([.spec.containers[].resources.requests.cpu // "0"] | join("+")) mem=\([.spec.containers[].resources.requests.memory // "0"] | join("+")) → billed \(.metadata.annotations["CapacityProvisioned"])"'
+```
+
+**Detection outcome:**
+
+- If no Fargate profiles exist → skip this reference entirely; note "Fargate: not used" in the report.
+- If profiles exist → record which namespaces (and label selectors) are Fargate-scheduled, exclude Fargate pods from node-based checks (idle nodes, consolidation, node-based estimation), and run checks F1 and F2 below. List the Fargate-scheduled namespaces in the report metadata.
+
+A profile selector always contains a namespace and may include labels (up to 5 selectors per profile; `*` and `?` wildcards are allowed in selector criteria).
+
+---
+
+## Check F1: Right-Size Pod Requests to Fargate Combinations
+
+### What it detects
+
+Fargate pods whose requests round up into a larger billed combination than the workload needs. You pay for the rounded-up combination, not the raw request — so a request sitting just above a combination boundary wastes the entire gap to the next tier.
+
+### Fargate vCPU/memory combinations
+
+Fargate provisions the smallest combination that fits the pod's aggregate request **plus 256 MB** of memory overhead reserved for Kubernetes components (kubelet, kube-proxy, containerd). If no requests are specified, the smallest combination (.25 vCPU / 0.5 GB) is used.
+
+> Facts verified 2026-07-17 against https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html
+
+| vCPU value | Memory values |
+|-----------|---------------|
+| .25 vCPU | 0.5 GB, 1 GB, 2 GB |
+| .5 vCPU | 1 GB, 2 GB, 3 GB, 4 GB |
+| 1 vCPU | 2–8 GB in 1-GB increments |
+| 2 vCPU | 4–16 GB in 1-GB increments |
+| 4 vCPU | 8–30 GB in 1-GB increments |
+| 8 vCPU | 16–60 GB in 4-GB increments |
+| 16 vCPU | 32–120 GB in 8-GB increments |
+
+The 256 MB overhead can bump a pod into a larger tier: per the AWS docs example, a request of 1 vCPU / 8 GB becomes 8 GB + 256 MB, which doesn't fit any 1-vCPU combination — Fargate provisions **2 vCPU / 9 GB**.
+
+### Analysis logic
+
+```
+For each Fargate-scheduled pod:
+  billed = parse CapacityProvisioned annotation (e.g., "0.5vCPU 2GB")
+  requested = sum of container requests (+ init-container max rule)
+
+  # Boundary waste: request lands just above a combination boundary
+  If (requested + 256MB) marginally exceeds a smaller combination:
+    → Finding: trimming requests slightly would drop the pod a full tier
+    monthly_waste = (billed_tier_cost - smaller_tier_cost) × 730h × replica_count
+
+  # Utilization waste: billed capacity far above P95 usage (when metrics available)
+  If P95 usage < 50% of billed capacity:
+    → Finding: right-size requests toward P95 + headroom, re-check tier fit
+```
+
+Use Fargate per-vCPU-hour and per-GB-hour rates from the AWS Price List API (`pricing:GetProducts`) or https://aws.amazon.com/fargate/pricing/ — do not hardcode rates.
+
+### Severity classification
+
+Severity follows the standard monthly-waste thresholds (see `findings-format.md`): >$500 CRITICAL, $200–$500 HIGH, $50–$200 MEDIUM, <$50 LOW.
+
+### Remediation
+
+```yaml
+# Right-size requests so (requests + 256MB) fits the intended combination
+# Example: fit into the 0.5 vCPU / 1 GB tier
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "768Mi"   # 768Mi + 256MB overhead ≈ 1 GB tier
+          limits:
+            cpu: "500m"       # Fargate enforces requests == limits (Guaranteed QoS)
+            memory: "768Mi"
+```
+
+---
+
+## Check F2: Interruption-Tolerant Workloads on Fargate
+
+### What it detects
+
+Workloads that meet the Spot-eligibility criteria (stateless Deployment, replicas ≥ 2, PDB present — see Check 5 in `spot-graviton-adoption.md`) but run on Fargate. As of 2026-07-17, **Amazon EKS does not support Fargate Spot**, so these workloads cannot get a Spot discount while staying on Fargate.
+
+### Analysis logic
+
+```
+For each Spot-eligible workload scheduled on Fargate:
+  → Finding: interruption-tolerant workload on Fargate (no Spot tier available on EKS)
+  Options, in savings order:
+    1. Migrate to EC2 Spot capacity (Karpenter NodePool or Spot node group)
+       — up to 90% discount vs On-Demand; use ~60% for conservative estimates
+    2. Cover steady Fargate usage with a Compute Savings Plan
+       — Fargate is eligible for Compute Savings Plans
+  monthly_savings (option 1) ≈ fargate_monthly_cost × 0.60 (conservative)
+```
+
+Also surface Compute Savings Plans coverage for clusters with significant steady Fargate spend even when workloads are not Spot-eligible (informational, consistent with the SP/RI out-of-scope rule — coverage notes only, not scored).
+
+### Severity classification
+
+| Condition | Severity |
+|-----------|----------|
+| Spot-eligible Fargate workloads with monthly savings > $200 | HIGH |
+| Spot-eligible Fargate workloads with monthly savings $50–$200 | MEDIUM |
+| Below $50/month or migration blocked (e.g., isolation requirement drove the Fargate choice) | LOW |
+
+### Remediation
+
+```yaml
+# Karpenter NodePool for migrating interruption-tolerant Fargate workloads to EC2 Spot
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: spot-migration
+spec:
+  template:
+    spec:
+      requirements:
+      - key: karpenter.sh/capacity-type
+        operator: In
+        values: ["spot", "on-demand"]
+      - key: karpenter.k8s.aws/instance-category
+        operator: In
+        values: ["m", "c", "r"]
+```
+
+Then remove (or narrow) the Fargate profile selector matching the workload's namespace/labels so pods schedule onto EC2 nodes. Note: Fargate profiles are immutable — create a replacement profile without the selector, then delete the old one.
+
+---
+
+## Scoring Contribution
+
+Fargate findings feed **existing dimensions** — no new dimension is added:
+
+- Check F1 findings → **Compute Efficiency** (dimension `compute`)
+- Check F2 findings → **Spot/Graviton Adoption** (dimension `spot_graviton`)
+
+Severity-weighted deductions and caps follow the standard rules in `report-generation.md`.
+
+---
+
+## Sources
+
+- [Fargate Pod vCPU and memory configuration](https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html) — combination table, 256 MB overhead, rounding behavior, `CapacityProvisioned` annotation
+- [AWS Fargate considerations for Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html) — one pod per compute boundary, "Amazon EKS doesn't support Fargate Spot", DaemonSet/EBS limitations
+- [Define which Pods use AWS Fargate when launched](https://docs.aws.amazon.com/eks/latest/userguide/fargate-profile.html) — profile selectors (namespace + labels, up to 5, wildcards), profile immutability
+- [Services eligible for Savings Plans benefits](https://docs.aws.amazon.com/savingsplans/latest/userguide/sp-services.html) — Fargate is eligible for Compute Savings Plans
+- [AWS Fargate Pricing](https://aws.amazon.com/fargate/pricing/) — per-vCPU-hour and per-GB-hour rates
+
+---
+
+*This reference file is part of the eks-cost-intelligence skill, provided as sample code
+for educational and demonstration purposes only. See the project's README and LICENSE
+for full terms.*

--- a/skills/eks-cost-intelligence/references/fargate-costs.md
+++ b/skills/eks-cost-intelligence/references/fargate-costs.md
@@ -39,6 +39,9 @@ aws eks describe-fargate-profile \
 # Fargate nodes carry the compute-type label
 kubectl get nodes -l eks.amazonaws.com/compute-type=fargate -o wide
 
+# Fallback: Fargate node names start with "fargate-"
+kubectl get nodes | grep ^fargate-
+
 # The CapacityProvisioned annotation on a Fargate pod shows the billed combination
 kubectl get pods --all-namespaces -o json | \
   jq -r '.items[] |
@@ -48,7 +51,7 @@ kubectl get pods --all-namespaces -o json | \
 
 **Detection outcome:**
 
-- If no Fargate profiles exist → skip this reference entirely; note "Fargate: not used" in the report.
+- If no Fargate profiles exist → skip this reference entirely; note "Fargate Profiles: none" in the report.
 - If profiles exist → record which namespaces (and label selectors) are Fargate-scheduled, exclude Fargate pods from node-based checks (idle nodes, consolidation, node-based estimation), and run checks F1 and F2 below. List the Fargate-scheduled namespaces in the report metadata.
 
 A profile selector always contains a namespace and may include labels (up to 5 selectors per profile; `*` and `?` wildcards are allowed in selector criteria).
@@ -148,7 +151,8 @@ Also surface Compute Savings Plans coverage for clusters with significant steady
 
 | Condition | Severity |
 |-----------|----------|
-| Spot-eligible Fargate workloads with monthly savings > $200 | HIGH |
+| Spot-eligible Fargate workloads with monthly savings > $500 | CRITICAL |
+| Spot-eligible Fargate workloads with monthly savings $200–$500 | HIGH |
 | Spot-eligible Fargate workloads with monthly savings $50–$200 | MEDIUM |
 | Below $50/month or migration blocked (e.g., isolation requirement drove the Fargate choice) | LOW |
 

--- a/skills/eks-cost-intelligence/references/report-generation.md
+++ b/skills/eks-cost-intelligence/references/report-generation.md
@@ -161,8 +161,10 @@ Recommendations in the report are sorted by:
 | Cluster | {cluster_name} |
 | Region | {region} |
 | Assessment Date | {YYYY-MM-DD HH:MM} |
+| Analysis Window | {lookback_window, e.g. "7 days (default)" or "30 days (user-specified)"} |
 | Total Estimated Spend | ${total_spend}/month |
 | Data Sources | {data_sources_list} |
+| Fargate Profiles | {none | list of profiles with Fargate-scheduled namespaces} |
 
 ---
 


### PR DESCRIPTION
Addresses the two Should Fix items in the issue body of #114; backlog items (fleet mode, confidence levels, delta mode) deferred, and the later comment-added items (3–8) are out of scope for this PR.

Both copies updated: `skills/eks-cost-intelligence/` (Claude Code) and `devops-agent/eks-cost-intelligence/` (DevOps Agent port, adapted to its API-description style).

## 1. Default time window for Cost Explorer queries

- Cost Explorer queries now default to a **7-day lookback**, matching the 7-day window already used for CloudWatch utilization checks; the user can override (e.g. "last 30 days"), and the override applies to all CE queries in the run.
- The rule lives in SKILL.md (Data Sources section) and in `references/cost-data-collection.md` where the CE queries are specified.
- The report template gains an `Analysis Window` metadata field so every report records which window produced its findings.

## 2. Fargate detection and Fargate-specific checks

- Step 0 pre-flight now runs `aws eks list-fargate-profiles` (EKS ListFargateProfiles API in the agent port). When profiles exist, the skill records which namespaces/label selectors are Fargate-scheduled (report metadata field added), and excludes Fargate pods from node-based checks (idle nodes, consolidation, node-based estimation) since Fargate bills on rounded-up pod requests, not node capacity.
- New `references/fargate-costs.md` in both copies with two checks:
  - **F1 — request right-sizing:** Fargate rounds pod requests (plus 256 MB Kubernetes overhead) up to the nearest vCPU/memory combination and bills the rounded tier; the check compares the `CapacityProvisioned` annotation against requests/P95 usage. Feeds the Compute Efficiency dimension.
  - **F2 — interruption-tolerant workloads on Fargate:** EKS does not support Fargate Spot, so Spot-eligible workloads on Fargate are flagged with EC2 Spot migration or Compute Savings Plans as the levers. Feeds the Spot/Graviton dimension.
- **Note on issue premise:** #114's item 2 asked for a "Fargate Spot adoption" check, but that premise is incorrect — Amazon EKS does not support Fargate Spot (as of 2026-07-17, verified against the [EKS user guide](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html) and the What's New feed; Fargate Spot exists for ECS/Batch). Implemented instead as check F2, which flags Fargate workloads that would qualify for Spot pricing after migration to EC2 node groups, with Compute Savings Plans as the in-place alternative.
- Fargate facts (combination table, 256 MB overhead, no-Fargate-Spot-on-EKS, SP eligibility) were verified against live AWS docs; the file carries dated "Facts verified" gates and a Sources section.
- `eks:ListFargateProfiles` / `eks:DescribeFargateProfile` added to required permissions (and to the agent port's `iam-policy.json`).

No scoring model changes — Fargate findings feed the existing dimensions. Generated website mirrors and README tables regenerated via `misc/update-all-references.sh` and `misc/update-pages.sh`; frontmatter validator passes (28 skills, 0 errors).
