### PR TITLE
fix(ecs-recon): correct aws:cdk:path claim + NLB blue/green LB derivation

### DIFF
--- a/misc/website/docs/skills/ecs/ecs-recon/references/iac.md
+++ b/misc/website/docs/skills/ecs/ecs-recon/references/iac.md
@@ -54,7 +54,7 @@ Run detections in this order — each step adds evidence and confidence:
 ```
 
 **Why this order matters:**
-- Tags are the strongest single-call signal for the tools that DO tag: CloudFormation always applies `aws:cloudformation:*` tags, CDK adds `aws:cdk:path` (when metadata is enabled), and Copilot adds `copilot-*` tags
+- Tags are the strongest single-call signal for the tools that DO tag: CloudFormation always applies `aws:cloudformation:*` tags, CDK may add `aws-cdk:*` tags on some constructs, and Copilot adds `copilot-*` tags. (Note: `aws:cdk:path` is **not** a resource tag — CDK writes it into the CloudFormation template's per-resource `Metadata` section, so it never appears in `ListTagsForResource` output. Detect CDK via stack association instead — see step 2.)
 - **Terraform is the critical exception: Terraform applies NO default tags.** Unless the team configured `default_tags` on the AWS provider or tagged resources explicitly, a fully Terraform-managed estate is invisible to tag-based detection. Expect `undetermined: true` to frequently mean "Terraform or console-managed" — do not read it as "no IaC"
 - Stack association confirms CloudFormation-family tools (CDK, Copilot, raw CloudFormation) with high confidence
 - Naming patterns provide supporting evidence when tags are stripped or absent, but carry lower confidence alone
@@ -102,13 +102,12 @@ aws ecs list-tags-for-resource \
 ```
 
 **Example output (CDK-managed resource):**
+
+CDK's `aws:cdk:path` identifier lives in the CloudFormation template `Metadata`, not in resource tags, so it does not appear here. Some CDK constructs do apply real `aws-cdk:*` tags:
+
 ```json
 {
   "tags": [
-    {
-      "key": "aws:cdk:path",
-      "value": "MyStack/MyService/Service"
-    },
     {
       "key": "aws-cdk:auto-delete-objects",
       "value": "true"
@@ -116,6 +115,8 @@ aws ecs list-tags-for-resource \
   ]
 }
 ```
