### PR TITLE
chore(deps): patch transitive brace-expansion + js-yaml vulns in misc/website

### DIFF
--- a/misc/website/package-lock.json
+++ b/misc/website/package-lock.json
@@ -6386,9 +6386,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -9198,9 +9198,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -10319,9 +10319,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What

Lockfile-only patch of transitive dependencies in `misc/website` to clear open Dependabot security alerts that had no auto-generated PR (deeply-nested transitive duplicates). Applied via `npm audit fix` (no `--force`) — **no major version bumps, no top-level dependency changes, no source/content changes.**

## Advisories cleared (4 alerts across 3 distinct GHSAs)

| Package | Before → After | Advisory | Severity |
|---------|----------------|----------|----------|
| brace-expansion | 1.1.15 → 1.1.16 | [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) | HIGH |
| js-yaml | 3.14.2 → 3.15.0 | [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m), [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) | HIGH / MEDIUM |
| js-yaml | 4.2.0 → 4.3.0 | [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) | HIGH |

The 3 distinct advisories are GHSA-3jxr-9vmj-r5cp, GHSA-52cp-r559-cp3m (matches both the 3.x and 4.x js-yaml lines, hence counted as 2 of the 4 alerts), and GHSA-h67p-54hq-rp68.

Both major lines of js-yaml (3.x and 4.x) are patched. All three changed entries' integrity hashes were verified against the npm registry.

## Build verification

`npm run build` (Docusaurus) **passes**. The only warning is a pre-existing, unrelated broken-anchor warning (`terraform-skill/references/module-patterns#testing-philosophy--patterns`) that is present on `main` and untouched by this change.

## Accepted / not fixed

**GHSA-mh99-v99m-4gvg** — brace-expansion DoS via unbounded expansion length (HIGH) — is **knowingly left open** in this PR:

- The advisory range is `<= 5.0.7`, and its **only** patched version is **5.0.8**. There is **no within-major backport** to the 1.x line (nor to 2.x/3.x/4.x).
- In this tree, brace-expansion resolves to the **1.x line**, pinned via `@docusaurus/core` → `serve-handler` → `minimatch@3.1.5` (which requires `^1.1.7`).
- Clearing this advisory would require a forced override to `brace-expansion@>=5.0.8` — a **four-major jump** injected under a `minimatch@3.x` written against the 1.x API. That exceeds "patch/minor transitive fix" scope and is deferred.
- **Exposure is negligible**: this brace-expansion copy sits under `serve-handler`, i.e. it is only reachable at **serve time** (`docusaurus serve`), not during the build. CI and production **never run `docusaurus serve`** — GitHub Pages ships a pre-built static artifact — so that code path does not execute in any deployed environment. Even where it does run locally, the ReDoS input is the **operator-supplied glob/config pattern**, not attacker-controlled data, so there is no reachable trigger from untrusted input.

This can be revisited if/when the upstream Docusaurus/minimatch chain adopts brace-expansion 5.x, or handled separately as a deliberate major-bump change.