+
+Most CDK-managed ECS resources carry only the `aws:cloudformation:*` tags below (CDK deploys via CloudFormation) — confirm CDK through stack association (step 2), not tags.
 
 **Example output (Copilot-managed resource):**
 ```json
@@ -175,14 +176,13 @@ aws ecs list-tags-for-resource \
 
 **Tag patterns to match:**
 
-> Facts verified 2026-07-14 against https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-resource-tags.html — CloudFormation automatically applies the stack-level tags `aws:cloudformation:logical-id`, `aws:cloudformation:stack-id`, and `aws:cloudformation:stack-name` (the `aws:` prefix is reserved for AWS use). Terraform's AWS provider applies NO tags by default — `terraform:*` / `tf-*` keys only exist when a team configured them deliberately.
+> Facts verified 2026-07-14 against https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-resource-tags.html — CloudFormation automatically applies the stack-level tags `aws:cloudformation:logical-id`, `aws:cloudformation:stack-id`, and `aws:cloudformation:stack-name` (the `aws:` prefix is reserved for AWS use). Because `aws:` is reserved, CDK's `aws:cdk:path` identifier is **not** a resource tag — it is written into the CloudFormation template's per-resource `Metadata` section and does not appear in `ListTagsForResource`; detect CDK via stack association (step 2). Terraform's AWS provider applies NO tags by default — `terraform:*` / `tf-*` keys only exist when a team configured them deliberately.
 
 | Tool | Tag Key Pattern | Confidence | Origin |
 |------|----------------|------------|--------|
 | Terraform | Key starts with `terraform:` | High | Team convention (Terraform emits no default tags) |
 | Terraform | Key starts with `tf-` | High | Team convention (Terraform emits no default tags) |
-| CDK | Key is `aws:cdk:path` | High | Tool-emitted (when CDK path metadata is enabled) |
-| CDK | Key starts with `aws-cdk:` | High | Tool-emitted (specific constructs) |
+| CDK | Key starts with `aws-cdk:` | High | Tool-emitted (specific constructs only; `aws:cdk:path` is template Metadata, not a tag — see step 2) |
 | Copilot | Key is `copilot-application` | High | Tool-emitted |
 | Copilot | Key is `copilot-environment` | High | Tool-emitted |
 | Copilot | Key is `copilot-service` | High | Tool-emitted |
@@ -353,8 +353,7 @@ If evidence IS found for one or more tools:
 |----------------|-----------|-------------|
 | Tag: `terraform:*` prefix | Terraform state management tags | `terraform` |
 | Tag: `tf-*` prefix | Terraform workspace/module tags | `terraform` |
-| Tag: `aws:cdk:path` | CDK construct path tag | `cdk` |
-| Tag: `aws-cdk:*` prefix | CDK metadata tags | `cdk` |
+| Tag: `aws-cdk:*` prefix | CDK construct tags | `cdk` |
 | Tag: `copilot-application` | Copilot application tag | `copilot` |
 | Tag: `copilot-environment` | Copilot environment tag | `copilot` |
 | Tag: `copilot-service` | Copilot service tag | `copilot` |
@@ -410,10 +409,10 @@ iac:
     - tool: "cdk"
       confidence: "high"
       evidence:
-        - type: "resource_tags"
-          detail: "Tag 'aws:cdk:path' found on service 'api-service' with value 'MyStack/ApiService/Service'"
         - type: "stack_association"
-          detail: "Service belongs to CloudFormation stack 'CdkEcsStack' with CDK-pattern naming"
+          detail: "Service belongs to CloudFormation stack 'CdkEcsStack'; stack has CDK-pattern logical IDs and a CDKMetadata resource"
+        - type: "naming_pattern"
+          detail: "Service name carries an 8-hex-char CDK construct suffix"
     - tool: "terraform"
       confidence: "high"
       evidence:
@@ -534,10 +533,10 @@ Only three evidence types are valid: `"resource_tags"`, `"stack_association"`, a
 Both CDK and Copilot deploy resources via CloudFormation, so their resources will have `aws:cloudformation:*` tags in addition to their own tool-specific tags. This creates overlapping evidence.
 
 **How to handle:**
-- If CDK-specific tags (`aws:cdk:path`, `aws-cdk:*`) are present alongside `aws:cloudformation:*` tags → report `"cdk"` (not `"cloudformation"`)
+- If CDK evidence (an `aws-cdk:*` tag, or CDK-pattern logical IDs / a `CDKMetadata` resource from stack association) is present alongside `aws:cloudformation:*` tags → report `"cdk"` (not `"cloudformation"`). Note `aws:cdk:path` is template Metadata, not a tag, so it is not part of the tag evidence.
 - If Copilot-specific tags (`copilot-application`, `copilot-environment`, `copilot-service`) are present alongside `aws:cloudformation:*` tags → report `"copilot"` (not `"cloudformation"`)
-- Report `"cloudformation"` only when `aws:cloudformation:*` tags are present WITHOUT CDK or Copilot-specific tags
-- Priority: Copilot tags > CDK tags > plain CloudFormation tags (most specific tool wins)
+- Report `"cloudformation"` only when `aws:cloudformation:*` tags are present WITHOUT CDK or Copilot evidence
+- Priority: Copilot > CDK > plain CloudFormation (most specific tool wins)
 
 **Example (CDK with CloudFormation tags — report as CDK):**
 ```yaml
@@ -546,10 +545,8 @@ iac:
     - tool: "cdk"
       confidence: "high"
       evidence:
-        - type: "resource_tags"
-          detail: "Tag 'aws:cdk:path' found on service with value 'MyStack/Service/Resource'"
         - type: "stack_association"
-          detail: "Service belongs to stack 'CdkEcsStack' (CDK-generated)"
+          detail: "Service belongs to stack 'CdkEcsStack' with CDK-pattern logical IDs and a CDKMetadata resource"
   undetermined: false
   error: null
 ```

--- a/misc/website/docs/skills/ecs/ecs-recon/references/networking.md
+++ b/misc/website/docs/skills/ecs/ecs-recon/references/networking.md
@@ -506,6 +506,8 @@ networking:
 
 ### Target group with empty LoadBalancerArns
 
+> Facts verified 2026-07-14 against https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_AdvancedConfiguration.html — `productionListenerRule`/`testListenerRule` hold a listener-rule ARN for an Application Load Balancer and a listener ARN for a Network Load Balancer. ECS-native blue/green, linear, and canary deployments (GA 2025-07-17) attach target groups to the load balancer via these listener rules rather than by direct association, so their target groups return an empty `LoadBalancerArns`.
+
 `DescribeTargetGroups` returns an empty `LoadBalancerArns` list in two common scenarios:
 
 1. **ECS-native blue/green deployments** — the target groups attach to the load balancer via listener rules managed by the ECS deployment controller (returned in `loadBalancers[].advancedConfiguration`), not via direct association.
@@ -514,8 +516,11 @@ networking:
 In both cases the `DescribeTargetGroups` → `DescribeLoadBalancers` path cannot determine the LB type.
 
 **How to handle:**
-- If `LoadBalancerArns` is empty, check whether the service uses `advancedConfiguration` (present on ECS-native blue/green services). If `advancedConfiguration.productionListenerRule` exists, derive the load balancer ARN from the listener-rule ARN and resolve the type with `DescribeLoadBalancers`.
-- **ARN derivation:** a listener-rule ARN has the form `arn:aws:elasticloadbalancing:<region>:<account>:listener-rule/<lb-type>/<lb-name>/<lb-id>/<listener-id>/<rule-id>`. Replace the `listener-rule` resource token with `loadbalancer` and keep only the first three path segments: `arn:aws:elasticloadbalancing:<region>:<account>:loadbalancer/<lb-type>/<lb-name>/<lb-id>`.
+- If `LoadBalancerArns` is empty, check whether the service uses `advancedConfiguration` (present on ECS-native blue/green services). If `advancedConfiguration.productionListenerRule` exists, derive the load balancer ARN from it and resolve the type with `DescribeLoadBalancers`.
+- **`productionListenerRule` carries different ARN types by load balancer:** for an **ALB** it is a *listener-rule* ARN; for an **NLB** it is a *listener* ARN (NLBs have no rules). Both embed the load balancer identity in the same first three path segments, so one derivation covers both:
+  - ALB: `arn:aws:elasticloadbalancing:<region>:<account>:listener-rule/app/<lb-name>/<lb-id>/<listener-id>/<rule-id>`
+  - NLB: `arn:aws:elasticloadbalancing:<region>:<account>:listener/net/<lb-name>/<lb-id>/<listener-id>`
+  - **Derivation (both):** take the resource segment (`listener-rule/app/<lb-name>/<lb-id>...` or `listener/net/<lb-name>/<lb-id>...`), replace the leading `listener-rule` or `listener` token with `loadbalancer`, and keep only the `<lb-type>/<lb-name>/<lb-id>` triplet → `arn:aws:elasticloadbalancing:<region>:<account>:loadbalancer/<lb-type>/<lb-name>/<lb-id>` (where `<lb-type>` is `app` for ALB, `net` for NLB). `DescribeLoadBalancers` on that ARN returns `"application"` → `"ALB"` or `"network"` → `"NLB"`.
 - If `DescribeLoadBalancers` on the derived ARN returns `LoadBalancerNotFound`, the reference is stale (the load balancer was deleted after the service's last deployment) — set `type` to `"unknown"` and note the stale reference in the service's `error` field.
 - If `advancedConfiguration` is absent or the derivation is impractical, set `type` to `"unknown"`.
 - Always report the entry with the target group ARN, container name, and port regardless.
@@ -546,3 +551,5 @@ load_balancers:
 - Service Connect (configuration lives on the deployment): https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html
 - Service discovery (`serviceRegistries`): https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html
 - AWS App Mesh overview and end-of-support announcement (2026-09-30): https://docs.aws.amazon.com/app-mesh/latest/userguide/what-is-app-mesh.html
+- ECS blue/green `advancedConfiguration` (`productionListenerRule`/`testListenerRule` = listener-rule ARN for ALB, listener ARN for NLB): https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_AdvancedConfiguration.html
+- NLB resources for ECS blue/green, linear, and canary deployments: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/nlb-resources-for-blue-green.html

--- a/skills/ecs-recon/references/iac.md
+++ b/skills/ecs-recon/references/iac.md
@@ -43,7 +43,7 @@ Run detections in this order — each step adds evidence and confidence:
 ```
 
 **Why this order matters:**
-- Tags are the strongest single-call signal for the tools that DO tag: CloudFormation always applies `aws:cloudformation:*` tags, CDK adds `aws:cdk:path` (when metadata is enabled), and Copilot adds `copilot-*` tags
+- Tags are the strongest single-call signal for the tools that DO tag: CloudFormation always applies `aws:cloudformation:*` tags, CDK may add `aws-cdk:*` tags on some constructs, and Copilot adds `copilot-*` tags. (Note: `aws:cdk:path` is **not** a resource tag — CDK writes it into the CloudFormation template's per-resource `Metadata` section, so it never appears in `ListTagsForResource` output. Detect CDK via stack association instead — see step 2.)
 - **Terraform is the critical exception: Terraform applies NO default tags.** Unless the team configured `default_tags` on the AWS provider or tagged resources explicitly, a fully Terraform-managed estate is invisible to tag-based detection. Expect `undetermined: true` to frequently mean "Terraform or console-managed" — do not read it as "no IaC"
 - Stack association confirms CloudFormation-family tools (CDK, Copilot, raw CloudFormation) with high confidence
 - Naming patterns provide supporting evidence when tags are stripped or absent, but carry lower confidence alone
@@ -91,13 +91,12 @@ aws ecs list-tags-for-resource \
 ```
 
 **Example output (CDK-managed resource):**
+
+CDK's `aws:cdk:path` identifier lives in the CloudFormation template `Metadata`, not in resource tags, so it does not appear here. Some CDK constructs do apply real `aws-cdk:*` tags:
+
 ```json
 {
   "tags": [
-    {
-      "key": "aws:cdk:path",
-      "value": "MyStack/MyService/Service"
-    },
     {
       "key": "aws-cdk:auto-delete-objects",
       "value": "true"
@@ -105,6 +104,8 @@ aws ecs list-tags-for-resource \
   ]
 }
 ```
+
+Most CDK-managed ECS resources carry only the `aws:cloudformation:*` tags below (CDK deploys via CloudFormation) — confirm CDK through stack association (step 2), not tags.
 
 **Example output (Copilot-managed resource):**
 ```json
@@ -164,14 +165,13 @@ aws ecs list-tags-for-resource \
 
 **Tag patterns to match:**
 
-> Facts verified 2026-07-14 against https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-resource-tags.html — CloudFormation automatically applies the stack-level tags `aws:cloudformation:logical-id`, `aws:cloudformation:stack-id`, and `aws:cloudformation:stack-name` (the `aws:` prefix is reserved for AWS use). Terraform's AWS provider applies NO tags by default — `terraform:*` / `tf-*` keys only exist when a team configured them deliberately.
+> Facts verified 2026-07-14 against https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-resource-tags.html — CloudFormation automatically applies the stack-level tags `aws:cloudformation:logical-id`, `aws:cloudformation:stack-id`, and `aws:cloudformation:stack-name` (the `aws:` prefix is reserved for AWS use). Because `aws:` is reserved, CDK's `aws:cdk:path` identifier is **not** a resource tag — it is written into the CloudFormation template's per-resource `Metadata` section and does not appear in `ListTagsForResource`; detect CDK via stack association (step 2). Terraform's AWS provider applies NO tags by default — `terraform:*` / `tf-*` keys only exist when a team configured them deliberately.
 
 | Tool | Tag Key Pattern | Confidence | Origin |
 |------|----------------|------------|--------|
 | Terraform | Key starts with `terraform:` | High | Team convention (Terraform emits no default tags) |
 | Terraform | Key starts with `tf-` | High | Team convention (Terraform emits no default tags) |
-| CDK | Key is `aws:cdk:path` | High | Tool-emitted (when CDK path metadata is enabled) |
-| CDK | Key starts with `aws-cdk:` | High | Tool-emitted (specific constructs) |
+| CDK | Key starts with `aws-cdk:` | High | Tool-emitted (specific constructs only; `aws:cdk:path` is template Metadata, not a tag — see step 2) |
 | Copilot | Key is `copilot-application` | High | Tool-emitted |
 | Copilot | Key is `copilot-environment` | High | Tool-emitted |
 | Copilot | Key is `copilot-service` | High | Tool-emitted |
@@ -342,8 +342,7 @@ If evidence IS found for one or more tools:
 |----------------|-----------|-------------|
 | Tag: `terraform:*` prefix | Terraform state management tags | `terraform` |
 | Tag: `tf-*` prefix | Terraform workspace/module tags | `terraform` |
-| Tag: `aws:cdk:path` | CDK construct path tag | `cdk` |
-| Tag: `aws-cdk:*` prefix | CDK metadata tags | `cdk` |
+| Tag: `aws-cdk:*` prefix | CDK construct tags | `cdk` |
 | Tag: `copilot-application` | Copilot application tag | `copilot` |
 | Tag: `copilot-environment` | Copilot environment tag | `copilot` |
 | Tag: `copilot-service` | Copilot service tag | `copilot` |
@@ -399,10 +398,10 @@ iac:
     - tool: "cdk"
       confidence: "high"
       evidence:
-        - type: "resource_tags"
-          detail: "Tag 'aws:cdk:path' found on service 'api-service' with value 'MyStack/ApiService/Service'"
         - type: "stack_association"
-          detail: "Service belongs to CloudFormation stack 'CdkEcsStack' with CDK-pattern naming"
+          detail: "Service belongs to CloudFormation stack 'CdkEcsStack'; stack has CDK-pattern logical IDs and a CDKMetadata resource"
+        - type: "naming_pattern"
+          detail: "Service name carries an 8-hex-char CDK construct suffix"
     - tool: "terraform"
       confidence: "high"
       evidence:
@@ -523,10 +522,10 @@ Only three evidence types are valid: `"resource_tags"`, `"stack_association"`, a
 Both CDK and Copilot deploy resources via CloudFormation, so their resources will have `aws:cloudformation:*` tags in addition to their own tool-specific tags. This creates overlapping evidence.
 
 **How to handle:**
-- If CDK-specific tags (`aws:cdk:path`, `aws-cdk:*`) are present alongside `aws:cloudformation:*` tags → report `"cdk"` (not `"cloudformation"`)
+- If CDK evidence (an `aws-cdk:*` tag, or CDK-pattern logical IDs / a `CDKMetadata` resource from stack association) is present alongside `aws:cloudformation:*` tags → report `"cdk"` (not `"cloudformation"`). Note `aws:cdk:path` is template Metadata, not a tag, so it is not part of the tag evidence.
 - If Copilot-specific tags (`copilot-application`, `copilot-environment`, `copilot-service`) are present alongside `aws:cloudformation:*` tags → report `"copilot"` (not `"cloudformation"`)
-- Report `"cloudformation"` only when `aws:cloudformation:*` tags are present WITHOUT CDK or Copilot-specific tags
-- Priority: Copilot tags > CDK tags > plain CloudFormation tags (most specific tool wins)
+- Report `"cloudformation"` only when `aws:cloudformation:*` tags are present WITHOUT CDK or Copilot evidence
+- Priority: Copilot > CDK > plain CloudFormation (most specific tool wins)
 
 **Example (CDK with CloudFormation tags — report as CDK):**
 ```yaml
@@ -535,10 +534,8 @@ iac:
     - tool: "cdk"
       confidence: "high"
       evidence:
-        - type: "resource_tags"
-          detail: "Tag 'aws:cdk:path' found on service with value 'MyStack/Service/Resource'"
         - type: "stack_association"
-          detail: "Service belongs to stack 'CdkEcsStack' (CDK-generated)"
+          detail: "Service belongs to stack 'CdkEcsStack' with CDK-pattern logical IDs and a CDKMetadata resource"
   undetermined: false
   error: null
 ```

--- a/skills/ecs-recon/references/networking.md
+++ b/skills/ecs-recon/references/networking.md
@@ -495,6 +495,8 @@ networking:
 
 ### Target group with empty LoadBalancerArns
 
+> Facts verified 2026-07-14 against https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_AdvancedConfiguration.html — `productionListenerRule`/`testListenerRule` hold a listener-rule ARN for an Application Load Balancer and a listener ARN for a Network Load Balancer. ECS-native blue/green, linear, and canary deployments (GA 2025-07-17) attach target groups to the load balancer via these listener rules rather than by direct association, so their target groups return an empty `LoadBalancerArns`.
+
 `DescribeTargetGroups` returns an empty `LoadBalancerArns` list in two common scenarios:
 
 1. **ECS-native blue/green deployments** — the target groups attach to the load balancer via listener rules managed by the ECS deployment controller (returned in `loadBalancers[].advancedConfiguration`), not via direct association.
@@ -503,8 +505,11 @@ networking:
 In both cases the `DescribeTargetGroups` → `DescribeLoadBalancers` path cannot determine the LB type.
 
 **How to handle:**
-- If `LoadBalancerArns` is empty, check whether the service uses `advancedConfiguration` (present on ECS-native blue/green services). If `advancedConfiguration.productionListenerRule` exists, derive the load balancer ARN from the listener-rule ARN and resolve the type with `DescribeLoadBalancers`.
-- **ARN derivation:** a listener-rule ARN has the form `arn:aws:elasticloadbalancing:<region>:<account>:listener-rule/<lb-type>/<lb-name>/<lb-id>/<listener-id>/<rule-id>`. Replace the `listener-rule` resource token with `loadbalancer` and keep only the first three path segments: `arn:aws:elasticloadbalancing:<region>:<account>:loadbalancer/<lb-type>/<lb-name>/<lb-id>`.
+- If `LoadBalancerArns` is empty, check whether the service uses `advancedConfiguration` (present on ECS-native blue/green services). If `advancedConfiguration.productionListenerRule` exists, derive the load balancer ARN from it and resolve the type with `DescribeLoadBalancers`.
+- **`productionListenerRule` carries different ARN types by load balancer:** for an **ALB** it is a *listener-rule* ARN; for an **NLB** it is a *listener* ARN (NLBs have no rules). Both embed the load balancer identity in the same first three path segments, so one derivation covers both:
+  - ALB: `arn:aws:elasticloadbalancing:<region>:<account>:listener-rule/app/<lb-name>/<lb-id>/<listener-id>/<rule-id>`
+  - NLB: `arn:aws:elasticloadbalancing:<region>:<account>:listener/net/<lb-name>/<lb-id>/<listener-id>`
+  - **Derivation (both):** take the resource segment (`listener-rule/app/<lb-name>/<lb-id>...` or `listener/net/<lb-name>/<lb-id>...`), replace the leading `listener-rule` or `listener` token with `loadbalancer`, and keep only the `<lb-type>/<lb-name>/<lb-id>` triplet → `arn:aws:elasticloadbalancing:<region>:<account>:loadbalancer/<lb-type>/<lb-name>/<lb-id>` (where `<lb-type>` is `app` for ALB, `net` for NLB). `DescribeLoadBalancers` on that ARN returns `"application"` → `"ALB"` or `"network"` → `"NLB"`.
 - If `DescribeLoadBalancers` on the derived ARN returns `LoadBalancerNotFound`, the reference is stale (the load balancer was deleted after the service's last deployment) — set `type` to `"unknown"` and note the stale reference in the service's `error` field.
 - If `advancedConfiguration` is absent or the derivation is impractical, set `type` to `"unknown"`.
 - Always report the entry with the target group ARN, container name, and port regardless.
@@ -535,3 +540,5 @@ load_balancers:
 - Service Connect (configuration lives on the deployment): https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html
 - Service discovery (`serviceRegistries`): https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html
 - AWS App Mesh overview and end-of-support announcement (2026-09-30): https://docs.aws.amazon.com/app-mesh/latest/userguide/what-is-app-mesh.html
+- ECS blue/green `advancedConfiguration` (`productionListenerRule`/`testListenerRule` = listener-rule ARN for ALB, listener ARN for NLB): https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_AdvancedConfiguration.html
+- NLB resources for ECS blue/green, linear, and canary deployments: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/nlb-resources-for-blue-green.html


### PR DESCRIPTION
## Summary

Follow-up to #137. That PR merged with three small residual items flagged in the final review round (all in already-merged content, **none are regressions**). This PR addresses them.

## Changes

### `aws:cdk:path` is not a resource tag (`iac.md`)
`aws:cdk:path` is written into the **CloudFormation template's per-resource `Metadata` section**, not applied as a resource tag — so it never appears in `ecs:ListTagsForResource` output. Classifying it as a tag was both incorrect and self-contradictory with the file's own "`aws:` prefix is reserved for AWS use" note.

- Removed `aws:cdk:path` from the tag-pattern table, tool-mapping table, the CDK tag example, and the overlapping-evidence edge case.
- Kept the real `aws-cdk:*` construct tags (e.g. `aws-cdk:auto-delete-objects`).
- CDK detection now routes through **stack association** (CDK-pattern logical IDs / `CDKMetadata` resource), which the module already documents.

### NLB blue/green load balancer derivation (`networking.md`)
`advancedConfiguration.productionListenerRule` holds a **listener-rule ARN for an ALB** but a **listener ARN for an NLB** (NLBs have no listener rules). The previous ALB-only derivation silently degraded NLB blue/green services to `type: "unknown"`.

- Documented both ARN shapes and a single derivation (strip to the `loadbalancer/<type>/<name>/<id>` triplet) that covers `app` and `net`.

### Sourcing for the blue/green content (`networking.md`)
Added `## Sources` entries (`API_AdvancedConfiguration`, NLB blue/green resources) and a dated freshness gate for the new blue/green edge case, matching the family convention applied throughout the rest of the skill.

## Verification

- All claims verified against AWS docs (2026-07-14): [API_AdvancedConfiguration](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_AdvancedConfiguration.html) (ALB→listener-rule / NLB→listener), [NLB blue/green resources](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/nlb-resources-for-blue-green.html), and CDK metadata semantics.
- Docs regenerated via `update-all-references.sh` + `update-pages.sh`; frontmatter validates (29 skills, 0 errors); mirror parity clean.

## If this PR adds or changes a skill

- [x] `skills/ecs-recon/SKILL.md` present with valid frontmatter (unchanged this PR)
- [x] Ran the docs regeneration scripts and committed the resulting mirror changes
- [ ] `misc/evals/ecs-recon/triggering.json` — not included (consistent with #137 and the current ECS skill precedent)
