### PR TITLE
eks-best-practices: currency pass — correct stale/wrong claims against live AWS docs + targeted enrichments

### DIFF
--- a/misc/website/docs/skills/eks/eks-best-practices/index.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/index.md
@@ -166,7 +166,7 @@ metadata:
 | **Secrets Store CSI** | Medium | Mount secrets as volumes |
 | **KMS envelope encryption** | Low | Encrypt etcd secrets |
 
-**Always enable KMS envelope encryption for Kubernetes secrets.**
+Envelope encryption is on by default (≥1.28) and covers all Kubernetes API data; layer your own KMS CMK when you need key control and CloudTrail visibility. Source: https://docs.aws.amazon.com/eks/latest/userguide/envelope-encryption.html
 
 **For detailed security guidance, see:** [Security Reference](references/security) | [Runtime & Network](references/security-runtime-network) | [Supply Chain & Compliance](references/security-supply-chain)
 
@@ -244,7 +244,7 @@ topologySpreadConstraints:
 | **Rollback** | ✅ To N-1 within 7 days of upgrade | ✅ Switch back (any window) |
 | **Use when** | ✅ Most upgrades | Post-7-day rollback, multi-minor jumps, data-plane isolation |
 
-Native in-place rollback to N-1 is supported within **7 days** of an in-place upgrade (all regions, all cluster types; Auto Mode rolls back nodes automatically). `update-cluster-version` supports type `VersionRollback`, gated by a `ROLLBACK_READINESS` insight; add-ons/data-plane roll back separately. Blue-green retains independent rationale for post-7-day windows, multi-minor jumps, and data-plane isolation — not "because you can't roll back."
+Native in-place rollback to N-1 is supported within **7 days** of an in-place upgrade (all regions; Auto Mode rolls back nodes automatically; rollback into an extended-support version requires setting the cluster upgrade policy to `EXTENDED` first). `update-cluster-version` supports type `VersionRollback`, gated by a `ROLLBACK_READINESS` insight; add-ons/data-plane roll back separately. Blue-green retains independent rationale for post-7-day windows, multi-minor jumps, and data-plane isolation — not "because you can't roll back."
 
 ### Data Plane with Karpenter
 

--- a/misc/website/docs/skills/eks/eks-best-practices/index.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/index.md
@@ -136,7 +136,7 @@ Comprehensive guidance for designing, deploying, and operating Amazon EKS cluste
 
 | Approach | Use When | Setup |
 |----------|----------|-------|
-| **Pod Identity** | ✅ New workloads (EKS 1.24+) | EKS add-on + association |
+| **Pod Identity** | ✅ New workloads | EKS add-on + association |
 | **IRSA** | Older clusters, Fargate | OIDC provider + trust policy |
 
 **Key rules:**
@@ -241,8 +241,10 @@ topologySpreadConstraints:
 |--------|---------|------------|
 | **Risk** | Low-Medium | Lowest |
 | **Cost** | No extra | 2× during migration |
-| **Rollback** | ❌ No CP rollback | ✅ Switch back |
-| **Use when** | ✅ Most upgrades | Critical workloads |
+| **Rollback** | ✅ To N-1 within 7 days of upgrade | ✅ Switch back (any window) |
+| **Use when** | ✅ Most upgrades | Post-7-day rollback, multi-minor jumps, data-plane isolation |
+
+Native in-place rollback to N-1 is supported within **7 days** of an in-place upgrade (all regions, all cluster types; Auto Mode rolls back nodes automatically). `update-cluster-version` supports type `VersionRollback`, gated by a `ROLLBACK_READINESS` insight; add-ons/data-plane roll back separately. Blue-green retains independent rationale for post-7-day windows, multi-minor jumps, and data-plane isolation — not "because you can't roll back."
 
 ### Data Plane with Karpenter
 
@@ -266,6 +268,8 @@ disruption:
 | **Scale-up speed** | ~30s | ~60-90s | AWS-managed |
 | **Consolidation** | ✅ Built-in | ❌ | ✅ |
 | **Customization** | High | Medium | Low |
+
+Cluster Autoscaler's ~60-90s scale-up assumes cold EC2 launches; MNG EC2 warm pools (2026-04) pre-initialize instances and cut that latency substantially for MNG-backed node groups.
 
 ### Pod Autoscaler Selection
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/autoscaling.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/autoscaling.md
@@ -40,7 +40,7 @@ This page is generated from [skills/eks-best-practices/references/autoscaling.md
 | **Spot support** | Native Spot handling | Via mixed instance policy | AWS-managed |
 | **Operational overhead** | Low -- CRD-based config | Medium -- ASG management | Lowest -- fully managed |
 | **Customization** | High | Medium | Low |
-| **Maturity** | GA (v1.0+) | Very mature | Newer -- evaluate for your use case |
+| **Maturity** | GA (v1.0+) | Very mature | GA and mature -- managed drivers, self-service troubleshooting, GPU support |
 | **Recommendation** | Default choice | When Karpenter is not an option | When minimal ops is top priority |
 
 **For detailed Karpenter guidance, see:** [Karpenter Reference](karpenter)
@@ -60,7 +60,7 @@ This page is generated from [skills/eks-best-practices/references/autoscaling.md
 
 ### When to Use CAS Over Karpenter
 
-- EKS on Outposts (Karpenter not supported)
+- EKS on Outposts (Karpenter not supported, as of 2026-08-04)
 - Self-managed node groups with specific AMI requirements
 - Clusters already running CAS with complex ASG configurations
 - Organizations requiring node group-level operational boundaries
@@ -286,7 +286,7 @@ EKS Auto Mode provides AWS-managed:
 - **Node provisioning and scaling** (no node groups to manage)
 - **Node OS patching and upgrades**
 - **Compute optimization** (instance selection, Spot)
-- **Cluster add-ons** (VPC CNI, CoreDNS, kube-proxy)
+- **Built-in networking, DNS, load balancing, and storage** — VPC CNI, CoreDNS, kube-proxy, the AWS Load Balancer Controller, and EBS CSI run as AWS-managed built-in components, not as cluster add-ons you install. Installing the corresponding EKS add-ons on an Auto Mode cluster is redundant (and conflicts with the managed components).
 
 ### When to Use Auto Mode
 
@@ -298,10 +298,12 @@ Use Auto Mode when:
 
 Don't use Auto Mode when:
 - You need custom AMIs or specific kernel configurations
-- GPU/ML workloads requiring specific instance types or drivers
+- You must pin a *specific* GPU/Neuron driver version (Auto Mode is Bottlerocket-only and ships AWS-managed driver versions)
 - Windows containers are required
 - You need fine-grained control over node configuration
 - Running on EKS Outposts or EKS Anywhere
+
+**GPU/ML on Auto Mode:** Auto Mode DOES support GPU and accelerated workloads — it ships managed NVIDIA and Neuron drivers plus the GPU device plugins, and specific accelerated instance types are selectable via custom NodePools (e.g. `requirements` on `node.kubernetes.io/instance-type` or instance-family/GPU labels). The only residual limitation is that you can't pin a custom driver *version* (drivers track the managed Bottlerocket AMI). If a specific driver version or custom AMI is mandatory, use standard EKS + Karpenter instead.
 
 ### Auto Mode Configuration
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/cluster-upgrades.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/cluster-upgrades.md
@@ -110,12 +110,12 @@ If an insight shows `"status": ERROR`, you **must** resolve it before upgrading.
 | Factor | In-Place Upgrade | Blue-Green Upgrade |
 |--------|-----------------|-------------------|
 | **Downtime risk** | Minutes (control plane) | Near-zero |
-| **Rollback** | Not possible for control plane | DNS/LB switch back |
+| **Rollback** | Yes, to N-1 within 7 days of an in-place upgrade (readiness-checked; add-ons/data-plane separate) | DNS/LB switch back (any time) |
 | **Cost** | No extra cost | 2× cluster cost during migration |
 | **Complexity** | Low-Medium | High |
 | **State migration** | None needed | Must migrate PVs, DNS, state |
 | **Version jump** | One minor at a time | Can skip versions (new cluster) |
-| **Use when** | Most upgrades | Critical workloads, major version jumps |
+| **Use when** | Most upgrades (in-place N-1 rollback available within 7 days) | Post-7-day rollback window, multi-minor jumps, data-plane isolation |
 
 ---
 
@@ -145,7 +145,7 @@ aws eks describe-cluster --name my-cluster \
 # Upgrade control plane (one minor version at a time)
 aws eks update-cluster-version \
   --name my-cluster \
-  --kubernetes-version 1.31
+  --kubernetes-version 1.34
 
 # Monitor upgrade status
 aws eks describe-update \
@@ -154,10 +154,10 @@ aws eks describe-update \
 ```
 
 **Key constraints:**
-- Can only upgrade one minor version at a time (1.29 → 1.30, not 1.29 → 1.31)
+- Can only upgrade one minor version at a time (1.34 → 1.35, not 1.34 → 1.36)
 - Control plane upgrade takes 15-30 minutes
 - API server remains available during upgrade (brief API errors possible)
-- Cannot rollback control plane version
+- Native in-place rollback to N-1 is supported within **7 days** of an in-place upgrade (GA, all regions, all cluster types; Auto Mode also rolls back nodes automatically). `update-cluster-version` supports type `VersionRollback`; a `ROLLBACK_READINESS` insight gates it. Add-ons/data-plane roll back separately. Past the 7-day window, roll back via blue-green or cluster rebuild.
 
 ### Step 2: Upgrade Add-ons
 
@@ -168,6 +168,8 @@ aws eks describe-addon --cluster-name my-cluster --addon-name coredns
 aws eks describe-addon --cluster-name my-cluster --addon-name kube-proxy
 
 # Upgrade each add-on
+# (--addon-version below is illustrative — check the current version with
+#  `aws eks describe-addon-versions` rather than pinning this exact value)
 aws eks update-addon \
   --cluster-name my-cluster \
   --addon-name vpc-cni \
@@ -187,7 +189,7 @@ EKS add-ons are **not** automatically upgraded during a control plane upgrade �
 aws eks update-nodegroup-version \
   --cluster-name my-cluster \
   --nodegroup-name default \
-  --kubernetes-version 1.31
+  --kubernetes-version 1.34
 
 # Monitor rolling update
 aws eks describe-nodegroup \
@@ -214,7 +216,9 @@ After the cluster upgrade, update your kubectl client to match:
 
 ```bash
 # Verify kubectl version matches cluster
-kubectl version --short
+# (--short was removed in kubectl 1.28; it errors on current clients)
+kubectl version
+# Optionally: kubectl version -o yaml   (or -o json)
 ```
 
 ### Ensure Availability During Upgrade
@@ -272,7 +276,8 @@ Spreading across zones and hosts ensures pods migrate to new nodes automatically
 - Major version jumps (skipping multiple minor versions via new cluster)
 - Zero-downtime requirement for the upgrade itself
 - Significant architectural changes alongside version upgrade
-- Compliance requirement for rollback capability
+- Data-plane isolation (validate the new version on a separate data plane before cutover)
+- Rollback needed beyond the 7-day in-place window (in-place N-1 rollback covers the first 7 days — see [Emergency Rollback Procedures](#emergency-rollback-procedures))
 
 ### Blue-Green Procedure
 
@@ -291,8 +296,32 @@ Spreading across zones and hosts ensures pods migrate to new nodes automatically
 |--------|------------|----------------|
 | **Route 53 weighted routing** | Percentage-based | Fast (DNS TTL) |
 | **ALB weighted target groups** | Percentage-based | Instant |
+| **NLB weighted target groups** | Percentage-based | Instant (weight shift is manual — no automatic failover) |
 | **Global Accelerator** | Endpoint weights | Instant |
 | **External DNS cutover** | All-or-nothing | DNS TTL dependent |
+
+#### NLB Weighted Target-Group Cutover
+
+For L4 / internal-NLB blue/green cutover, use **NLB weighted target groups** (a weighted `forward` action), GA as of 2025-11-19. Point one NLB listener at two target groups — one registered to the blue cluster, one to the green — and shift weights to move traffic:
+
+```bash
+aws elbv2 modify-listener \
+  --listener-arn <listener-arn> \
+  --default-actions '[{
+    "Type": "forward",
+    "ForwardConfig": {
+      "TargetGroups": [
+        {"TargetGroupArn": "<blue-tg-arn>", "Weight": 90},
+        {"TargetGroupArn": "<green-tg-arn>", "Weight": 10}
+      ]
+    }
+  }]'
+```
+
+Constraints:
+- Use **`ip`-type** target groups with a `TargetGroupBinding` per cluster. Never share one target group between clusters — the two clusters' controllers will fight over registration/deregistration.
+- With the AWS Load Balancer Controller, set `multiClusterTargetGroup: true` so the controller does not deregister targets it did not create.
+- **NLB has no automatic failover** — weight shifts are manual, so watch health checks and roll weights back yourself if the green cluster misbehaves.
 
 ### Blue-Green Downsides to Consider
 
@@ -334,7 +363,7 @@ For workloads with PersistentVolumes:
 # List compatible versions for an add-on
 aws eks describe-addon-versions \
   --addon-name vpc-cni \
-  --kubernetes-version 1.31 \
+  --kubernetes-version 1.34 \
   --query 'addons[0].addonVersions[*].{Version:addonVersion,Default:compatibilities[0].defaultVersion}' \
   --output table
 ```
@@ -409,20 +438,20 @@ aws logs get-query-results --query-id $QUERY_ID
 brew install FairwindsOps/tap/pluto
 
 # Scan Helm releases in cluster
-pluto detect-helm --target-versions k8s=v1.31
+pluto detect-helm --target-versions k8s=v1.34
 
 # Scan manifest files (more accurate — recommended for CI)
-pluto detect-files -d manifests/ --target-versions k8s=v1.31
+pluto detect-files -d manifests/ --target-versions k8s=v1.34
 
 # Scan live cluster
-pluto detect-api-resources --target-versions k8s=v1.31
+pluto detect-api-resources --target-versions k8s=v1.34
 ```
 
 ### Using kube-no-trouble
 
 ```bash
 sh -c "$(curl -sSL https://git.io/install-kubent)"
-kubent --target-version 1.31
+kubent --target-version 1.34
 ```
 
 Scanning static manifests is generally more accurate than live cluster scanning (fewer false positives). Run `kubent`/`pluto` in CI pipelines to catch issues before deployment.
@@ -433,15 +462,18 @@ Scanning static manifests is generally more accurate than live cluster scanning 
 |---------|------------|-------------|
 | **1.25** | PodSecurityPolicy | Pod Security Admission (PSA) |
 | **1.25** | batch/v1beta1 CronJob | batch/v1 |
-| **1.25** | Dockershim (CRI) | containerd (EKS Optimized AMI default) |
 | **1.26** | flowcontrol.apiserver.k8s.io/v1beta1 | flowcontrol.apiserver.k8s.io/v1beta3 |
 | **1.27** | storage.k8s.io/v1beta1 CSIStorageCapacity | storage.k8s.io/v1 |
 | **1.29** | flowcontrol.apiserver.k8s.io/v1beta2 | flowcontrol.apiserver.k8s.io/v1 |
 | **1.32** | flowcontrol.apiserver.k8s.io/v1beta3 | flowcontrol.apiserver.k8s.io/v1 |
 
+> This table lists API removals as of 2026-08-04 and is not a complete list for versions beyond 1.32 — always verify against the live [Kubernetes deprecation guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/) and EKS release notes for your target version.
+>
+> **Note:** Dockershim is a container-runtime component, **not** an API removal. It was removed upstream in Kubernetes **1.24** (EKS-Optimized AMIs use containerd) — see the migration guidance below.
+
 ### Feature-Specific Migration Guidance
 
-**Dockershim removal (1.25):** EKS Optimized AMI for 1.25+ uses containerd, not Docker. If you mount the Docker socket (`/var/run/docker.sock`), detect dependencies with the [Detector for Docker Socket (DDS)](https://github.com/aws-containers/kubectl-detector-for-docker-socket) kubectl plugin before upgrading nodes.
+**Dockershim removal (1.24):** Dockershim was removed upstream in Kubernetes 1.24; EKS-Optimized AMIs for 1.24+ use containerd, not Docker. If you mount the Docker socket (`/var/run/docker.sock`), detect dependencies with the [Detector for Docker Socket (DDS)](https://github.com/aws-containers/kubectl-detector-for-docker-socket) kubectl plugin before upgrading nodes.
 
 **PodSecurityPolicy removal (1.25):** Migrate to built-in [Pod Security Standards (PSS)](https://docs.aws.amazon.com/eks/latest/userguide/pod-security-policy-removal-faq.html) or a policy-as-code solution (Kyverno, OPA/Gatekeeper) before upgrading to 1.25.
 
@@ -507,9 +539,13 @@ Karpenter does not add jitter to expiry — configure PDBs to prevent simultaneo
 
 **Force immediate node replacement:**
 
+To force replacement of a specific node, delete its NodeClaim — Karpenter drains the node (respecting PDBs) and provisions a replacement:
+
 ```bash
-kubectl annotate nodes --all karpenter.sh/voluntary-disruption=drifted --overwrite
+kubectl delete nodeclaim/<nodeclaim-name>
 ```
+
+There is no `karpenter.sh/voluntary-disruption` annotation that forces replacement across the fleet — setting such an annotation is a silent no-op. See the [Karpenter disruption docs](https://karpenter.sh/docs/concepts/disruption/).
 
 ### Managed Node Group Upgrades
 
@@ -541,6 +577,8 @@ For nodes deployed outside the EKS managed service, use your provisioning tool:
 
 ## Version Support Policy
 
+> **Version anchors as of 2026-08-04:** the standard-support versions are **1.34 / 1.35 / 1.36** (newest is 1.36). **1.31, 1.32, and 1.33 are all in extended support** (1.33 exited standard support 2026-07-29). These move roughly every quarter — always confirm the current/newest versions against the live [EKS Kubernetes version release calendar](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar) and the per-cluster API (below) rather than trusting a static list.
+
 ### EKS Version Lifecycle
 
 | Phase | Patching | Cost | Auto-upgrade? |
@@ -566,7 +604,7 @@ You can [disable extended support](https://docs.aws.amazon.com/eks/latest/usergu
 - **End of extended support:** query the API per cluster version
 - **After:** EKS auto-upgrades your cluster (may disrupt workloads)
 
-**Recommendation:** Upgrade every 3-4 months to stay within standard support. Budget one upgrade cycle per quarter. Look beyond the next version — review upcoming K8s releases to identify major changes early (e.g., Dockershim removal was announced well before 1.25).
+**Recommendation:** Upgrade every 3-4 months to stay within standard support. Budget one upgrade cycle per quarter. Look beyond the next version — review upcoming K8s releases to identify major changes early (e.g., Dockershim removal was announced well before 1.24).
 
 ### Additional Upgrade Tools
 
@@ -661,7 +699,7 @@ To verify SSM connectivity: check that the SSM agent is running on the node, the
 
 | Component | Can Rollback? | Method | Notes |
 |---|---|---|---|
-| **EKS control plane** | No | Cannot downgrade K8s version | Must rebuild cluster at previous version |
+| **EKS control plane** | Yes (within 7 days) | In-place rollback to N-1 via `update-cluster-version` type `VersionRollback` (gated by a `ROLLBACK_READINESS` insight); Auto Mode rolls back nodes automatically | Post-7-day: blue-green or rebuild is the fallback, not the only path. Add-ons/data-plane roll back separately. |
 | **Data plane nodes** | Yes | Replace with previous AMI | Karpenter: update EC2NodeClass AMI; MNG: update launch template |
 | **EKS managed add-ons** | Yes | Revert to previous version via API/Terraform | Some add-ons have minimum version requirements |
 | **Helm-managed add-ons** | Yes | `helm rollback` or GitOps revert | Check CRD compatibility |
@@ -708,4 +746,6 @@ Use when: catastrophic cluster failure, corrupted etcd state, or failed upgrade 
 **Sources:**
 - [AWS EKS Best Practices Guide — Cluster Upgrades](https://docs.aws.amazon.com/eks/latest/best-practices/cluster-upgrades.html)
 - [EKS Version Lifecycle](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)
+- [EKS control-plane version rollback](https://docs.aws.amazon.com/eks/latest/userguide/rollback-cluster.html) · [What's New — Amazon EKS version rollback](https://aws.amazon.com/about-aws/whats-new/2026/07/amazon-eks-version-rollback/)
 - [Karpenter Upgrade Guide](https://karpenter.sh/docs/upgrading/)
+- [Karpenter Disruption](https://karpenter.sh/docs/concepts/disruption/)

--- a/misc/website/docs/skills/eks/eks-best-practices/references/cluster-upgrades.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/cluster-upgrades.md
@@ -588,7 +588,7 @@ For nodes deployed outside the EKS managed service, use your provisioning tool:
 | Phase | Patching | Cost | Auto-upgrade? |
 |-------|----------|------|----------------|
 | **Standard support** | Security + bug fixes | Standard pricing | No |
-| **Extended support** | Critical security only | Additional per-hour surcharge | No |
+| **Extended support** | CP security patches + VPC CNI/kube-proxy/CoreDNS + EKS AMI patches; full AWS support | Additional per-hour surcharge | No |
 | **End of extended support** | None | N/A | Yes — AWS auto-upgrades at a time it chooses |
 
 **Always get exact dates from the EKS API — do not compute them from release dates.** Standard and extended support windows have historically shifted; the API is the only trustworthy source.

--- a/misc/website/docs/skills/eks/eks-best-practices/references/cluster-upgrades.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/cluster-upgrades.md
@@ -588,7 +588,7 @@ For nodes deployed outside the EKS managed service, use your provisioning tool:
 | Phase | Patching | Cost | Auto-upgrade? |
 |-------|----------|------|----------------|
 | **Standard support** | Security + bug fixes | Standard pricing | No |
-| **Extended support** | CP security patches + VPC CNI/kube-proxy/CoreDNS + EKS AMI patches; full AWS support | Additional per-hour surcharge | No |
+| **Extended support** | CP security patches + VPC CNI/kube-proxy/CoreDNS + EKS AMI patches | Additional per-hour surcharge | No |
 | **End of extended support** | None | N/A | Yes — AWS auto-upgrades at a time it chooses |
 
 **Always get exact dates from the EKS API — do not compute them from release dates.** Standard and extended support windows have historically shifted; the API is the only trustworthy source.

--- a/misc/website/docs/skills/eks/eks-best-practices/references/cluster-upgrades.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/cluster-upgrades.md
@@ -520,9 +520,13 @@ spec:
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
     budgets:
-    - nodes: "10%"    # Max 10% of nodes disrupted at a time
-    - nodes: "0"
-      schedule: "0 9 * * 1-5"  # No disruptions during business hours
+    - nodes: "10%"                 # all-reasons fallback: at most 10% of nodes disrupted at once
+    - nodes: "100%"
+      reasons: ["Empty"]           # always reclaim empty nodes without throttling (outside the freeze window)
+    - nodes: "0"                   # freeze ALL voluntary disruption during the scheduled window
+      # NOTE: Karpenter budget schedules are evaluated in UTC, not cluster-local time.
+      # 01:00 UTC = 09:00 in a UTC+8 region — anchor the cron to UTC accordingly.
+      schedule: "0 1 * * 1-5"      # 01:00 UTC Mon–Fri (e.g. 09:00 in UTC+8)
       duration: 8h
 ```
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/cluster-upgrades.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/cluster-upgrades.md
@@ -157,7 +157,7 @@ aws eks describe-update \
 - Can only upgrade one minor version at a time (1.34 → 1.35, not 1.34 → 1.36)
 - Control plane upgrade takes 15-30 minutes
 - API server remains available during upgrade (brief API errors possible)
-- Native in-place rollback to N-1 is supported within **7 days** of an in-place upgrade (GA, all regions, all cluster types; Auto Mode also rolls back nodes automatically). `update-cluster-version` supports type `VersionRollback`; a `ROLLBACK_READINESS` insight gates it. Add-ons/data-plane roll back separately. Past the 7-day window, roll back via blue-green or cluster rebuild.
+- Native in-place rollback to N-1 is supported within **7 days** of an in-place upgrade (GA, all regions; Auto Mode also rolls back nodes automatically). `update-cluster-version` supports type `VersionRollback`; a `ROLLBACK_READINESS` insight gates it. Rollback into an extended-support version requires setting the cluster upgrade policy to `EXTENDED` first (rollback-cluster.html). Add-ons/data-plane roll back separately. Past the 7-day window, roll back via blue-green or cluster rebuild.
 
 ### Step 2: Upgrade Add-ons
 
@@ -296,7 +296,7 @@ Spreading across zones and hosts ensures pods migrate to new nodes automatically
 |--------|------------|----------------|
 | **Route 53 weighted routing** | Percentage-based | Fast (DNS TTL) |
 | **ALB weighted target groups** | Percentage-based | Instant |
-| **NLB weighted target groups** | Percentage-based | Instant (weight shift is manual — no automatic failover) |
+| **NLB weighted target groups** | Percentage-based | Fast (new flows, ≤~3 min; existing flows drain) |
 | **Global Accelerator** | Endpoint weights | Instant |
 | **External DNS cutover** | All-or-nothing | DNS TTL dependent |
 
@@ -320,8 +320,8 @@ aws elbv2 modify-listener \
 
 Constraints:
 - Use **`ip`-type** target groups with a `TargetGroupBinding` per cluster. Never share one target group between clusters — the two clusters' controllers will fight over registration/deregistration.
-- With the AWS Load Balancer Controller, set `multiClusterTargetGroup: true` so the controller does not deregister targets it did not create.
-- **NLB has no automatic failover** — weight shifts are manual, so watch health checks and roll weights back yourself if the green cluster misbehaves.
+- With the AWS Load Balancer Controller, set `multiClusterTargetGroup: true` so the controller does not deregister targets it did not create — the flag guards a manually-created target group from controller deregistration, so the LBC manages only targets it registered on the manually-provisioned target group.
+- **NLB has no automatic failover between weighted target groups** (unlike ALB automatic target weights), as of 2026-08-05 — weight shifts are manual, so watch health checks and roll weights back yourself if the green cluster misbehaves.
 
 ### Blue-Green Downsides to Consider
 
@@ -520,9 +520,10 @@ spec:
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
     budgets:
-    - nodes: "10%"                 # all-reasons fallback: at most 10% of nodes disrupted at once
+    - nodes: "10%"                 # fallback for churn-driven disruption (drift/underutilization)
+      reasons: ["Drifted","Underutilized"]
     - nodes: "100%"
-      reasons: ["Empty"]           # always reclaim empty nodes without throttling (outside the freeze window)
+      reasons: ["Empty"]           # reclaim empty nodes at full speed (not capped by the fallback above)
     - nodes: "0"                   # freeze ALL voluntary disruption during the scheduled window
       # NOTE: Karpenter budget schedules are evaluated in UTC, not cluster-local time.
       # 01:00 UTC = 09:00 in a UTC+8 region — anchor the cron to UTC accordingly.

--- a/misc/website/docs/skills/eks/eks-best-practices/references/container-registry.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/container-registry.md
@@ -139,10 +139,10 @@ DON'T:
 
 | Feature | Basic Scanning | Enhanced Scanning (Inspector) |
 |---|---|---|
-| **Engine** | Clair (open-source) | Amazon Inspector |
+| **Engine** | AWS-native (`AWS_NATIVE`) | Amazon Inspector |
 | **Coverage** | OS packages only | OS + programming language libraries |
-| **Trigger** | On-push only | Continuous (re-scans on new CVE disclosure) |
-| **Findings** | ECR console only | Security Hub + EventBridge |
+| **Trigger** | On-push, plus manual on-demand scans | Continuous (re-scans on new CVE disclosure) |
+| **Findings** | ECR console + EventBridge | Security Hub + EventBridge |
 | **Cost** | Free | Per-image pricing |
 | **Limitation** | -- | Cannot scan archived images (must restore first) |
 | **Recommendation** | Development only | Production |
@@ -290,8 +290,9 @@ ECR pull-through cache rules automatically cache images from upstream public reg
 | **Docker Hub** | `docker.io` | Yes (Secrets Manager) |
 | **ECR Public** | `public.ecr.aws` | No |
 | **GitHub Container Registry** | `ghcr.io` | Yes (Secrets Manager) |
-| **Quay.io** | `quay.io` | Yes (Secrets Manager) |
+| **Quay.io** | `quay.io` | No |
 | **Kubernetes Registry** | `registry.k8s.io` | No |
+| **ECR (another private ECR)** | `<account>.dkr.ecr.<region>.amazonaws.com` | Yes (IAM/cross-account) |
 | **GitLab Container Registry** | `registry.gitlab.com` | Yes (Secrets Manager) |
 | **Chainguard** | `cgr.dev` | Yes (Secrets Manager) |
 | **Azure Container Registry** | `<name>.azurecr.io` | Yes (Secrets Manager) |
@@ -424,7 +425,7 @@ ECR archival storage provides a low-cost tier for images you need to retain but 
 | **Transition** | Via lifecycle policy `archive` action, or manual API call |
 | **Storage cost** | Lower than standard ECR storage |
 | **Restore time** | Up to 20 minutes |
-| **Restore duration** | Restored copy available for a configurable number of days |
+| **Restore duration** | Permanent -- restore moves the image back to the STANDARD storage class; there is no timed window after which it re-archives |
 | **Scanning** | Archived images cannot be scanned -- restore first |
 
 ### Lifecycle Policy Integration
@@ -481,19 +482,26 @@ Blob mounting allows image layers that already exist in one repository to be ref
 
 | Setting | Effect |
 |---|---|
-| **Enabled (default)** | Push operations mount existing layers from other repos, saving bandwidth and time |
-| **Disabled** | Every push uploads all layers, even if identical copies exist in the registry |
+| **Disabled (default)** | Every push uploads all layers, even if identical copies exist in the registry |
+| **Enabled (opt-in)** | Push operations mount existing layers from other repos, saving bandwidth and time |
 
-Keep blob mounting enabled unless you have a specific security requirement to isolate layer access between repositories.
+Blob mounting is **off by default** -- opt in at the registry level with `aws ecr put-account-setting --name BLOB_MOUNTING --value ENABLED`. Constraints once enabled:
+- Not supported for pull-through-cache (PTC) images
+- Source and destination repositories must use identical encryption keys
+- Cross-repository mounts require the caller to hold `ecr:GetDownloadUrlForLayer` on the source repository
+
+Enable it when many images share common base layers, unless you have a specific security requirement to isolate layer access between repositories.
 
 ### Pull-Time Update Exclusions
 
-When pull-through cache is enabled, ECR checks the upstream registry for updates every 24 hours. Pull-time update exclusions let you pin specific repositories so ECR never re-checks upstream -- the cached version is treated as authoritative.
+Pull-time update exclusions are a registry setting that lists IAM role ARNs (up to 100 per account) whose image pulls do **not** update an image's `LastRecordedPullTime`. They have nothing to do with caching or pinning upstream versions.
 
-Use this for:
-- **Known-good images** you've validated and don't want upstream changes to override
-- **Air-gapped environments** where you've seeded images and upstream is unreachable
-- **Compliance scenarios** where you need a frozen, auditable copy
+The purpose is to protect `sinceImagePulled` lifecycle policies from being skewed by automated pulls. Security scanners, replication jobs, and other automation pull images frequently; without exclusions, those pulls keep refreshing `LastRecordedPullTime` and make images look "actively used," defeating lifecycle rules that expire images nobody actually deploys.
+
+Use this to:
+- **Exclude scanner roles** (e.g., Inspector or third-party CVE scanners) so their pulls don't reset the pull clock
+- **Exclude replication/automation roles** whose pulls shouldn't count as real usage
+- **Keep `sinceImagePulled` lifecycle policies accurate** so only genuinely-used images are retained
 
 ---
 
@@ -531,6 +539,8 @@ The workflow for Helm charts stored in ECR OCI follows three steps:
 - [Designing a secure container image registry](https://aws.amazon.com/blogs/containers/designing-a-secure-container-image-registry/)
 - [Amazon Inspector container scanning](https://docs.aws.amazon.com/inspector/latest/user/scanning-ecr.html)
 - [ECR Pull-Through Cache](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache.html)
+- [ECR Basic Scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning-basic.html)
+- [ECR Pull-Time Update Exclusions](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-time-update-exclusions.html)
 - [ECR Managed Signing](https://docs.aws.amazon.com/AmazonECR/latest/userguide/managed-signing.html)
 - [ECR Archival Storage](https://docs.aws.amazon.com/AmazonECR/latest/userguide/archive_restore_image.html)
 - [ECR Repository Creation Templates](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-creation-templates.html)

--- a/misc/website/docs/skills/eks/eks-best-practices/references/container-registry.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/container-registry.md
@@ -425,7 +425,7 @@ ECR archival storage provides a low-cost tier for images you need to retain but 
 | **Transition** | Via lifecycle policy `archive` action, or manual API call |
 | **Storage cost** | Lower than standard ECR storage |
 | **Restore time** | Up to 20 minutes |
-| **Restore duration** | Permanent -- restore moves the image back to the STANDARD storage class; there is no timed window after which it re-archives |
+| **Restore duration** | Permanent -- restore moves the image back to the STANDARD storage class; there is no timed window after which it re-archives (as of 2026-08-04) |
 | **Scanning** | Archived images cannot be scanned -- restore first |
 
 ### Lifecycle Policy Integration
@@ -486,7 +486,7 @@ Blob mounting allows image layers that already exist in one repository to be ref
 | **Enabled (opt-in)** | Push operations mount existing layers from other repos, saving bandwidth and time |
 
 Blob mounting is **off by default** -- opt in at the registry level with `aws ecr put-account-setting --name BLOB_MOUNTING --value ENABLED`. Constraints once enabled:
-- Not supported for pull-through-cache (PTC) images
+- Not supported for pull-through-cache (PTC) images (as of 2026-08-04)
 - Source and destination repositories must use identical encryption keys
 - Cross-repository mounts require the caller to hold `ecr:GetDownloadUrlForLayer` on the source repository
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/cost-optimization.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/cost-optimization.md
@@ -44,7 +44,7 @@ The "See" pillar comes first because you can't optimize what you can't measure. 
 
 | Component | Cost Driver | Optimization Lever |
 |-----------|-----------|-------------------|
-| **EKS control plane** | $0.10/hour per cluster | Fewer clusters, multi-tenant |
+| **EKS control plane** | $0.10/hour per cluster (standard support); $0.60/hour under extended support (6x) | Stay in standard support, fewer clusters, multi-tenant |
 | **EC2 instances** | Instance type + hours | Right-sizing, Spot, Graviton |
 | **EBS volumes** | Volume type + size + IOPS | gp3, right-size, cleanup unused |
 | **Data transfer** | Cross-AZ, internet egress | Topology-aware routing, VPC endpoints |
@@ -52,10 +52,13 @@ The "See" pillar comes first because you can't optimize what you can't measure. 
 | **NAT Gateway** | Per GB processed + hourly | VPC endpoints for AWS services |
 | **Observability** | Log ingestion + metric storage | Filter, retain selectively, reduce cardinality |
 
+> **Control-plane support tier is the largest controllable control-plane cost lever.** Standard support is $0.10/hour per cluster; once a version exits standard support it moves to **extended support at $0.60/hour -- 6x the standard rate**. As of 2026-08-04, Kubernetes versions 1.31, 1.32, and 1.33 are all in extended support. Staying on a standard-support version (upgrade before standard support ends) avoids roughly **+$4,380/yr per cluster**. EKS Auto Mode adds a separate management fee on top of control-plane and EC2 costs.
+
 ### Quick Wins
 
 | Action | Typical Savings | Effort |
 |--------|----------------|--------|
+| Stay in EKS standard support | ~$4,380/yr per cluster ($0.60 vs $0.10/hr) | Low -- upgrade before standard support ends |
 | Switch to Graviton (arm64) | 20-40% | Low -- rebuild images for arm64 |
 | Use Spot for non-critical | 60-90% | Low -- Karpenter handles fallback |
 | Enable Karpenter consolidation | 20-30% | Low -- enable in NodePool |
@@ -292,13 +295,13 @@ kind: Service
 metadata:
   name: orders-service
 spec:
-  trafficDistribution: PreferClose
+  trafficDistribution: PreferSameZone   # formerly PreferClose (alias still works)
   selector:
     app: orders
   type: ClusterIP
 ```
 
-`PreferClose` routes to same-zone endpoints first, falling back to any endpoint when none are local. Can overload endpoints in high-traffic zones -- mitigate with per-zone deployments with independent HPAs, or topology spread constraints.
+`PreferSameZone` (the renamed `PreferClose`; the `PreferClose` alias still works) routes to same-zone endpoints first, falling back to any endpoint when none are local. A `PreferSameNode` option also exists to prefer node-local endpoints. Can overload endpoints in high-traffic zones -- mitigate with per-zone deployments with independent HPAs, or topology spread constraints.
 
 **Service Internal Traffic Policy** restricts traffic to the originating node:
 
@@ -344,7 +347,7 @@ Use **IP mode** to eliminate data transfer charges from LB-to-Pod traffic. Ensur
 | **gp3 root volume** | ~20% less than gp2 | Default choice for node root volumes |
 | **EC2 instance stores** | No additional cost | Caches, scratch space, temporary data |
 
-Instance stores are physically attached to the host -- free, but data is lost on termination. Use `HostPath` or the Local Persistent Volume Static Provisioner to expose them in Kubernetes.
+Instance stores are physically attached to the host -- free, but data is lost on termination. The **Instance Store CSI driver is GA as an EKS managed add-on (as of 2026-08-04)** and supersedes the `HostPath` / Local Persistent Volume Static Provisioner approach for exposing them in Kubernetes.
 
 ### Persistent Volumes: EBS
 
@@ -406,6 +409,8 @@ For FSx for Lustre, link to S3 for long-term storage -- lazy-load data into Lust
 | Container image optimization | Distroless/scratch base images, multi-stage builds |
 | Clean up dangling volumes | Direct savings -- Popeye or AWS Trusted Advisor |
 | EBS snapshot retention policy | Avoid unbounded snapshot growth via DLM or Velero TTL |
+
+> **Backup:** beyond Velero, **AWS Backup now supports EKS** (cluster-state and persistent-volume backups) as a managed option -- consider it alongside Velero for a native backup story.
 
 ---
 
@@ -493,7 +498,7 @@ AWS resource tags don't directly correlate with Kubernetes labels. Use Kubernete
 |------|-------|------|----------|
 | **AWS Cost Explorer** | Account-level | Free | High-level trends, SP/RI recommendations |
 | **Kubecost** | Cluster-level | Free (open source) | Per-namespace/pod cost allocation |
-| **CloudWatch Container Insights** | Cluster + pod | ~$0.30/container/month | Resource utilization monitoring |
+| **CloudWatch Container Insights** | Cluster + pod | $0.21 per 1M observations, tiered (e.g. ~$51.75/mo for a 10-node/20-pod cluster, as of 2026-08-04) | Resource utilization monitoring |
 | **AWS Billing + tags** | Account-level | Free | Chargeback by team/project |
 | **Karpenter metrics** | Node-level | Free | Consolidation efficiency |
 
@@ -513,7 +518,7 @@ helm install kubecost kubecost/cost-analyzer \
 | Namespace/label cost allocation | Yes | Yes |
 | Right-sizing recommendations | Yes | Yes |
 | Idle cost detection | Yes | Yes |
-| Multi-cluster | No | Yes |
+| Multi-cluster | Yes -- unlimited clusters up to 250 cores total | Yes (no core limit) |
 | SSO/RBAC | No | Yes |
 | Long-term storage | 15 days | Unlimited |
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/eks-auto-mode.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/eks-auto-mode.md
@@ -38,7 +38,7 @@ Auto Mode is geared towards users that want the benefits of Kubernetes and EKS b
 | **Compliance (custom AMI pinning, air-gapped)** | Limited -- no custom AMIs | Full control |
 | **Cost** | Standard EC2 pricing + Auto Mode management fee on managed nodes | Standard EC2 pricing + self-managed operational cost |
 | **Mix with other compute** | Yes -- can run MNG alongside Auto Mode nodes | Yes -- can run MNG alongside Karpenter nodes |
-| **Troubleshooting managed components** | AWS Support ticket (components run off-cluster) | Direct access to pod logs |
+| **Troubleshooting managed components** | Self-service: `NodeDiagnostic`, `kubectl debug node`, `get-console-output`, CloudWatch Insights (managed controllers' own pod logs still not exposed) | Direct access to pod logs |
 
 **Choose Auto Mode when:** Minimal ops is the priority, standard Bottlerocket AMIs are acceptable, and you don't need custom AMI configurations or air-gapped setups.
 
@@ -85,7 +85,7 @@ A new Auto Mode cluster comes pre-configured with two NodePools:
 Provisions nodes with:
 - Capacity Type: On-Demand
 - Instance Types: C, M, or R families
-- Instance Generation: 4+
+- Instance Generation: 5 or newer
 - Architecture: AMD (x86_64)
 - OS: Linux
 - Disruption: max 10% of nodes disrupted at any time, consolidation when empty or underutilized
@@ -122,7 +122,14 @@ Currently the only supported AMIs are Amazon-provided Bottlerocket. No custom AM
 Because AMI customization is not supported, if you need host-level software for things like security scanning, deploy it as a Kubernetes DaemonSet.
 
 ### Troubleshooting Managed Components
-With EKS Auto Mode, components like the AWS Load Balancer Controller and Karpenter are managed outside your cluster. You won't have direct visibility into their logs. If troubleshooting is needed, create an AWS Support Ticket.
+With EKS Auto Mode, components like the AWS Load Balancer Controller and Karpenter are managed outside your cluster, so their own controller pod logs are not exposed. However, node-level troubleshooting is self-service and does not require a support ticket:
+
+- **`NodeDiagnostic`** — collect node log bundles and export them to S3
+- **`kubectl debug node`** — start a debugging container on the node
+- **`get-console-output`** — retrieve EC2 instance console output
+- **CloudWatch Insights** — Karpenter provisioning/scheduling decision events
+
+Open an AWS Support case only for issues that these self-service tools cannot surface (e.g. the internals of the off-cluster managed controllers).
 
 ### Mixed Compute
 You may run managed node groups alongside Auto Mode-managed nodes in the same cluster.

--- a/misc/website/docs/skills/eks/eks-best-practices/references/karpenter.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/karpenter.md
@@ -286,7 +286,7 @@ spec:
 
 ### Create Mutually Exclusive or Weighted NodePools
 
-If multiple NodePools match a pod's scheduling requirements and they are neither mutually exclusive (via taints/selectors) nor weighted, Karpenter **randomly chooses** which NodePool to use. This causes unpredictable scheduling. Design NodePools so they either:
+If multiple NodePools match a pod's scheduling requirements and they are neither mutually exclusive (via taints/selectors) nor weighted, Karpenter breaks the tie **deterministically**: NodePools are ordered by `weight` (descending), and on equal weight the NodePool whose name sorts **later in the alphabet** is tried first (Karpenter scheduler source, `OrderByWeight`, as of 2026-08-05). This ordering is easy to get wrong by accident, so scheduling is still hard to reason about. Design NodePools so they either:
 - **Don't overlap** -- use taints on specialized NodePools (GPU, high-memory) so only pods with matching tolerations schedule there
 - **Use weights** -- set `weight` to establish preference ordering among overlapping NodePools
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/karpenter.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/karpenter.md
@@ -35,7 +35,7 @@ This page is generated from [skills/eks-best-practices/references/karpenter.md](
 
 ### Run Karpenter on Fargate or a Dedicated MNG
 
-The Karpenter controller runs as a Deployment that must be available before Karpenter can scale your cluster. (The separate webhook Deployment was removed in Karpenter v1.0/1.1 -- webhooks are no longer a distinct component, so there is a single controller Deployment to schedule.) Run it on infrastructure Karpenter does not manage -- either a small MNG (at least one worker node) or a Fargate profile for the `karpenter` namespace. If Karpenter runs on a node it manages, it could scale down that node and lose the ability to provision replacements.
+The Karpenter controller runs as a Deployment that must be available before Karpenter can scale your cluster. (Webhook containers were consolidated into the controller binary (v0.19.0), disabled by default (v0.33.0) -- a single controller Deployment today.) Run it on infrastructure Karpenter does not manage -- either a small MNG (at least one worker node) or a Fargate profile for the `karpenter` namespace. If Karpenter runs on a node it manages, it could scale down that node and lose the ability to provision replacements.
 
 ### Lock Down AMIs in Production
 
@@ -222,7 +222,7 @@ To prevent this, set `requests == limits` for memory and other non-CPU resources
 
 ### Disruption Budgets
 
-`disruption.budgets` caps how much voluntary disruption Karpenter performs at once, across all NodePool-initiated actions. **When you define no budgets, the default is a single budget of `nodes: 10%`** -- Karpenter disrupts at most 10% of the NodePool's nodes concurrently.
+`disruption.budgets` caps how much voluntary disruption Karpenter performs at once, across drift, emptiness, and consolidation (expiration exempt). **When you define no budgets, the default is a single budget of `nodes: 10%`** -- Karpenter disrupts at most 10% of the NodePool's nodes concurrently.
 
 A budget's allowed node count is computed as:
 
@@ -232,22 +232,23 @@ allowed = roundup(total_nodes * percentage) - currently_deleting - not_ready
 
 so `notReady` and in-flight deletions already count against the budget. A budget may be expressed as a percentage (`nodes: "10%"`) or an absolute count (`nodes: "5"`); `nodes: "0"` blocks all voluntary disruption for the window.
 
-**Reasons-based budgets** scope a budget to specific disruption reasons via the `reasons` field (`Drifted`, `Underutilized`, `Empty`). A budget with no `reasons` applies to every reason. This lets you, for example, allow empty-node reclamation to run wide open while throttling underutilization-driven consolidation:
+**Reasons-based budgets** scope a budget to specific disruption reasons via the `reasons` field (`Drifted`, `Underutilized`, `Empty`). A budget with no `reasons` applies to every reason. This lets you, for example, allow empty-node reclamation to proceed at full speed while throttling underutilization-driven consolidation:
 
 ```yaml
 spec:
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
     budgets:
-    - nodes: "20%"                    # applies to all reasons (fallback)
+    - nodes: "20%"                    # fallback for drift/underutilization churn
+      reasons: ["Drifted","Underutilized"]
     - nodes: "100%"
-      reasons: ["Empty"]              # reclaim empty nodes without throttling
+      reasons: ["Empty"]              # reclaim empty nodes at full speed (not capped by the fallback)
     - nodes: "5%"
-      reasons: ["Underutilized"]      # go slow on underutilization churn
+      reasons: ["Underutilized"]      # extra throttle on underutilization churn
 ```
 
 **Scheduled / business-hours budgets** (e.g. a `nodes: "0"` block on a cron `schedule` + `duration` to freeze disruption during business hours) are documented once, alongside the drift-during-upgrade flow, rather than duplicated here. See:
-- [cluster-upgrades.md -- Karpenter Node Upgrades](cluster-upgrades#karpenter-node-upgrades) for the canonical 3-budget pattern in one NodePool spec: a 10% all-reasons fallback, always-allow-`Empty` at 100%, and a scheduled `nodes: "0"` freeze window (UTC cron)
+- [cluster-upgrades.md -- Karpenter Node Upgrades](cluster-upgrades#karpenter-node-upgrades) for the canonical 3-budget pattern in one NodePool spec: a 10% fallback scoped to churn (drift/underutilization), an unthrottled `Empty` budget at 100%, and a scheduled `nodes: "0"` freeze window (UTC cron)
 - [SKILL.md -- Data Plane with Karpenter](../#data-plane-with-karpenter) for the same budget in the upgrade-speed context
 - [reliability-core.md -- PDB Interaction with Karpenter](reliability-core#pdb-interaction-with-karpenter) for how budgets compose with Pod Disruption Budgets
 
@@ -262,6 +263,7 @@ The NodePool-level `terminationGracePeriod` (a v1 field, distinct from a pod's `
 - It has **no default** -- when unset (nil), Karpenter waits **indefinitely** for pods to drain, so a blocking PDB or `do-not-disrupt` pod can stall the node.
 - Setting it bounds the maximum node lifetime: **max node lifetime = `terminationGracePeriod` + `expireAfter`** (the node can live up to `expireAfter`, then take up to `terminationGracePeriod` to finish draining).
 - Do not confuse it with the pod-level `terminationGracePeriodSeconds` (default 30s), which governs a single pod's shutdown, not the node's drain deadline.
+- With `terminationGracePeriod` set, a node can be disrupted via **Drift even when blocking PDBs or `do-not-disrupt` are present** -- the drain then proceeds up to the grace-period deadline, after which pods are force-evicted (see the [Karpenter disruption docs](https://karpenter.sh/docs/concepts/disruption/)).
 
 ```yaml
 spec:

--- a/misc/website/docs/skills/eks/eks-best-practices/references/karpenter.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/karpenter.md
@@ -35,7 +35,7 @@ This page is generated from [skills/eks-best-practices/references/karpenter.md](
 
 ### Run Karpenter on Fargate or a Dedicated MNG
 
-The Karpenter controller and webhook run as a Deployment that must be available before Karpenter can scale your cluster. Run them on infrastructure Karpenter does not manage -- either a small MNG (at least one worker node) or a Fargate profile for the `karpenter` namespace. If Karpenter runs on a node it manages, it could scale down that node and lose the ability to provision replacements.
+The Karpenter controller runs as a Deployment that must be available before Karpenter can scale your cluster. (The separate webhook Deployment was removed in Karpenter v1.0/1.1 -- webhooks are no longer a distinct component, so there is a single controller Deployment to schedule.) Run it on infrastructure Karpenter does not manage -- either a small MNG (at least one worker node) or a Fargate profile for the `karpenter` namespace. If Karpenter runs on a node it manages, it could scale down that node and lose the ability to provision replacements.
 
 ### Lock Down AMIs in Production
 
@@ -43,11 +43,11 @@ Pin well-known AMI versions for production clusters. Using `@latest` or methods 
 
 ```yaml
 amiSelectorTerms:
-- alias: al2023@v20240807  # Pin tested version in production
+- alias: al2023@v20240807  # Illustrative pin -- check the current AMI alias
 # Use al2023@latest only in dev/test
 ```
 
-Test newer AMI versions in non-production clusters before rolling to production.
+The `v20240807` alias above is a 2024-era example, not a recommended value -- look up the current tested AMI alias for your Kubernetes version and pin that. Test newer AMI versions in non-production clusters before rolling to production.
 
 ### No Custom Launch Templates
 
@@ -97,6 +97,8 @@ spec:
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
     consolidateAfter: 1m
+    budgets:
+    - nodes: "10%"   # Cap concurrent voluntary disruption (see Disruption Budgets)
 
   limits:
     cpu: "1000"
@@ -141,7 +143,7 @@ metadata:
 spec:
   role: KarpenterNodeRole-my-cluster
   amiSelectorTerms:
-  - alias: al2023@v20240807  # Pin AMI version in production
+  - alias: al2023@v20240807  # Illustrative pin -- check current AMI alias, not a hard-coded value
   subnetSelectorTerms:
   - tags:
       karpenter.sh/discovery: my-cluster
@@ -203,17 +205,80 @@ Do not use Karpenter interruption handling alongside AWS Node Termination Handle
 | Policy | Behavior | Use When |
 |--------|----------|----------|
 | **WhenEmpty** | Only replaces nodes with zero pods | Conservative -- minimal disruption |
-| **WhenEmptyOrUnderutilized** | Replaces underutilized nodes too | Default -- best cost optimization |
+| **WhenEmptyOrUnderutilized** | Replaces empty nodes and consolidates underutilized ones | Best cost optimization |
+| **Balanced** | Consolidates while weighing disruption cost against savings, favoring fewer, less disruptive actions | GA in Karpenter v1.14.0 (current) -- steadier middle ground between the two above |
 
 **Consolidation respects:**
 - Pod disruption budgets
 - `karpenter.sh/do-not-disrupt: "true"` annotation on pods or nodes
+
+These two protections gate **consolidation and drift** only. They do **not** block node **expiration** -- see [do-not-disrupt Does Not Block Expiration](#do-not-disrupt-does-not-block-expiration).
 
 ### Set requests=limits for Non-CPU Resources
 
 Consolidation packs pods based on resource **requests**, not limits. Pods with memory limits higher than requests can burst above requests. If several pods on the same node burst simultaneously, this can trigger OOM kills. Consolidation makes this more likely because it packs nodes more tightly.
 
 To prevent this, set `requests == limits` for memory and other non-CPU resources. CPU is the exception -- CPU is compressible and throttling (not OOM) is the consequence of exceeding limits.
+
+### Disruption Budgets
+
+`disruption.budgets` caps how much voluntary disruption Karpenter performs at once, across all NodePool-initiated actions. **When you define no budgets, the default is a single budget of `nodes: 10%`** -- Karpenter disrupts at most 10% of the NodePool's nodes concurrently.
+
+A budget's allowed node count is computed as:
+
+```
+allowed = roundup(total_nodes * percentage) - currently_deleting - not_ready
+```
+
+so `notReady` and in-flight deletions already count against the budget. A budget may be expressed as a percentage (`nodes: "10%"`) or an absolute count (`nodes: "5"`); `nodes: "0"` blocks all voluntary disruption for the window.
+
+**Reasons-based budgets** scope a budget to specific disruption reasons via the `reasons` field (`Drifted`, `Underutilized`, `Empty`). A budget with no `reasons` applies to every reason. This lets you, for example, allow empty-node reclamation to run wide open while throttling underutilization-driven consolidation:
+
+```yaml
+spec:
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    budgets:
+    - nodes: "20%"                    # applies to all reasons (fallback)
+    - nodes: "100%"
+      reasons: ["Empty"]              # reclaim empty nodes without throttling
+    - nodes: "5%"
+      reasons: ["Underutilized"]      # go slow on underutilization churn
+```
+
+**Scheduled / business-hours budgets** (e.g. a `nodes: "0"` block on a cron `schedule` + `duration` to freeze disruption during business hours) are documented once, alongside the drift-during-upgrade flow, rather than duplicated here. See:
+- [cluster-upgrades.md -- Karpenter Node Upgrades](cluster-upgrades#karpenter-node-upgrades) for the scheduled `nodes: "0"` business-hours block (plus always-allow-`Empty` at 100% and a 10% fallback)
+- [SKILL.md -- Data Plane with Karpenter](../#data-plane-with-karpenter) for the same budget in the upgrade-speed context
+- [reliability-core.md -- PDB Interaction with Karpenter](reliability-core#pdb-interaction-with-karpenter) for how budgets compose with Pod Disruption Budgets
+
+### do-not-disrupt Does Not Block Expiration
+
+`karpenter.sh/do-not-disrupt: "true"` and blocking PDBs gate the **graceful/voluntary** disruption methods -- consolidation and drift. **Expiration (`expireAfter`) is a forceful disruption method and is NOT blocked by these protections.** When a node reaches `expireAfter`, Karpenter proceeds with replacement regardless of the annotation; pod eviction is deferred at most until the node's configured `terminationGracePeriod` (see below), after which pods are force-drained. Do not rely on `do-not-disrupt` to keep an expired node alive indefinitely -- use it to protect against consolidation/drift churn, and tune `expireAfter` for node lifetime.
+
+### NodePool terminationGracePeriod (v1)
+
+The NodePool-level `terminationGracePeriod` (a v1 field, distinct from a pod's `terminationGracePeriodSeconds`) is the safety escape hatch against PDB deadlock. Once a node begins terminating, Karpenter waits at most this long for a graceful drain; when the deadline passes it **forces the drain, overriding blocking PDBs and `do-not-disrupt`**. This is what prevents a single stuck PDB from pinning a node forever.
+
+- It has **no default** -- when unset (nil), Karpenter waits **indefinitely** for pods to drain, so a blocking PDB or `do-not-disrupt` pod can stall the node.
+- Setting it bounds the maximum node lifetime: **max node lifetime = `terminationGracePeriod` + `expireAfter`** (the node can live up to `expireAfter`, then take up to `terminationGracePeriod` to finish draining).
+- Do not confuse it with the pod-level `terminationGracePeriodSeconds` (default 30s), which governs a single pod's shutdown, not the node's drain deadline.
+
+```yaml
+spec:
+  template:
+    spec:
+      expireAfter: 720h
+      terminationGracePeriod: 24h  # force drain 24h after termination begins, even past a blocking PDB
+```
+
+### Reducing Sudden Node Changes / Stabilizing Consolidation
+
+**Symptom:** nodes churn or the cluster sees sudden node changes as consolidation repeatedly repacks workloads. These levers, applied together, stabilize consolidation without turning it off:
+
+- **Raise `consolidateAfter`.** The examples in this doc use short values like `1m` to illustrate the field; short windows make Karpenter act on brief lulls. Values in the **15--60m** range let load settle before consolidation triggers, cutting churn.
+- **Add `disruption.budgets`** to cap how many nodes move at once (start from the default 10%, and consider reasons-based budgets to throttle only `Underutilized`).
+- **Use `WhenEmpty` on the single most interruption-sensitive NodePool** -- not generically across every NodePool. Reserve conservative consolidation for the workloads that most dislike being moved, and keep `WhenEmptyOrUnderutilized` (or `Balanced`) elsewhere so you still capture savings.
+- **Apply `do-not-disrupt` to the critical pods themselves** so consolidation and drift leave them in place (remember this does not stop expiration).
 
 ---
 
@@ -332,7 +397,9 @@ If routing Karpenter container logs to CloudWatch Logs, create a metrics filter 
 
 ### Use do-not-disrupt for Long-Running Workloads
 
-For batch jobs, ML training, or stateful workloads that are expensive to restart, annotate pods with `karpenter.sh/do-not-disrupt: "true"`. This prevents Karpenter from terminating the node even if `expireAfter` has been reached or consolidation would normally trigger. The annotation is respected until the pod terminates or the annotation is removed.
+For batch jobs, ML training, or stateful workloads that are expensive to restart, annotate pods with `karpenter.sh/do-not-disrupt: "true"`. This prevents Karpenter from disrupting the node via **consolidation or drift** while the pod runs; the annotation is respected until the pod terminates or the annotation is removed.
+
+**It does not, however, block expiration.** `expireAfter` is a forceful disruption method: when a node hits its expiry, Karpenter replaces it regardless of `do-not-disrupt` (pod eviction is deferred at most until the node's `terminationGracePeriod`). See [do-not-disrupt Does Not Block Expiration](#do-not-disrupt-does-not-block-expiration). For workloads that must not be interrupted mid-run, size `expireAfter` (and, if set, `terminationGracePeriod`) to outlast the work rather than relying on the annotation alone.
 
 Note: if the only non-daemonset pods left on a node are from completed Jobs (status succeeded or failed), Karpenter can still terminate that node.
 
@@ -381,6 +448,9 @@ When running EKS in a VPC with no internet access, Karpenter requires these VPC 
 | **SSM** | Karpenter queries SSM parameters for AMI IDs during node provisioning |
 | **EC2** | Standard EC2 API calls for instance provisioning |
 | **EKS** | EKS API calls |
+| **SQS** | Interruption handling polls the SQS interruption queue (required if you enable `--interruption-queue`, above) |
+| **ECR** (`ecr.api` + `ecr.dkr`) | Nodes pull container images from Amazon ECR |
+| **S3** (gateway endpoint) | ECR image layers and other artifacts are served from S3 |
 
 **No VPC endpoint exists for the Price List Query API.** Karpenter bundles on-demand pricing data in its binary, but this data only updates when Karpenter is upgraded. You'll see non-fatal errors about pricing data retrieval -- these are expected in private clusters.
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/karpenter.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/karpenter.md
@@ -247,7 +247,7 @@ spec:
 ```
 
 **Scheduled / business-hours budgets** (e.g. a `nodes: "0"` block on a cron `schedule` + `duration` to freeze disruption during business hours) are documented once, alongside the drift-during-upgrade flow, rather than duplicated here. See:
-- [cluster-upgrades.md -- Karpenter Node Upgrades](cluster-upgrades#karpenter-node-upgrades) for the scheduled `nodes: "0"` business-hours block (plus always-allow-`Empty` at 100% and a 10% fallback)
+- [cluster-upgrades.md -- Karpenter Node Upgrades](cluster-upgrades#karpenter-node-upgrades) for the canonical 3-budget pattern in one NodePool spec: a 10% all-reasons fallback, always-allow-`Empty` at 100%, and a scheduled `nodes: "0"` freeze window (UTC cron)
 - [SKILL.md -- Data Plane with Karpenter](../#data-plane-with-karpenter) for the same budget in the upgrade-speed context
 - [reliability-core.md -- PDB Interaction with Karpenter](reliability-core#pdb-interaction-with-karpenter) for how budgets compose with Pod Disruption Budgets
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/networking-ingress-dns.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/networking-ingress-dns.md
@@ -41,7 +41,7 @@ This page is generated from [skills/eks-best-practices/references/networking-ing
 | **AWS ALB (via LBC)** | HTTP/HTTPS, gRPC | Web apps, REST APIs | Native WAF, Cognito auth |
 | **AWS NLB (via LBC)** | TCP/UDP, TLS | Non-HTTP, ultra-low latency | Static IPs, preserve source IP |
 | **Gateway API + LBC** | HTTP/HTTPS | New standard, future-proof | Multi-team route management |
-| **VPC Lattice** | HTTP/HTTPS | Cross-VPC, service-to-service | No ingress controller needed |
+| **VPC Lattice** | HTTP/HTTPS | Cross-VPC, service-to-service | No ALB/NLB ingress controller (still runs the in-cluster Gateway API controller) |
 | **NGINX Ingress** | HTTP/HTTPS | Complex routing, rate limiting | Most configurable |
 | **Istio Gateway** | HTTP/HTTPS, TCP | Service mesh users | Integrated with Istio |
 
@@ -181,14 +181,25 @@ spec:
 
 Gateway API is the successor to the Ingress resource, offering role-oriented resource model and multi-team route management. **Recommended for new deployments.**
 
+**Two different AWS implementations back Gateway API — do not blend them.** The `controllerName` on the GatewayClass decides which one you get:
+
+| Implementation | GatewayClass `controllerName` | Provisions | Use for |
+|---|---|---|---|
+| **AWS Load Balancer Controller (LBC) Gateway API** | `gateway.k8s.aws/alb` (L7) or `gateway.k8s.aws/nlb` (L4) | An ALB (L7) or NLB (L4) | In-cluster ingress that would otherwise use an ALB/NLB Ingress or Service |
+| **VPC Lattice (Gateway API controller)** | `application-networking.k8s.aws/gateway-api-controller` | A VPC Lattice service network | Cross-VPC / cross-account service-to-service networking |
+
+Copy-pasting the Lattice `controllerName` when you actually want an ALB yields a Lattice service network, not a load balancer — a common mistake. The LBC Gateway API support is GA (v3.0.0, released 2025-01-23; current v3.5.0 as of 2026-08-04) and installs its own CRDs (`TargetGroupBinding` plus the LBC Gateway CRDs); both L7 (ALB) and L4 (NLB) Gateways are supported.
+
+**Example A — ALB via the LBC Gateway API** (in-cluster HTTP ingress):
+
 ```yaml
 # GatewayClass (one per cluster — defines which controller)
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
-  name: amazon-alb
+  name: alb
 spec:
-  controllerName: application-networking.k8s.aws/gateway-api-controller
+  controllerName: gateway.k8s.aws/alb   # LBC ALB Gateway (use gateway.k8s.aws/nlb for an L4/NLB Gateway)
 
 ---
 # Gateway (per team/environment — defines listeners)
@@ -197,7 +208,7 @@ kind: Gateway
 metadata:
   name: app-gateway
 spec:
-  gatewayClassName: amazon-alb
+  gatewayClassName: alb
   listeners:
   - name: https
     port: 443
@@ -227,6 +238,17 @@ spec:
       port: 80
 ```
 
+**Example B — VPC Lattice via the Gateway API controller** (cross-VPC service networking, *not* an ALB):
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: amazon-vpc-lattice
+spec:
+  controllerName: application-networking.k8s.aws/gateway-api-controller
+```
+
 **Why Gateway API over Ingress:**
 - **Role separation** — infrastructure teams manage GatewayClass/Gateway, application teams manage HTTPRoutes
 - **Multi-team** — multiple HTTPRoutes can attach to one Gateway without annotation conflicts
@@ -249,7 +271,7 @@ spec:
 |--------|---------|-----------|----------|
 | **VPC Lattice** | Fully managed | Low | Cross-VPC, AWS-native |
 | **Istio (on EKS)** | Self-managed | High | Full service mesh features |
-| **App Mesh** | AWS managed | Medium | **Maintenance mode — avoid for new projects** |
+| **App Mesh** | AWS managed | Medium | **End of support 2026-09-30 — do not adopt; console/resources become inaccessible after that date. Use Istio or Cilium mTLS instead.** |
 
 **VPC Lattice** is recommended for new AWS-native service-to-service networking:
 - No sidecar proxies needed
@@ -350,9 +372,11 @@ resource "aws_eks_cluster" "private" {
 | Access Method | Complexity | Use When |
 |--------------|-----------|----------|
 | **VPN/Direct Connect** | Medium | Existing corporate network |
-| **SSM Session Manager** | Low | Ad-hoc access via bastion |
+| **SSM Session Manager** | Low | Ad-hoc access via a bastion in the VPC (no inbound SSH, no public IP) |
 | **PrivateLink** | Medium | Cross-VPC or cross-account |
-| **Cloud9 in VPC** | Low | Development/testing |
+| **VS Code Remote / IDE over SSM** | Low | Development/testing from a workstation into a VPC bastion |
+
+> AWS Cloud9 is **closed to new customers** and is no longer a recommended in-VPC access path. Reach a private cluster through **SSM Session Manager** to a bastion (or VS Code Remote tunneling over that SSM session) instead.
 
 ---
 
@@ -369,6 +393,8 @@ For detailed network policy guidance including default-deny patterns, DNS allow 
 | **Cilium** | K8s + Cilium extended | Self-managed | L3/L4/L7 + DNS + identity |
 
 **Recommendation:** Use VPC CNI native network policies for most workloads. Use Cilium or Calico only if you need L7 policies or advanced features like DNS hostname rules.
+
+> Beyond the namespaced `NetworkPolicy` above, VPC CNI added cluster-scoped **`ClusterNetworkPolicy`** and an **admin-tier** enforcement model (in a later release, v1.21) for cluster-wide, higher-priority rules that a namespace owner can't override. Verify your installed VPC CNI version supports it before relying on the admin tier.
 
 ---
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/networking-ingress-dns.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/networking-ingress-dns.md
@@ -188,7 +188,7 @@ Gateway API is the successor to the Ingress resource, offering role-oriented res
 | **AWS Load Balancer Controller (LBC) Gateway API** | `gateway.k8s.aws/alb` (L7) or `gateway.k8s.aws/nlb` (L4) | An ALB (L7) or NLB (L4) | In-cluster ingress that would otherwise use an ALB/NLB Ingress or Service |
 | **VPC Lattice (Gateway API controller)** | `application-networking.k8s.aws/gateway-api-controller` | A VPC Lattice service network | Cross-VPC / cross-account service-to-service networking |
 
-Copy-pasting the Lattice `controllerName` when you actually want an ALB yields a Lattice service network, not a load balancer — a common mistake. The LBC Gateway API support is GA (v3.0.0, released 2026-01-23; current v3.5.0 as of 2026-08-04) and installs its own CRDs (`TargetGroupBinding` plus the LBC Gateway CRDs); both L7 (ALB) and L4 (NLB) Gateways are supported.
+Copy-pasting the Lattice `controllerName` when you actually want an ALB yields a Lattice service network, not a load balancer — a common mistake. The LBC Gateway API support is GA (v3.0.0, released 2026-01-23; current v3.5.0 as of 2026-08-04) and requires installing its CRDs (`TargetGroupBinding`, the LBC Gateway CRDs, and the upstream Gateway API CRDs) via a manual `kubectl apply` step, per the [v3.0.0 release notes'](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v3.0.0) Action-Required block; both L7 (ALB) and L4 (NLB) Gateways are supported.
 
 **Example A — ALB via the LBC Gateway API** (in-cluster HTTP ingress):
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/networking-ingress-dns.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/networking-ingress-dns.md
@@ -188,7 +188,7 @@ Gateway API is the successor to the Ingress resource, offering role-oriented res
 | **AWS Load Balancer Controller (LBC) Gateway API** | `gateway.k8s.aws/alb` (L7) or `gateway.k8s.aws/nlb` (L4) | An ALB (L7) or NLB (L4) | In-cluster ingress that would otherwise use an ALB/NLB Ingress or Service |
 | **VPC Lattice (Gateway API controller)** | `application-networking.k8s.aws/gateway-api-controller` | A VPC Lattice service network | Cross-VPC / cross-account service-to-service networking |
 
-Copy-pasting the Lattice `controllerName` when you actually want an ALB yields a Lattice service network, not a load balancer — a common mistake. The LBC Gateway API support is GA (v3.0.0, released 2025-01-23; current v3.5.0 as of 2026-08-04) and installs its own CRDs (`TargetGroupBinding` plus the LBC Gateway CRDs); both L7 (ALB) and L4 (NLB) Gateways are supported.
+Copy-pasting the Lattice `controllerName` when you actually want an ALB yields a Lattice service network, not a load balancer — a common mistake. The LBC Gateway API support is GA (v3.0.0, released 2026-01-23; current v3.5.0 as of 2026-08-04) and installs its own CRDs (`TargetGroupBinding` plus the LBC Gateway CRDs); both L7 (ALB) and L4 (NLB) Gateways are supported.
 
 **Example A — ALB via the LBC Gateway API** (in-cluster HTTP ingress):
 
@@ -376,7 +376,7 @@ resource "aws_eks_cluster" "private" {
 | **PrivateLink** | Medium | Cross-VPC or cross-account |
 | **VS Code Remote / IDE over SSM** | Low | Development/testing from a workstation into a VPC bastion |
 
-> AWS Cloud9 is **closed to new customers** and is no longer a recommended in-VPC access path. Reach a private cluster through **SSM Session Manager** to a bastion (or VS Code Remote tunneling over that SSM session) instead.
+> AWS Cloud9 is **closed to new customers** (as of 2026-08-04) and is no longer a recommended in-VPC access path. Reach a private cluster through **SSM Session Manager** to a bastion (or VS Code Remote tunneling over that SSM session) instead.
 
 ---
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/networking.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/networking.md
@@ -173,10 +173,10 @@ Kubernetes labels nodes with `topology.kubernetes.io/zone` automatically, so the
 
 Deploy VPC CNI as an [EKS managed add-on](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html) rather than self-managed. Managed add-ons provide:
 - Validated compatibility with your EKS version
-- Drift handling — EKS-managed fields are enforced during add-on create/update/delete operations, not on a steady-state timer ([field management](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-field-management.html), as of 2026-08-05)
+- Drift handling — changes to EKS-managed fields conflict under server-side apply and may be overwritten: the AWS best-practices guide documents automatic overwrite of managed configuration roughly every 15 minutes ([VPC CNI BPG](https://docs.aws.amazon.com/eks/latest/best-practices/vpc-cni.html)), and add-on create/update applies conflict resolution (`OVERWRITE`/`PRESERVE`/`NONE`) ([field management](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-field-management.html)), as of 2026-08-05
 - Simpler upgrades via EKS API/Console/CLI
 
-Frequently-used fields like `WARM_ENI_TARGET`, `WARM_IP_TARGET`, and `MINIMUM_IP_TARGET` are **not** managed and won't be overwritten by drift prevention.
+Frequently-used fields like `WARM_ENI_TARGET`, `WARM_IP_TARGET`, and `MINIMUM_IP_TARGET` are **not** managed by EKS field management and won't be overwritten.
 
 ### EKS Auto Mode
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/networking.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/networking.md
@@ -24,8 +24,9 @@ This page is generated from [skills/eks-best-practices/references/networking.md]
 1. [VPC CNI Deep Dive](#vpc-cni-deep-dive)
 2. [VPC CNI Operations](#vpc-cni-operations)
 3. [Subnet Planning](#subnet-planning)
-4. [IPv4 vs IPv6](#ipv4-vs-ipv6)
-5. [Security Groups for Pods](#security-groups-for-pods)
+4. [Control Plane Egress (CUSTOMER_ROUTED)](#control-plane-egress-customer_routed)
+5. [IPv4 vs IPv6](#ipv4-vs-ipv6)
+6. [Security Groups for Pods](#security-groups-for-pods)
 
 ---
 
@@ -49,7 +50,7 @@ Each pod receives one secondary private IP from an ENI attached to the node. The
 
 **Max pods per node** = (Number of ENIs × IPs per ENI) - 1
 
-ENI counts and IPs-per-ENI vary by instance type and change over time — use the live [max-pods-calculator.sh](https://github.com/awslabs/amazon-eks-ami/blob/main/templates/al2/runtime/max-pods-calculator.sh) script as the source of truth rather than relying on a static table:
+ENI counts and IPs-per-ENI vary by instance type and change over time — use the live [max-pods-calculator.sh](https://github.com/awslabs/amazon-eks-ami/blob/v20241213/templates/al2/runtime/max-pods-calculator.sh) script as the source of truth rather than relying on a static table (the script moved out of the `main` branch when the AL2 tree was removed, so pin a tag such as `v20241213`; the `--cni-version` value in the examples below is illustrative — check your installed version with `kubectl describe daemonset aws-node -n kube-system`):
 
 ```bash
 ./max-pods-calculator.sh --instance-type m5.large --cni-version 1.9.0
@@ -292,6 +293,56 @@ kubernetes.io/cluster/<cluster-name> = shared  # or "owned"
 | **IPv6** | High | Unlimited | Irreversible; dual-stack complexity |
 | **Private NAT gateway** | Medium | N/A | Solves overlapping CIDRs; adds NAT GW cost |
 
+#### Who owns the VPC? (shared / RAM-shared subnets)
+
+The strategies above — especially adding a secondary CIDR via `associate-vpc-cidr-block` — assume you own the VPC and its subnets. When the cluster runs in **shared subnets you don't own** (for example, subnets shared into your account via AWS Resource Access Manager from a central networking account), you cannot self-service a secondary CIDR or new subnets: those API calls act on the owner account. Route by ownership:
+
+- **You own the VPC** — use the strategies above directly (secondary CIDR, custom networking, prefix delegation, IPv6).
+- **Subnets are shared and you don't own them** — you have three options:
+  - Request the VPC owner add a **secondary CIDR** (or provision additional/larger subnets) for your cluster.
+  - Stretch the **existing** shared space you already have with **prefix delegation** or **IPv6**, which raise pod density without needing new CIDR space.
+  - Raise a **cross-team request** to the networking owner to re-plan address space if neither of the above closes the gap.
+
+---
+
+## Control Plane Egress (CUSTOMER_ROUTED)
+
+By default, EKS sends control-plane-initiated traffic through an AWS-managed egress path. The `cluster.resourcesVpcConfig.controlPlaneEgressMode` field (GA as of 2026-08-04) lets you change this:
+
+| Value | Behavior |
+|-------|----------|
+| **`AWS_MANAGED`** (default) | Control-plane-initiated egress uses the AWS-managed path |
+| **`CUSTOMER_ROUTED`** | Control-plane-initiated traffic (to webhooks, OIDC providers, aggregated API servers, kubelet) routes through your VPC networking — subnets, route tables, and NAT — rather than AWS-managed egress |
+
+`CUSTOMER_ROUTED` is supported on **EKS Auto Mode** as well.
+
+> **One-way switch:** Once you enable `CUSTOMER_ROUTED`, you **cannot revert to `AWS_MANAGED`**. Plan the reachability and security requirements below *before* switching.
+
+### Egress Categories to Plan For
+
+| Target | Port | Path |
+|--------|------|------|
+| Admission webhooks | 443 | Through the customer VPC egress device |
+| OIDC provider | 443 | Through the customer VPC egress device |
+| Aggregated API servers | 443 | Through the customer VPC egress device |
+| Kubelet API | 10250 | Reaches nodes via the **cluster ENI** — does **not** traverse the egress device |
+
+etcd, CloudWatch, and internal EKS traffic stay on the AWS-managed path.
+
+### NACL / Security Group Requirement
+
+The egress path must allow **outbound 443** *and* **inbound ephemeral ports 1024–65535** (return traffic). A "just allow 443" summary is wrong — omitting the inbound ephemeral range breaks the return path.
+
+### Pre-Switch Checklist
+
+Because the switch is irreversible, enumerate reachability before enabling:
+
+1. **Enumerate all admission webhooks** and their endpoints — distinguish external endpoints from in-cluster ones.
+2. **Confirm OIDC provider reachability** from the VPC.
+3. **Enumerate aggregated API services.**
+4. **Ensure route/NAT/NACL/SG allow the required flows** — outbound 443 plus inbound ephemeral (1024–65535).
+5. **Verify after switching** — trigger a webhook with a test pod, and watch the cluster log group `/aws/eks/<cluster-name>/cluster`.
+
 ---
 
 ## IPv4 vs IPv6
@@ -310,6 +361,8 @@ kubernetes.io/cluster/<cluster-name> = shared  # or "owned"
 | **Network policy** | Full support | Full support (VPC CNI 1.14+) |
 | **Load balancers** | ALB/NLB full support | ALB/NLB dual-stack (requires LBC, in-tree controller doesn't support IPv6) |
 | **Recommendation** | Default choice | Use when IPv4 exhaustion is a real concern |
+
+> **Network policy caveat:** VPC CNI network policy support is per-address-family — a cluster is either IPv4 or IPv6, so policies apply to whichever family the cluster runs (there is no dual-family enforcement in a single cluster). The newer `ClusterNetworkPolicy`/admin-tier enforcement (an addition in a later VPC CNI release, v1.21) is separate from the baseline `NetworkPolicy` support noted above; verify your installed VPC CNI version supports the tier you need.
 
 ### IPv6 Technical Details
 
@@ -407,6 +460,7 @@ aws eks describe-cluster --name CLUSTER_NAME \
 
 **Requirements not supported:**
 - Windows nodes and non-Nitro instances
+- **EKS Auto Mode** — the branch-ENI `SecurityGroupPolicy` path is not supported. On Auto Mode, attach security groups to pods by setting `podSecurityGroupSelectorTerms` on the NodeClass instead.
 - NodeLocal DNSCache in strict mode
 - SG for Pods with custom networking uses the SG from SecurityGroupPolicy, **not** from ENIConfig
 
@@ -436,6 +490,8 @@ multus:
 ```
 
 Multus is deployed via `kubectl_manifest` resources that apply the upstream thick-plugin DaemonSet manifests directly into `kube-system` (not via Helm). The only config keys that matter are `enabled` and `image`.
+
+> The `v4.1.x` image tags above are illustrative — the upstream project has moved on (current is v4.3.0). Check the [Multus releases](https://github.com/k8snetworkplumbingwg/multus-cni/releases) and pin a current tag that includes the pod-lookup race fix rather than copying these values verbatim.
 
 **When it is safe to enable:**
 - You are using thin-plugin mode (`multus-cni:v4.1.0-thin` or later) which avoids the race entirely
@@ -496,5 +552,6 @@ node_sg_additional_rules:
 - [AWS EKS Best Practices Guide — Prefix Mode](https://docs.aws.amazon.com/eks/latest/best-practices/prefix-mode-linux.html)
 - [AWS EKS Best Practices Guide — Custom Networking](https://docs.aws.amazon.com/eks/latest/best-practices/custom-networking.html)
 - [AWS EKS Best Practices Guide — Subnets](https://docs.aws.amazon.com/eks/latest/best-practices/subnets.html)
+- [Amazon EKS User Guide — Control plane egress](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-egress.html)
 - [AWS EKS Best Practices Guide — IPv6](https://docs.aws.amazon.com/eks/latest/best-practices/ipv6.html)
 - [AWS EKS Best Practices Guide — Security Groups Per Pod](https://docs.aws.amazon.com/eks/latest/best-practices/sgpp.html)

--- a/misc/website/docs/skills/eks/eks-best-practices/references/networking.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/networking.md
@@ -173,7 +173,7 @@ Kubernetes labels nodes with `topology.kubernetes.io/zone` automatically, so the
 
 Deploy VPC CNI as an [EKS managed add-on](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html) rather than self-managed. Managed add-ons provide:
 - Validated compatibility with your EKS version
-- Automatic drift prevention — EKS reconciles managed fields every 15 minutes
+- Drift handling — EKS-managed fields are enforced during add-on create/update/delete operations, not on a steady-state timer ([field management](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-field-management.html), as of 2026-08-05)
 - Simpler upgrades via EKS API/Console/CLI
 
 Frequently-used fields like `WARM_ENI_TARGET`, `WARM_IP_TARGET`, and `MINIMUM_IP_TARGET` are **not** managed and won't be overwritten by drift prevention.

--- a/misc/website/docs/skills/eks/eks-best-practices/references/networking.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/networking.md
@@ -300,7 +300,8 @@ The strategies above — especially adding a secondary CIDR via `associate-vpc-c
 - **You own the VPC** — use the strategies above directly (secondary CIDR, custom networking, prefix delegation, IPv6).
 - **Subnets are shared and you don't own them** — you have three options:
   - Request the VPC owner add a **secondary CIDR** (or provision additional/larger subnets) for your cluster.
-  - Stretch the **existing** shared space you already have with **prefix delegation** or **IPv6**, which raise pod density without needing new CIDR space.
+  - Stretch the **existing** shared IPv4 space with **prefix delegation** — a VPC CNI / ENI-level setting that carves /28 prefixes from the subnet's current CIDR, so a participant can enable it on ENIs they own with no VPC change. (Subnet CIDR *reservations*, used to keep prefixes contiguous, are an owner-only operation.)
+  - **IPv6 is not a participant-only lever**: it requires the owner to assign an IPv6 CIDR to the VPC and dual-stack the subnets (a VPC/subnet modification, owner-only). Pursue IPv6 only if the owner has already made the shared subnets dual-stack — otherwise fold it into the owner request above.
   - Raise a **cross-team request** to the networking owner to re-plan address space if neither of the above closes the gap.
 
 ---
@@ -341,7 +342,7 @@ Because the switch is irreversible, enumerate reachability before enabling:
 2. **Confirm OIDC provider reachability** from the VPC.
 3. **Enumerate aggregated API services.**
 4. **Ensure route/NAT/NACL/SG allow the required flows** — outbound 443 plus inbound ephemeral (1024–65535).
-5. **Verify after switching** — trigger a webhook with a test pod, and watch the cluster log group `/aws/eks/<cluster-name>/cluster`.
+5. **Verify after switching** — trigger a webhook with a test pod, watch the cluster log group `/aws/eks/<cluster-name>/cluster`, and enable **VPC Flow Logs** on the egress subnets to confirm control-plane traffic is actually taking the customer-routed path.
 
 ---
 
@@ -362,7 +363,7 @@ Because the switch is irreversible, enumerate reachability before enabling:
 | **Load balancers** | ALB/NLB full support | ALB/NLB dual-stack (requires LBC, in-tree controller doesn't support IPv6) |
 | **Recommendation** | Default choice | Use when IPv4 exhaustion is a real concern |
 
-> **Network policy caveat:** VPC CNI network policy support is per-address-family — a cluster is either IPv4 or IPv6, so policies apply to whichever family the cluster runs (there is no dual-family enforcement in a single cluster). The newer `ClusterNetworkPolicy`/admin-tier enforcement (an addition in a later VPC CNI release, v1.21) is separate from the baseline `NetworkPolicy` support noted above; verify your installed VPC CNI version supports the tier you need.
+> **Network policy caveat:** VPC CNI network policy support is per-address-family — a cluster is either IPv4 or IPv6, so policies apply to whichever family the cluster runs (there is no dual-family enforcement in a single cluster, as of 2026-08-04). The newer `ClusterNetworkPolicy`/admin-tier enforcement (an addition in a later VPC CNI release, v1.21) is separate from the baseline `NetworkPolicy` support noted above; verify your installed VPC CNI version supports the tier you need.
 
 ### IPv6 Technical Details
 
@@ -460,7 +461,7 @@ aws eks describe-cluster --name CLUSTER_NAME \
 
 **Requirements not supported:**
 - Windows nodes and non-Nitro instances
-- **EKS Auto Mode** — the branch-ENI `SecurityGroupPolicy` path is not supported. On Auto Mode, attach security groups to pods by setting `podSecurityGroupSelectorTerms` on the NodeClass instead.
+- **EKS Auto Mode** — the branch-ENI `SecurityGroupPolicy` path is not supported (as of 2026-08-04). On Auto Mode, attach security groups to pods by setting `podSecurityGroupSelectorTerms` on the NodeClass instead.
 - NodeLocal DNSCache in strict mode
 - SG for Pods with custom networking uses the SG from SecurityGroupPolicy, **not** from ENIConfig
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/networking.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/networking.md
@@ -173,7 +173,7 @@ Kubernetes labels nodes with `topology.kubernetes.io/zone` automatically, so the
 
 Deploy VPC CNI as an [EKS managed add-on](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html) rather than self-managed. Managed add-ons provide:
 - Validated compatibility with your EKS version
-- Drift handling — changes to EKS-managed fields conflict under server-side apply and may be overwritten: the AWS best-practices guide documents automatic overwrite of managed configuration roughly every 15 minutes ([VPC CNI BPG](https://docs.aws.amazon.com/eks/latest/best-practices/vpc-cni.html)), and add-on create/update applies conflict resolution (`OVERWRITE`/`PRESERVE`/`NONE`) ([field management](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-field-management.html)), as of 2026-08-05
+- Drift handling — changes to EKS-managed fields conflict under server-side apply and may be overwritten: the AWS best-practices guide documents automatic overwrite of managed configuration roughly every 15 minutes ([VPC CNI BPG](https://docs.aws.amazon.com/eks/latest/best-practices/vpc-cni.html)), and add-on create/update applies conflict resolution (`OVERWRITE`/`PRESERVE`/`NONE`) ([CreateAddon API](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html)), as of 2026-08-05
 - Simpler upgrades via EKS API/Console/CLI
 
 Frequently-used fields like `WARM_ENI_TARGET`, `WARM_IP_TARGET`, and `MINIMUM_IP_TARGET` are **not** managed by EKS field management and won't be overwritten.
@@ -342,7 +342,9 @@ Because the switch is irreversible, enumerate reachability before enabling:
 2. **Confirm OIDC provider reachability** from the VPC.
 3. **Enumerate aggregated API services.**
 4. **Ensure route/NAT/NACL/SG allow the required flows** — outbound 443 plus inbound ephemeral (1024–65535).
-5. **Verify after switching** — trigger a webhook with a test pod, watch the cluster log group `/aws/eks/<cluster-name>/cluster`, and enable **VPC Flow Logs** on the egress subnets to confirm control-plane traffic is actually taking the customer-routed path.
+5. **Confirm DNS resolution** — the VPC DHCP options set includes `AmazonProvidedDNS` and can resolve both VPC-private and public hostnames (external webhooks/OIDC endpoints).
+6. **IPv6 clusters: configure both an IPv6 `::/0` route via an egress-only internet gateway and an IPv4 `0.0.0.0/0` route via NAT.**
+7. **Verify after switching** — trigger a webhook with a test pod, watch the cluster log group `/aws/eks/<cluster-name>/cluster`, and enable **VPC Flow Logs** on the egress subnets to confirm control-plane traffic is actually taking the customer-routed path.
 
 ---
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/observability.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/observability.md
@@ -501,7 +501,7 @@ fields @timestamp, @message
 
 An admission webhook configured with `failurePolicy: Ignore` fails **open** — when the webhook is unreachable or errors, the API request is admitted anyway and no error is surfaced to the caller. This is silent by design, so a broken policy/mutation webhook (e.g. a down Kyverno, OPA/Gatekeeper, or sidecar-injection webhook) can stop enforcing without any obvious signal.
 
-The kube-apiserver audit log does record these events: a fail-open admission surfaces as an annotation on the audit record, `failed-open.validating.webhook.admission.k8s.io/round_0_index_<n>` (validating webhooks) and `failed-open.mutation.webhook.admission.k8s.io/round_0_index_<n>` (mutating webhooks) — one indexed annotation per bypassed webhook, naming the webhook configuration that was bypassed. The mutating-side spelling (`mutation`) and the validating-side spelling (`validating`) are asymmetric — match them exactly.
+The kube-apiserver audit log does record these events: a fail-open admission surfaces as an annotation on the audit record, `failed-open.validating.webhook.admission.k8s.io/round_0_index_<n>` (validating webhooks) and `failed-open.mutation.webhook.admission.k8s.io/round_<r>_index_<n>` (mutating webhooks — `<r>` is `0`, or `1` when a mutating webhook fails open on reinvocation) — one indexed annotation per bypassed webhook, naming the webhook that was bypassed. The mutating-side spelling (`mutation`) and the validating-side spelling (`validating`) are asymmetric — match them exactly.
 
 Alarm on these the same way you alarm on 401/403 spikes — a CloudWatch Logs **metric filter** on the control-plane audit log group, paired with a CloudWatch **alarm**:
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/observability.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/observability.md
@@ -310,9 +310,16 @@ Remediation:
 
 ### Fluent Bit Configuration
 
+There is no `aws-for-fluent-bit` EKS add-on. Two supported paths:
+
 ```bash
-# Deploy as EKS add-on (recommended)
-aws eks create-addon --cluster-name my-cluster --addon-name aws-for-fluent-bit
+# Recommended: the CloudWatch Observability EKS add-on installs Fluent Bit
+# for CloudWatch Logs (alongside Container Insights and Application Signals)
+aws eks create-addon --cluster-name my-cluster --addon-name amazon-cloudwatch-observability
+
+# Alternative: deploy the community Fluent Bit DaemonSet directly (name: fluent-bit)
+# e.g. via the aws-for-fluent-bit Helm chart / manifests
+helm install fluent-bit eks/aws-for-fluent-bit --namespace amazon-cloudwatch --create-namespace
 ```
 
 **Scaling Fluent Bit for large clusters:**
@@ -383,13 +390,15 @@ spec:
           exporters: [awsxray]
 ```
 
-### X-Ray vs OpenTelemetry
+### OpenTelemetry (primary) vs X-Ray SDKs
 
-| Factor | AWS X-Ray | OpenTelemetry + Jaeger/Tempo |
-|--------|-----------|------------------------------|
-| **Setup** | Simple with ADOT | More configuration |
+The **X-Ray SDKs and the X-Ray daemon have been in maintenance mode since 2026-02-25** — they receive no new features. OpenTelemetry (via AWS Distro for OpenTelemetry, ADOT) is AWS's primary, recommended instrumentation standard for new work; instrument with OTel/ADOT rather than the X-Ray SDKs. The **X-Ray service and its APIs continue** as a trace backend/console — ADOT still exports traces to X-Ray (see the `awsxray` exporter above), so you can standardize on OTel instrumentation while keeping X-Ray as a backend.
+
+| Factor | AWS X-Ray (service/backend) | OpenTelemetry + Jaeger/Tempo |
+|--------|-----------------------------|------------------------------|
+| **Instrumentation** | X-Ray SDKs in maintenance mode since 2026-02-25 — use ADOT to feed X-Ray | ADOT / OTel SDKs (primary standard) |
 | **AWS integration** | Native (Lambda, API GW, etc.) | Manual |
-| **Vendor lock-in** | AWS-specific | Vendor-neutral |
+| **Vendor lock-in** | AWS-specific backend | Vendor-neutral |
 | **Querying** | X-Ray console, CloudWatch | Grafana (richer) |
 | **Cost** | Per trace recorded | Storage-dependent |
 
@@ -488,6 +497,34 @@ fields @timestamp, @message
 | sort @timestamp desc
 ```
 
+### Detecting Failed-Open Admission Webhooks
+
+An admission webhook configured with `failurePolicy: Ignore` fails **open** — when the webhook is unreachable or errors, the API request is admitted anyway and no error is surfaced to the caller. This is silent by design, so a broken policy/mutation webhook (e.g. a down Kyverno, OPA/Gatekeeper, or sidecar-injection webhook) can stop enforcing without any obvious signal.
+
+The kube-apiserver audit log does record these events: a fail-open admission surfaces as an annotation on the audit record, `failed-open.validation.webhook.admission.k8s.io` (validating webhooks) and `failed-open.mutation.webhook.admission.k8s.io` (mutating webhooks), naming the webhook configuration that was bypassed.
+
+Alarm on these the same way you alarm on 401/403 spikes — a CloudWatch Logs **metric filter** on the control-plane audit log group, paired with a CloudWatch **alarm**:
+
+```bash
+# Metric filter: count audit records carrying a failed-open webhook annotation
+aws logs put-metric-filter \
+  --log-group-name /aws/eks/my-cluster/cluster \
+  --filter-name webhook-failed-open \
+  --filter-pattern '{ ($.annotations."failed-open.validation.webhook.admission.k8s.io" = "*") || ($.annotations."failed-open.mutation.webhook.admission.k8s.io" = "*") }' \
+  --metric-transformations \
+      metricName=WebhookFailedOpen,metricNamespace=EKS/Admission,metricValue=1,defaultValue=0
+
+# Alarm on any occurrence
+aws cloudwatch put-metric-alarm \
+  --alarm-name eks-webhook-failed-open \
+  --namespace EKS/Admission --metric-name WebhookFailedOpen \
+  --statistic Sum --period 300 --evaluation-periods 1 \
+  --threshold 0 --comparison-operator GreaterThanThreshold \
+  --treat-missing-data notBreaching
+```
+
+Any non-zero value means an admission webhook silently failed open and enforcement gaps may exist — investigate the named webhook's availability before assuming policy is being applied.
+
 ### Amazon GuardDuty for EKS
 
 | Finding | Severity | Meaning |
@@ -496,7 +533,7 @@ fields @timestamp, @message
 | `Persistence:Kubernetes/ContainerWithSensitiveMount` | Medium | Sensitive host path mounted |
 | `Policy:Kubernetes/ExposedDashboard` | Medium | K8s dashboard exposed |
 | `CredentialAccess:Kubernetes/MaliciousIPCaller` | High | API call from known malicious IP |
-| `Impact:Runtime/CryptoCurrencyMiningDetected` | High | Crypto mining in container |
+| `Impact:Runtime/CryptoMinerExecuted` | High | Crypto mining in container |
 
 ### CloudTrail for EKS
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/observability.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/observability.md
@@ -310,7 +310,7 @@ Remediation:
 
 ### Fluent Bit Configuration
 
-There is no `aws-for-fluent-bit` EKS add-on. Two supported paths:
+There is no `aws-for-fluent-bit` EKS add-on (as of 2026-08-04). Two supported paths:
 
 ```bash
 # Recommended: the CloudWatch Observability EKS add-on installs Fluent Bit
@@ -501,16 +501,22 @@ fields @timestamp, @message
 
 An admission webhook configured with `failurePolicy: Ignore` fails **open** — when the webhook is unreachable or errors, the API request is admitted anyway and no error is surfaced to the caller. This is silent by design, so a broken policy/mutation webhook (e.g. a down Kyverno, OPA/Gatekeeper, or sidecar-injection webhook) can stop enforcing without any obvious signal.
 
-The kube-apiserver audit log does record these events: a fail-open admission surfaces as an annotation on the audit record, `failed-open.validation.webhook.admission.k8s.io` (validating webhooks) and `failed-open.mutation.webhook.admission.k8s.io` (mutating webhooks), naming the webhook configuration that was bypassed.
+The kube-apiserver audit log does record these events: a fail-open admission surfaces as an annotation on the audit record, `failed-open.validating.webhook.admission.k8s.io/round_0_index_<n>` (validating webhooks) and `failed-open.mutation.webhook.admission.k8s.io/round_0_index_<n>` (mutating webhooks) — one indexed annotation per bypassed webhook, naming the webhook configuration that was bypassed. The mutating-side spelling (`mutation`) and the validating-side spelling (`validating`) are asymmetric — match them exactly.
 
 Alarm on these the same way you alarm on 401/403 spikes — a CloudWatch Logs **metric filter** on the control-plane audit log group, paired with a CloudWatch **alarm**:
+
+> **Prerequisite:** EKS control-plane **audit logging is disabled by default**. Enable the `audit` log type first — nothing below matches until audit events reach the `/aws/eks/<cluster>/cluster` log group:
+> ```bash
+> aws eks update-cluster-config --name my-cluster \
+>   --logging '{"clusterLogging":[{"types":["audit"],"enabled":true}]}'
+> ```
 
 ```bash
 # Metric filter: count audit records carrying a failed-open webhook annotation
 aws logs put-metric-filter \
   --log-group-name /aws/eks/my-cluster/cluster \
   --filter-name webhook-failed-open \
-  --filter-pattern '{ ($.annotations."failed-open.validation.webhook.admission.k8s.io" = "*") || ($.annotations."failed-open.mutation.webhook.admission.k8s.io" = "*") }' \
+  --filter-pattern '?"failed-open.validating.webhook.admission.k8s.io" ?"failed-open.mutation.webhook.admission.k8s.io"' \
   --metric-transformations \
       metricName=WebhookFailedOpen,metricNamespace=EKS/Admission,metricValue=1,defaultValue=0
 
@@ -522,6 +528,13 @@ aws cloudwatch put-metric-alarm \
   --threshold 0 --comparison-operator GreaterThanThreshold \
   --treat-missing-data notBreaching
 ```
+
+> Metric filters count matching log events but can't extract the indexed annotation name. To see *which* webhook failed open, query the audit log group in CloudWatch Logs Insights instead:
+> ```
+> fields @timestamp, @message
+> | filter @message like /failed-open\.(validating|mutation)\.webhook\.admission\.k8s\.io/
+> | sort @timestamp desc
+> ```
 
 Any non-zero value means an admission webhook silently failed open and enforcement gaps may exist — investigate the named webhook's availability before assuming policy is being applied.
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/reliability-advanced.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/reliability-advanced.md
@@ -40,7 +40,7 @@ velero install \
   --bucket my-velero-bucket \
   --backup-location-config region=us-east-1 \
   --snapshot-location-config region=us-east-1 \
-  --plugins velero/velero-plugin-for-aws:v1.8.0
+  --plugins velero/velero-plugin-for-aws:v1.8.0  # illustrative pin — check the current release (e.g. v1.14.2) and match it to your Velero version
 
 # Schedule daily backups
 velero schedule create daily-backup \
@@ -68,16 +68,23 @@ velero schedule create daily-backup \
 
 ## EKS Zonal Shift (ARC Integration)
 
-Amazon Application Recovery Controller (ARC) zonal shift allows you to shift traffic away from an impaired Availability Zone for EKS workloads. When an AZ experiences degradation, zonal shift removes that AZ from the load balancer target group, redirecting traffic to healthy AZs without requiring application changes.
+Amazon Application Recovery Controller (ARC) zonal shift allows you to shift away from an impaired Availability Zone for EKS workloads. With the EKS-integrated ARC zonal shift enabled on the cluster, a shift does far more than reroute load balancer traffic — it acts across both the data plane and Kubernetes' own service routing:
+
+- **Nodes in the impaired AZ are cordoned** so no new pods schedule there.
+- **The EndpointSlice controller strips pod endpoints in the impaired AZ**, so east-west (in-cluster `ClusterIP`) traffic is shifted away too — not just external ALB/NLB traffic.
+- **Managed Node Group AZRebalance is suspended** so the ASG does not fight the shift by rebalancing capacity back into the impaired AZ.
+- **EKS Auto Mode stops provisioning** new capacity in the impaired AZ for the duration of the shift.
 
 | Aspect | Detail |
 |---|---|
-| **What it does** | Removes an AZ from ALB/NLB target groups, shifting traffic to healthy AZs |
+| **What it does** | Cordons impaired-AZ nodes, strips impaired-AZ pod endpoints (ClusterIP + ALB/NLB), suspends MNG AZRebalance, and stops Auto Mode provisioning in that AZ |
 | **Trigger** | Manual via console/API, or automated via zonal autoshift |
 | **Duration** | Up to 72 hours per shift, extendable |
-| **EKS impact** | Pods in the shifted AZ stop receiving traffic but continue running |
-| **Pod scheduling** | Existing pods remain; new pods still schedule to all AZs unless topology constraints prevent it |
-| **Prerequisites** | Multi-AZ deployment, topology spread constraints, sufficient capacity in remaining AZs |
+| **EKS impact** | Impaired-AZ pods are removed from Service endpoints (external and in-cluster); nodes are cordoned so nothing new lands there |
+| **Pod scheduling** | Impaired-AZ nodes are cordoned — new pods do not schedule into the AZ for the shift's duration |
+| **Prerequisites** | EKS-integrated ARC zonal shift enabled, multi-AZ deployment, topology spread constraints, sufficient capacity in remaining AZs |
+
+**Karpenter and Auto Mode integration:** Karpenter (as of 2026-05) and EKS Auto Mode (as of 2026-07) integrate with ARC zonal shift, so provisioning honors an active shift and stops adding capacity in the impaired AZ. This integration is what makes the older "traffic-only" characterization of zonal shift stale — with it enabled, the shift reaches scheduling and in-cluster routing, not just the load balancer.
 
 **When to use zonal shift:**
 - AZ-level impairment (network, storage, compute degradation)
@@ -85,9 +92,9 @@ Amazon Application Recovery Controller (ARC) zonal shift allows you to shift tra
 - Proactive shift during planned AZ maintenance
 
 **Limitations:**
-- Does not evict or reschedule pods — only affects traffic routing
+- Does not evict or reschedule already-running pods — it cordons nodes and removes endpoints, but existing pods in the impaired AZ keep running until they terminate on their own
 - Requires sufficient capacity in remaining AZs to handle full load
-- Works with ALB and NLB only (not ClusterIP or NodePort services)
+- Requires the EKS-integrated ARC zonal shift to be enabled on the cluster; without it, only the load-balancer traffic path shifts
 
 DO:
 - Ensure topology spread constraints distribute pods across all AZs before relying on zonal shift
@@ -96,7 +103,7 @@ DO:
 
 DON'T:
 - Use zonal shift as a substitute for proper multi-AZ pod distribution
-- Assume pods will automatically move — zonal shift only affects traffic, not scheduling
+- Assume already-running pods will be evicted or moved — the shift cordons nodes and strips endpoints, but does not reschedule pods that are already running
 
 ---
 
@@ -198,7 +205,7 @@ Create a new Deployment identical to the current version, verify pods are health
 
 ### Canary Deployments
 
-Deploy the new version with fewer replicas alongside the existing Deployment, divert a small percentage of traffic, and progressively increase if metrics are healthy. Use [Flagger](https://github.com/weaveworks/flagger) with Istio or AWS App Mesh for automated canary progression.
+Deploy the new version with fewer replicas alongside the existing Deployment, divert a small percentage of traffic, and progressively increase if metrics are healthy. Use [Flagger](https://github.com/fluxcd/flagger) with Istio for automated canary progression. (AWS App Mesh reaches end of support on 2026-09-30 — do not adopt it for new canary/mesh work; prefer Istio or Cilium-based service mesh instead.)
 
 ---
 
@@ -262,3 +269,4 @@ Prerequisite reading: [reliability-core.md](reliability-core).
 - [AWS EKS Best Practices Guide — High Availability](https://aws.github.io/aws-eks-best-practices/reliability/docs/)
 - [AWS Prescriptive Guidance — HA and Resiliency for EKS](https://docs.aws.amazon.com/prescriptive-guidance/latest/ha-resiliency-amazon-eks-apps/introduction.html)
 - [AWS FIS for EKS](https://docs.aws.amazon.com/fis/latest/userguide/fis-actions-reference.html)
+- [EKS Zonal Shift (ARC integration)](https://docs.aws.amazon.com/eks/latest/userguide/zone-shift.html)

--- a/misc/website/docs/skills/eks/eks-best-practices/references/reliability-core.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/reliability-core.md
@@ -227,7 +227,7 @@ Karpenter respects PDBs during:
 - **Drift replacement** — Waits for PDB budget before cordoning
 - **Expiry** — Respects PDB during node replacement
 
-If a PDB blocks node drain, Karpenter waits indefinitely by default — there is no built-in timeout. The NodePool's `terminationGracePeriod` is an opt-in force-delete deadline that has **no default** (when unset, `nil`, Karpenter waits indefinitely for the PDB to allow eviction). Once set, it forces drain after that deadline even if a PDB is still blocking.
+If a PDB blocks node drain, Karpenter waits indefinitely by default — there is no built-in timeout (as of 2026-08-04). The NodePool's `terminationGracePeriod` is an opt-in force-delete deadline that has **no default** (when unset, `nil`, Karpenter waits indefinitely for the PDB to allow eviction). Once set, it forces drain after that deadline even if a PDB is still blocking.
 
 ---
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/reliability-core.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/reliability-core.md
@@ -227,7 +227,7 @@ Karpenter respects PDBs during:
 - **Drift replacement** — Waits for PDB budget before cordoning
 - **Expiry** — Respects PDB during node replacement
 
-If a PDB blocks node drain for >15 minutes (default), Karpenter's `terminationGracePeriod` on the NodePool determines behavior.
+If a PDB blocks node drain, Karpenter waits indefinitely by default — there is no built-in timeout. The NodePool's `terminationGracePeriod` is an opt-in force-delete deadline that has **no default** (when unset, `nil`, Karpenter waits indefinitely for the PDB to allow eviction). Once set, it forces drain after that deadline even if a PDB is still blocking.
 
 ---
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/scalability.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/scalability.md
@@ -388,7 +388,7 @@ Karpenter does not have this limitation -- it handles large clusters without sha
 | Node autoscaling | 1,000+ nodes | Use Karpenter or shard CAS |
 | kubectl | Automation/scripts | Enable cache-dir, disable compression |
 | Node efficiency | Any scale | Prefer 4xlarge-12xlarge, match churn to node size |
-| Pod networking | IP exhaustion | Use prefix delegation or IPv6 |
+| Pod networking | IP exhaustion | Use prefix delegation; IPv6 (dual-stack) for larger address space |
 
 **For clusters beyond 1,000 nodes or 50,000 pods**, AWS recommends engaging your support team or TAM for specialist guidance. EKS can support up to 100,000 nodes with appropriate planning.
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/scalability.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/scalability.md
@@ -62,6 +62,8 @@ When investigating scaling issues, check metrics in both upstream and downstream
 
 EKS automatically scales the control plane (API servers across 2+ AZs, etcd across 3 AZs), but there are limits on how fast it scales.
 
+For large clusters that hit these auto-scaling limits, **EKS Provisioned Control Plane (PCP)** directly addresses the API-scaling concern: it offers a 99.99% SLA, an 8XL control-plane tier (added 2026-03), and faster pod autoscaling (added 2026-07). See [Amazon EKS Provisioned Control Plane](https://docs.aws.amazon.com/eks/latest/userguide/scale-cluster.html). Consider it before relying solely on the Terraform-level burst knobs below.
+
 ### Burst Limits
 
 Avoid scaling spikes that increase cluster size by more than ~10% at a time (e.g., 1,000 to 1,100 nodes, or 4,000 to 4,500 pods at once). The control plane auto-scales but needs time to adapt. New clusters will not immediately support hundreds of nodes.
@@ -100,7 +102,7 @@ If you see 429s from your controllers, they're likely making excessive LIST call
 | Metric | What It Tells You |
 |--------|-------------------|
 | `etcd_request_duration_seconds` | etcd latency per operation |
-| `apiserver_storage_size_bytes` (EKS >= 1.28) | etcd database size |
+| `apiserver_storage_size_bytes` | etcd database size |
 
 When etcd's database size exceeds its limit, it emits a "no space" alarm and the cluster becomes **read-only** -- no new pods, no scaling, no deployments.
 
@@ -179,7 +181,7 @@ spec:
 
 Keep worker nodes up to date with the latest EKS-optimized AMIs:
 
-- **Karpenter** automatically uses the latest AMI for new nodes
+- **Karpenter** (v1) selects AMIs via `amiSelectorTerms` on the EC2NodeClass -- it does not auto-track the latest AMI unless you use the `@latest` alias, which is discouraged in production (pin a specific AMI/alias instead)
 - **MNG** requires updating the ASG launch template for patch releases; minor versions are available as managed upgrades
 - Use Bottlerocket for automatic, minimal-downtime updates
 
@@ -259,7 +261,7 @@ Use separate EKS clusters for different application environments (dev, test, pro
 | ELB Type | Default Target Quota | Per-AZ Limit |
 |----------|---------------------|--------------|
 | ALB | 1,000 targets | -- |
-| NLB | 3,000 targets | 500 per AZ |
+| NLB | 3,000 targets | 500 per AZ (500 per LB total with cross-zone load balancing enabled) |
 
 If a service exceeds these targets, split across multiple LBs or use an in-cluster ingress controller. Use Route 53 (weighted DNS), Global Accelerator, or CloudFront to present multiple LBs as a single endpoint.
 
@@ -267,7 +269,7 @@ If a service exceeds these targets, split across multiple LBs or use an in-clust
 
 EndpointSlices reduce API server load compared to Endpoints for large, frequently-scaling services. They include topology information for features like topology-aware routing.
 
-Verify your controllers use them -- for the AWS Load Balancer Controller, enable `--enable-endpoint-slices`.
+Verify your controllers use them -- for older AWS Load Balancer Controller versions, enable `--enable-endpoint-slices`; it is on by default since LBC v2.7+ (and in v3), so no action is needed on current versions.
 
 ### Reduce Control Plane Watches
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/security-runtime-network.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/security-runtime-network.md
@@ -32,17 +32,18 @@ This page is generated from [skills/eks-best-practices/references/security-runti
 
 ### Amazon GuardDuty for EKS
 
-**Enable EKS Runtime Monitoring** as the first line of defense. GuardDuty analyzes K8s audit logs, VPC flow logs, and DNS logs using ML and threat intelligence to detect threats without manual configuration.
+**Enable Runtime Monitoring** as the first line of defense. GuardDuty's EKS protection is now delivered through the unified **Runtime Monitoring** feature (the separate "EKS Runtime Monitoring" console path has been removed; AWS recommends migrating to unified Runtime Monitoring). GuardDuty combines two complementary sources of signal:
 
-**Enable both:**
-- **EKS Audit Log Monitoring** — analyzes K8s audit logs for threats
-- **EKS Runtime Monitoring** — agent-based, detects container-level threats
+- **EKS Protection (audit-log analysis)** — analyzes K8s control-plane audit logs for threats; no agent required.
+- **Runtime Monitoring (agent-based)** — the GuardDuty security agent observes container-level runtime behavior (process, file, and network activity) on your nodes.
 
-**Key finding types:**
-- `Execution:Runtime/CryptocurrencyMiningDetected`
-- `PrivilegeEscalation:Runtime/DockerSocketAccess`
-- `Persistence:Runtime/ReverseShell`
-- `UnauthorizedAccess:IAMUser/AnomalousBehavior`
+These are distinct data sources — audit-log analysis and the runtime agent — so keep them conceptually separate rather than conflating them. GuardDuty applies ML and threat intelligence across both to detect threats without manual rule configuration.
+
+**Key runtime finding types:**
+- `CryptoCurrency:Runtime/BitcoinTool.B`
+- `Impact:Runtime/CryptoMinerExecuted`
+- `PrivilegeEscalation:Runtime/DockerSocketAccessed`
+- `Execution:Runtime/ReverseShell`
 
 GuardDuty produces security findings viewable in the console or via EventBridge for automated response.
 
@@ -115,6 +116,8 @@ helm install falco falcosecurity/falco \
 
 ```yaml
 # Enable network policy support in VPC CNI
+# NOTE: the addon-version below is illustrative -- check the current version with
+# `aws eks describe-addon-versions --addon-name vpc-cni` rather than pinning this value.
 aws eks create-addon --cluster-name my-cluster \
   --addon-name vpc-cni \
   --addon-version v1.14.0-eksbuild.3 \
@@ -122,6 +125,8 @@ aws eks create-addon --cluster-name my-cluster \
 ```
 
 Network policy support is NOT enabled by default — you must enable the `ENABLE_NETWORK_POLICY` flag on the VPC CNI add-on.
+
+Newer VPC CNI releases (v1.21+) also add a cluster-scoped **ClusterNetworkPolicy** admin tier and **strict mode** enforcement on top of the standard namespaced `NetworkPolicy` API — check the current VPC CNI version to see whether these are available in your cluster.
 
 ### Start with Default Deny + DNS Allow
 
@@ -246,7 +251,7 @@ Consider third-party engines when you need advanced features:
 | **Cilium** | Layer 7 (HTTP), DNS hostname rules, eBPF-native |
 | **Calico Enterprise** | Map K8s NP to AWS security groups, compliance reporting |
 
-**Migration:** If switching from Calico/Cilium to VPC CNI network policies, use the [K8s Network Policy Migrator](https://github.com/awslabs/k8s-network-policy-migrator) tool to convert CRDs to native K8s NetworkPolicy resources. Test in a separate cluster before production.
+**Migration:** If switching from Calico/Cilium to VPC CNI network policies, the [K8s Network Policy Migrator](https://github.com/awslabs/k8s-network-policy-migrator) tool can convert CRDs to native K8s NetworkPolicy resources. Note this tool has been **dormant since 2023-08** (no updates), so validate its output against current CRD schemas and always test in a separate cluster before production.
 
 ### Ensure Network Policies Exist via OPA
 
@@ -291,7 +296,9 @@ Traffic between Nitro instance types (C5n, G4, I3en, M5dn, M5n, P3dn, R5dn, R5n,
 For end-to-end encryption between pods:
 - **Istio** — automatic mTLS between all meshed services
 - **Linkerd** — automatic mTLS with minimal configuration
-- **App Mesh** — mTLS with X.509 certificates or Envoy SDS
+- **Cilium** — transparent mTLS / WireGuard-based node-to-node encryption via eBPF
+
+> **Do not adopt AWS App Mesh.** App Mesh reaches **end of support on 2026-09-30**, after which its console and resources become inaccessible. Do not start new App Mesh mTLS deployments; migrate existing ones to Istio, Cilium mTLS, or Linkerd.
 
 ### Ingress and Load Balancer TLS
 

--- a/misc/website/docs/skills/eks/eks-best-practices/references/security-runtime-network.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/security-runtime-network.md
@@ -32,7 +32,7 @@ This page is generated from [skills/eks-best-practices/references/security-runti
 
 ### Amazon GuardDuty for EKS
 
-**Enable Runtime Monitoring** as the first line of defense. GuardDuty's EKS protection is now delivered through the unified **Runtime Monitoring** feature (the separate "EKS Runtime Monitoring" console path has been removed; AWS recommends migrating to unified Runtime Monitoring). GuardDuty combines two complementary sources of signal:
+**Enable Runtime Monitoring** as the first line of defense. GuardDuty's EKS protection is now delivered through the unified **Runtime Monitoring** feature (the separate "EKS Runtime Monitoring" console path has been removed (as of 2026-08-05, per the GuardDuty User Guide); AWS recommends migrating to unified Runtime Monitoring). GuardDuty combines two complementary sources of signal:
 
 - **EKS Protection (audit-log analysis)** — analyzes K8s control-plane audit logs for threats; no agent required.
 - **Runtime Monitoring (agent-based)** — the GuardDuty security agent observes container-level runtime behavior (process, file, and network activity) on your nodes.

--- a/misc/website/docs/skills/eks/eks-best-practices/references/security-supply-chain.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/security-supply-chain.md
@@ -52,7 +52,7 @@ Reducing the attack surface of container images is a primary security goal:
   ENTRYPOINT ["/server"]
   ```
 - **Add the USER directive** to Dockerfiles to run as non-root by default
-- **Lint Dockerfiles** with tools like [dockerfile_lint](https://github.com/projectatomic/dockerfile_lint) to enforce best practices in CI
+- **Lint Dockerfiles** with tools like [hadolint](https://github.com/hadolint/hadolint) to enforce best practices in CI
 
 ### Software Bill of Materials (SBOMs)
 
@@ -79,7 +79,7 @@ aws ecr put-registry-scanning-configuration \
 
 | Scanning Type | Provider | Cost | Features |
 |--------------|----------|------|----------|
-| **Basic** | Clair (via ECR) | Free | On-push or on-demand |
+| **Basic** | AWS-native (`AWS_NATIVE`, via ECR) | Free | On-push or on-demand |
 | **Enhanced** | Amazon Inspector | Paid | Continuous, OS + language packages |
 
 Additional scanning tools: Grype, Trivy, Snyk, Prisma Cloud (twistcli), Aqua.

--- a/misc/website/docs/skills/eks/eks-best-practices/references/security.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/security.md
@@ -44,7 +44,7 @@ This page is generated from [skills/eks-best-practices/references/security.md](h
 **Minimum node IAM policies:**
 - `AmazonEKSWorkerNodePolicy`
 - `AmazonEKS_CNI_Policy` (or use IRSA/Pod Identity for VPC CNI)
-- `AmazonEC2ContainerRegistryReadOnly`
+- `AmazonEC2ContainerRegistryPullOnly` (current guidance; narrower than the older `AmazonEC2ContainerRegistryReadOnly`)
 
 Move VPC CNI permissions to IRSA/Pod Identity to reduce node role scope. Never add application-level permissions (S3, DynamoDB) to node roles — use Pod Identity or IRSA instead.
 
@@ -110,7 +110,7 @@ aws eks associate-access-policy \
 
 **Migration path:** `CONFIG_MAP` -> `API_AND_CONFIG_MAP` -> `API`. These transitions are **irreversible** — you cannot switch from `API` back to `CONFIG_MAP`.
 
-**Available access policies:**
+**Available access policies (illustrative — 15+ EKS access policies exist; list the full set with `aws eks list-access-policies`):**
 - `AmazonEKSClusterAdminPolicy` -> cluster-admin
 - `AmazonEKSAdminPolicy` -> admin (namespace-scopable)
 - `AmazonEKSEditPolicy` -> edit (namespace-scopable)
@@ -142,7 +142,6 @@ If `stsendpoint` equals `sts.amazonaws.com`, the client is using the global endp
 | **Cross-account** | Built-in support | Manual trust policy per account |
 | **Session tags** | Automatic (cluster, namespace, SA) | Not available |
 | **Role chaining** | Supported | Not supported |
-| **EKS version** | 1.24+ | 1.14+ |
 | **Fargate support** | Not yet | Supported |
 | **Recommendation** | Preferred for new workloads | Use for older clusters or Fargate |
 
@@ -210,6 +209,8 @@ metadata:
 - Use `StringEquals` (not `StringLike`) for sub conditions
 - Never use wildcard `*` in IRSA trust policy conditions
 - Don't share service accounts across applications with different privilege needs
+
+> **PrivateLink for the cluster OIDC endpoint** (GA as of 2026-08-04): the cluster OIDC issuer endpoint can be reached over PrivateLink, giving IRSA token validation a fully private path with no public internet egress — useful for private/isolated clusters. See [Interface VPC endpoints for the OIDC endpoint](https://docs.aws.amazon.com/eks/latest/userguide/authenticate-oidc-identity-provider.html).
 
 ---
 
@@ -301,7 +302,7 @@ spec:
 - Drop ALL capabilities and add back only what's needed
 - Use `readOnlyRootFilesystem: true` where possible
 - Set `seccompProfile: RuntimeDefault`
-- Never run Docker-in-Docker or mount the Docker socket — use Kaniko, buildah, or CodeBuild instead
+- Never run Docker-in-Docker or mount the Docker socket — use buildah, CodeBuild, or BuildKit instead (Kaniko is archived — prefer buildah/CodeBuild/BuildKit)
 - Restrict `hostPath` usage — if necessary, mount as `readOnly: true` and limit allowed prefixes via policy
 - Don't enable `privileged: true`, `hostNetwork`, `hostPID`, or `hostIPC` for application workloads
 - Set resource requests and limits on every container to prevent DoS and resource contention
@@ -442,10 +443,13 @@ The ExternalId requirement mitigates confused-deputy attacks by ensuring only th
 | **Sealed Secrets (Bitnami)** | Low | Manual | Encrypt secrets for Git storage |
 | **Direct SDK calls** | Low | N/A | Application handles own secret retrieval |
 
-### Enable Envelope Encryption
+### Bring Your Own KMS Key (Customer-Managed CMK)
+
+Envelope encryption for Kubernetes secrets is already **on by default** on every cluster (see [Data Encryption](#data-encryption)). `associate-encryption-config` does **not** turn encryption on — its current role is to layer your own customer-managed KMS key (CMK) over the default AWS-owned key, giving you CloudTrail visibility into key usage and direct control over the key (disable/rotate/scope via key policy). It still scopes only `resources: ["secrets"]`.
 
 ```bash
-# Enable KMS encryption for Kubernetes secrets
+# Associate a customer-managed CMK for secrets (adds key control + CloudTrail visibility;
+# does NOT enable encryption — that is already on by default)
 aws eks associate-encryption-config \
   --cluster-name my-cluster \
   --encryption-config '[{
@@ -501,14 +505,14 @@ fields @timestamp, @message
 
 ### Secrets Best Practices
 
-- Enable envelope encryption with KMS for etcd secrets
+- Envelope encryption for etcd secrets is on by default; layer a customer-managed KMS CMK when you need key control and CloudTrail visibility
 - Use ESO or Secrets Store CSI for production workloads
 - Set `refreshInterval` for automatic rotation pickup
 - **Use volume mounts instead of environment variables** — env var values can appear in logs, `kubectl describe`, and crash dumps. Secrets mounted as volumes use tmpfs (RAM-backed) and are removed when the pod is deleted
 - Use separate namespaces to isolate secrets from different applications — secrets in a namespace are accessible to all pods in that namespace
 - Don't store secrets in ConfigMaps
 - Don't commit secrets to Git (even base64-encoded)
-- Don't rely on default Kubernetes encryption (base64 only, not encrypted at rest)
+- In **vanilla Kubernetes**, Secrets are only base64-encoded (not encrypted at rest); don't rely on that. **On EKS this is not the case** — every cluster has default envelope encryption for secrets plus disk-level etcd encryption, so EKS Secrets are encrypted at rest out of the box. Layer a customer-managed CMK when you need key control (see above)
 
 ### Secrets Operating Models
 
@@ -587,7 +591,7 @@ ESO syncs to K8s Secret in target namespace
 
 | Component | Mechanism | Default |
 |-----------|-----------|---------|
-| **etcd (secrets)** | KMS envelope encryption | Off — must enable |
+| **etcd (secrets)** | KMS envelope encryption (AWS-owned KEK) | On by default (all clusters ≥ 1.28) |
 | **EBS volumes** | EBS encryption with KMS | Configure in StorageClass |
 | **EFS** | Encryption at rest | Configure at file system creation |
 | **FSx for Lustre** | Service-managed key or CMK | Service-managed by default |
@@ -627,7 +631,7 @@ spec:
     volumeHandle: <file_system_id>
 ```
 
-**Use EFS access points** to simplify shared dataset access with different POSIX file permissions. Each EFS file system supports up to 120 access points.
+**Use EFS access points** to simplify shared dataset access with different POSIX file permissions. Each EFS file system supports up to 10,000 access points (adjustable quota).
 
 ### CMK Rotation
 
@@ -649,3 +653,5 @@ Configure KMS to automatically rotate your CMKs. This rotates keys once a year w
 - [AWS EKS Best Practices Guide — IAM](https://docs.aws.amazon.com/eks/latest/best-practices/identity-and-access-management.html)
 - [AWS EKS Best Practices Guide — Pod Security](https://docs.aws.amazon.com/eks/latest/best-practices/pod-security.html)
 - [AWS EKS Best Practices Guide — Data Encryption](https://docs.aws.amazon.com/eks/latest/best-practices/data-encryption-and-secrets-management.html)
+- [Amazon EKS — Envelope encryption of Kubernetes secrets](https://docs.aws.amazon.com/eks/latest/userguide/envelope-encryption.html)
+- [Amazon EFS — Quotas and limits](https://docs.aws.amazon.com/efs/latest/ug/limits.html)

--- a/misc/website/docs/skills/eks/eks-best-practices/references/security.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/security.md
@@ -302,7 +302,7 @@ spec:
 - Drop ALL capabilities and add back only what's needed
 - Use `readOnlyRootFilesystem: true` where possible
 - Set `seccompProfile: RuntimeDefault`
-- Never run Docker-in-Docker or mount the Docker socket — use buildah, CodeBuild, or BuildKit instead (Kaniko is archived — prefer buildah/CodeBuild/BuildKit)
+- Never run Docker-in-Docker or mount the Docker socket — use buildah, CodeBuild, or BuildKit instead (Kaniko is archived — prefer buildah/CodeBuild/BuildKit) (as of 2026-08-04)
 - Restrict `hostPath` usage — if necessary, mount as `readOnly: true` and limit allowed prefixes via policy
 - Don't enable `privileged: true`, `hostNetwork`, `hostPID`, or `hostIPC` for application workloads
 - Set resource requests and limits on every container to prevent DoS and resource contention

--- a/misc/website/docs/skills/eks/eks-best-practices/references/security.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/security.md
@@ -445,7 +445,7 @@ The ExternalId requirement mitigates confused-deputy attacks by ensuring only th
 
 ### Bring Your Own KMS Key (Customer-Managed CMK)
 
-Envelope encryption for Kubernetes secrets is already **on by default** on every cluster (see [Data Encryption](#data-encryption)). `associate-encryption-config` does **not** turn encryption on — its current role is to layer your own customer-managed KMS key (CMK) over the default AWS-owned key, giving you CloudTrail visibility into key usage and direct control over the key (disable/rotate/scope via key policy). It still scopes only `resources: ["secrets"]`.
+Envelope encryption for Kubernetes secrets is already **on by default** on every cluster (see [Data Encryption](#data-encryption)). `associate-encryption-config` does **not** turn encryption on — its current role is to layer your own customer-managed KMS key (CMK) over the default AWS-owned key, giving you CloudTrail visibility into key usage and direct control over the key (disable/rotate/scope via key policy). On ≥1.28, default envelope encryption covers all Kubernetes API data; associating a CMK makes it the KEK for all of it. The `associate-encryption-config` API still accepts only `resources: ["secrets"]` as input, but the effect extends to all API data.
 
 ```bash
 # Associate a customer-managed CMK for secrets (adds key control + CloudTrail visibility;
@@ -512,7 +512,7 @@ fields @timestamp, @message
 - Use separate namespaces to isolate secrets from different applications — secrets in a namespace are accessible to all pods in that namespace
 - Don't store secrets in ConfigMaps
 - Don't commit secrets to Git (even base64-encoded)
-- In **vanilla Kubernetes**, Secrets are only base64-encoded (not encrypted at rest); don't rely on that. **On EKS this is not the case** — every cluster has default envelope encryption for secrets plus disk-level etcd encryption, so EKS Secrets are encrypted at rest out of the box. Layer a customer-managed CMK when you need key control (see above)
+- In **vanilla Kubernetes**, Secrets are only base64-encoded (not encrypted at rest); don't rely on that. **On EKS this is not the case** — on clusters ≥1.28 default envelope encryption covers all Kubernetes API data (not just secrets) plus disk-level etcd encryption, so EKS Secrets are encrypted at rest out of the box. Layer a customer-managed CMK when you need key control (see above)
 
 ### Secrets Operating Models
 
@@ -591,7 +591,7 @@ ESO syncs to K8s Secret in target namespace
 
 | Component | Mechanism | Default |
 |-----------|-----------|---------|
-| **etcd (secrets)** | KMS envelope encryption (AWS-owned KEK) | On by default (all clusters ≥ 1.28) |
+| **etcd (all K8s API data)** | KMS envelope encryption (AWS-owned KEK) | On by default (all clusters ≥ 1.28); covers all API data, not just secrets |
 | **EBS volumes** | EBS encryption with KMS | Configure in StorageClass |
 | **EFS** | Encryption at rest | Configure at file system creation |
 | **FSx for Lustre** | Service-managed key or CMK | Service-managed by default |

--- a/misc/website/docs/skills/eks/eks-best-practices/references/terraform-examples.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/terraform-examples.md
@@ -522,7 +522,8 @@ module "vpc" {
 ### Standard Add-on Block
 
 ```hcl
-cluster_addons = {
+# v21 (terraform-aws-modules/eks ~> 21.0): the argument is `addons` — it was `cluster_addons` in v20.
+addons = {
   coredns = {
     most_recent = true
   }

--- a/misc/website/docs/skills/eks/eks-best-practices/references/terraform-examples.md
+++ b/misc/website/docs/skills/eks/eks-best-practices/references/terraform-examples.md
@@ -113,7 +113,7 @@ module "eks" {
 
 | Feature | eks-auto-mode | eks-capabilities | eks-managed-node-group | self-managed-node-group | karpenter | eks-hybrid-nodes |
 |---------|:---:|:---:|:---:|:---:|:---:|:---:|
-| **K8s Version** | 1.33 | 1.34 | 1.33 | 1.33 | 1.33 | 1.33 |
+| **K8s Version** | 1.34 | 1.34 | 1.34 | 1.34 | 1.34 | 1.34 |
 | **Compute** | Auto Mode | Auto Mode | MNG | ASG | MNG + Karpenter | Hybrid + Cilium |
 | **AL2023** | — | — | ✅ | ✅ | — | — |
 | **Bottlerocket** | — | — | ✅ | ✅ | — | — |
@@ -139,8 +139,8 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 21.0"
 
-  cluster_name    = "auto-mode-cluster"
-  cluster_version = "1.33"
+  name               = "auto-mode-cluster"
+  kubernetes_version = "1.34"
 
   # Enable Auto Mode
   compute_config = {
@@ -151,7 +151,7 @@ module "eks" {
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
-  cluster_addons = {
+  addons = {
     coredns                = {}
     eks-pod-identity-agent = {}
     kube-proxy             = {}
@@ -227,8 +227,8 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 21.0"
 
-  cluster_name    = "mng-al2023"
-  cluster_version = "1.33"
+  name               = "mng-al2023"
+  kubernetes_version = "1.34"
 
   eks_managed_node_groups = {
     default = {
@@ -253,7 +253,7 @@ module "eks" {
     }
   }
 
-  cluster_addons = {
+  addons = {
     coredns                = {}
     eks-pod-identity-agent = { before_compute = true }
     kube-proxy             = {}
@@ -314,8 +314,8 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 21.0"
 
-  cluster_name    = "karpenter-cluster"
-  cluster_version = "1.33"
+  name               = "karpenter-cluster"
+  kubernetes_version = "1.34"
 
   # MNG for system pods (Karpenter controller runs here)
   eks_managed_node_groups = {
@@ -332,7 +332,7 @@ module "eks" {
     "karpenter.sh/discovery" = "karpenter-cluster"
   }
 
-  cluster_addons = {
+  addons = {
     coredns                = {}
     eks-pod-identity-agent = {}
     kube-proxy             = {}
@@ -345,8 +345,6 @@ module "karpenter" {
   source = "terraform-aws-modules/eks/aws//modules/karpenter"
 
   cluster_name          = module.eks.cluster_name
-  enable_pod_identity   = true
-  create_pod_identity_association = true
 
   node_iam_role_additional_policies = {
     AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
@@ -408,8 +406,8 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 21.0"
 
-  cluster_name    = "hybrid-cluster"
-  cluster_version = "1.33"
+  name               = "hybrid-cluster"
+  kubernetes_version = "1.34"
 
   # Enable hybrid node support
   remote_network_config = {
@@ -602,8 +600,8 @@ VPC (3 AZs)
 module "eks" {
   source = "terraform-aws-modules/eks/aws"
 
-  cluster_endpoint_public_access  = false
-  cluster_endpoint_private_access = true
+  endpoint_public_access  = false
+  endpoint_private_access = true
 
   # MNG for system pods
   eks_managed_node_groups = {

--- a/skills/eks-best-practices/SKILL.md
+++ b/skills/eks-best-practices/SKILL.md
@@ -129,7 +129,7 @@ Comprehensive guidance for designing, deploying, and operating Amazon EKS cluste
 
 | Approach | Use When | Setup |
 |----------|----------|-------|
-| **Pod Identity** | ✅ New workloads (EKS 1.24+) | EKS add-on + association |
+| **Pod Identity** | ✅ New workloads | EKS add-on + association |
 | **IRSA** | Older clusters, Fargate | OIDC provider + trust policy |
 
 **Key rules:**
@@ -234,8 +234,10 @@ topologySpreadConstraints:
 |--------|---------|------------|
 | **Risk** | Low-Medium | Lowest |
 | **Cost** | No extra | 2× during migration |
-| **Rollback** | ❌ No CP rollback | ✅ Switch back |
-| **Use when** | ✅ Most upgrades | Critical workloads |
+| **Rollback** | ✅ To N-1 within 7 days of upgrade | ✅ Switch back (any window) |
+| **Use when** | ✅ Most upgrades | Post-7-day rollback, multi-minor jumps, data-plane isolation |
+
+Native in-place rollback to N-1 is supported within **7 days** of an in-place upgrade (all regions, all cluster types; Auto Mode rolls back nodes automatically). `update-cluster-version` supports type `VersionRollback`, gated by a `ROLLBACK_READINESS` insight; add-ons/data-plane roll back separately. Blue-green retains independent rationale for post-7-day windows, multi-minor jumps, and data-plane isolation — not "because you can't roll back."
 
 ### Data Plane with Karpenter
 
@@ -259,6 +261,8 @@ disruption:
 | **Scale-up speed** | ~30s | ~60-90s | AWS-managed |
 | **Consolidation** | ✅ Built-in | ❌ | ✅ |
 | **Customization** | High | Medium | Low |
+
+Cluster Autoscaler's ~60-90s scale-up assumes cold EC2 launches; MNG EC2 warm pools (2026-04) pre-initialize instances and cut that latency substantially for MNG-backed node groups.
 
 ### Pod Autoscaler Selection
 

--- a/skills/eks-best-practices/SKILL.md
+++ b/skills/eks-best-practices/SKILL.md
@@ -159,7 +159,7 @@ metadata:
 | **Secrets Store CSI** | Medium | Mount secrets as volumes |
 | **KMS envelope encryption** | Low | Encrypt etcd secrets |
 
-**Always enable KMS envelope encryption for Kubernetes secrets.**
+Envelope encryption is on by default (≥1.28) and covers all Kubernetes API data; layer your own KMS CMK when you need key control and CloudTrail visibility. Source: https://docs.aws.amazon.com/eks/latest/userguide/envelope-encryption.html
 
 **For detailed security guidance, see:** [Security Reference](references/security.md) | [Runtime & Network](references/security-runtime-network.md) | [Supply Chain & Compliance](references/security-supply-chain.md)
 
@@ -237,7 +237,7 @@ topologySpreadConstraints:
 | **Rollback** | ✅ To N-1 within 7 days of upgrade | ✅ Switch back (any window) |
 | **Use when** | ✅ Most upgrades | Post-7-day rollback, multi-minor jumps, data-plane isolation |
 
-Native in-place rollback to N-1 is supported within **7 days** of an in-place upgrade (all regions, all cluster types; Auto Mode rolls back nodes automatically). `update-cluster-version` supports type `VersionRollback`, gated by a `ROLLBACK_READINESS` insight; add-ons/data-plane roll back separately. Blue-green retains independent rationale for post-7-day windows, multi-minor jumps, and data-plane isolation — not "because you can't roll back."
+Native in-place rollback to N-1 is supported within **7 days** of an in-place upgrade (all regions; Auto Mode rolls back nodes automatically; rollback into an extended-support version requires setting the cluster upgrade policy to `EXTENDED` first). `update-cluster-version` supports type `VersionRollback`, gated by a `ROLLBACK_READINESS` insight; add-ons/data-plane roll back separately. Blue-green retains independent rationale for post-7-day windows, multi-minor jumps, and data-plane isolation — not "because you can't roll back."
 
 ### Data Plane with Karpenter
 

--- a/skills/eks-best-practices/references/autoscaling.md
+++ b/skills/eks-best-practices/references/autoscaling.md
@@ -29,7 +29,7 @@
 | **Spot support** | Native Spot handling | Via mixed instance policy | AWS-managed |
 | **Operational overhead** | Low -- CRD-based config | Medium -- ASG management | Lowest -- fully managed |
 | **Customization** | High | Medium | Low |
-| **Maturity** | GA (v1.0+) | Very mature | Newer -- evaluate for your use case |
+| **Maturity** | GA (v1.0+) | Very mature | GA and mature -- managed drivers, self-service troubleshooting, GPU support |
 | **Recommendation** | Default choice | When Karpenter is not an option | When minimal ops is top priority |
 
 **For detailed Karpenter guidance, see:** [Karpenter Reference](karpenter.md)
@@ -49,7 +49,7 @@
 
 ### When to Use CAS Over Karpenter
 
-- EKS on Outposts (Karpenter not supported)
+- EKS on Outposts (Karpenter not supported, as of 2026-08-04)
 - Self-managed node groups with specific AMI requirements
 - Clusters already running CAS with complex ASG configurations
 - Organizations requiring node group-level operational boundaries
@@ -275,7 +275,7 @@ EKS Auto Mode provides AWS-managed:
 - **Node provisioning and scaling** (no node groups to manage)
 - **Node OS patching and upgrades**
 - **Compute optimization** (instance selection, Spot)
-- **Cluster add-ons** (VPC CNI, CoreDNS, kube-proxy)
+- **Built-in networking, DNS, load balancing, and storage** — VPC CNI, CoreDNS, kube-proxy, the AWS Load Balancer Controller, and EBS CSI run as AWS-managed built-in components, not as cluster add-ons you install. Installing the corresponding EKS add-ons on an Auto Mode cluster is redundant (and conflicts with the managed components).
 
 ### When to Use Auto Mode
 
@@ -287,10 +287,12 @@ Use Auto Mode when:
 
 Don't use Auto Mode when:
 - You need custom AMIs or specific kernel configurations
-- GPU/ML workloads requiring specific instance types or drivers
+- You must pin a *specific* GPU/Neuron driver version (Auto Mode is Bottlerocket-only and ships AWS-managed driver versions)
 - Windows containers are required
 - You need fine-grained control over node configuration
 - Running on EKS Outposts or EKS Anywhere
+
+**GPU/ML on Auto Mode:** Auto Mode DOES support GPU and accelerated workloads — it ships managed NVIDIA and Neuron drivers plus the GPU device plugins, and specific accelerated instance types are selectable via custom NodePools (e.g. `requirements` on `node.kubernetes.io/instance-type` or instance-family/GPU labels). The only residual limitation is that you can't pin a custom driver *version* (drivers track the managed Bottlerocket AMI). If a specific driver version or custom AMI is mandatory, use standard EKS + Karpenter instead.
 
 ### Auto Mode Configuration
 

--- a/skills/eks-best-practices/references/cluster-upgrades.md
+++ b/skills/eks-best-practices/references/cluster-upgrades.md
@@ -577,7 +577,7 @@ For nodes deployed outside the EKS managed service, use your provisioning tool:
 | Phase | Patching | Cost | Auto-upgrade? |
 |-------|----------|------|----------------|
 | **Standard support** | Security + bug fixes | Standard pricing | No |
-| **Extended support** | Critical security only | Additional per-hour surcharge | No |
+| **Extended support** | CP security patches + VPC CNI/kube-proxy/CoreDNS + EKS AMI patches; full AWS support | Additional per-hour surcharge | No |
 | **End of extended support** | None | N/A | Yes — AWS auto-upgrades at a time it chooses |
 
 **Always get exact dates from the EKS API — do not compute them from release dates.** Standard and extended support windows have historically shifted; the API is the only trustworthy source.

--- a/skills/eks-best-practices/references/cluster-upgrades.md
+++ b/skills/eks-best-practices/references/cluster-upgrades.md
@@ -99,12 +99,12 @@ If an insight shows `"status": ERROR`, you **must** resolve it before upgrading.
 | Factor | In-Place Upgrade | Blue-Green Upgrade |
 |--------|-----------------|-------------------|
 | **Downtime risk** | Minutes (control plane) | Near-zero |
-| **Rollback** | Not possible for control plane | DNS/LB switch back |
+| **Rollback** | Yes, to N-1 within 7 days of an in-place upgrade (readiness-checked; add-ons/data-plane separate) | DNS/LB switch back (any time) |
 | **Cost** | No extra cost | 2× cluster cost during migration |
 | **Complexity** | Low-Medium | High |
 | **State migration** | None needed | Must migrate PVs, DNS, state |
 | **Version jump** | One minor at a time | Can skip versions (new cluster) |
-| **Use when** | Most upgrades | Critical workloads, major version jumps |
+| **Use when** | Most upgrades (in-place N-1 rollback available within 7 days) | Post-7-day rollback window, multi-minor jumps, data-plane isolation |
 
 ---
 
@@ -134,7 +134,7 @@ aws eks describe-cluster --name my-cluster \
 # Upgrade control plane (one minor version at a time)
 aws eks update-cluster-version \
   --name my-cluster \
-  --kubernetes-version 1.31
+  --kubernetes-version 1.34
 
 # Monitor upgrade status
 aws eks describe-update \
@@ -143,10 +143,10 @@ aws eks describe-update \
 ```
 
 **Key constraints:**
-- Can only upgrade one minor version at a time (1.29 → 1.30, not 1.29 → 1.31)
+- Can only upgrade one minor version at a time (1.34 → 1.35, not 1.34 → 1.36)
 - Control plane upgrade takes 15-30 minutes
 - API server remains available during upgrade (brief API errors possible)
-- Cannot rollback control plane version
+- Native in-place rollback to N-1 is supported within **7 days** of an in-place upgrade (GA, all regions, all cluster types; Auto Mode also rolls back nodes automatically). `update-cluster-version` supports type `VersionRollback`; a `ROLLBACK_READINESS` insight gates it. Add-ons/data-plane roll back separately. Past the 7-day window, roll back via blue-green or cluster rebuild.
 
 ### Step 2: Upgrade Add-ons
 
@@ -157,6 +157,8 @@ aws eks describe-addon --cluster-name my-cluster --addon-name coredns
 aws eks describe-addon --cluster-name my-cluster --addon-name kube-proxy
 
 # Upgrade each add-on
+# (--addon-version below is illustrative — check the current version with
+#  `aws eks describe-addon-versions` rather than pinning this exact value)
 aws eks update-addon \
   --cluster-name my-cluster \
   --addon-name vpc-cni \
@@ -176,7 +178,7 @@ EKS add-ons are **not** automatically upgraded during a control plane upgrade �
 aws eks update-nodegroup-version \
   --cluster-name my-cluster \
   --nodegroup-name default \
-  --kubernetes-version 1.31
+  --kubernetes-version 1.34
 
 # Monitor rolling update
 aws eks describe-nodegroup \
@@ -203,7 +205,9 @@ After the cluster upgrade, update your kubectl client to match:
 
 ```bash
 # Verify kubectl version matches cluster
-kubectl version --short
+# (--short was removed in kubectl 1.28; it errors on current clients)
+kubectl version
+# Optionally: kubectl version -o yaml   (or -o json)
 ```
 
 ### Ensure Availability During Upgrade
@@ -261,7 +265,8 @@ Spreading across zones and hosts ensures pods migrate to new nodes automatically
 - Major version jumps (skipping multiple minor versions via new cluster)
 - Zero-downtime requirement for the upgrade itself
 - Significant architectural changes alongside version upgrade
-- Compliance requirement for rollback capability
+- Data-plane isolation (validate the new version on a separate data plane before cutover)
+- Rollback needed beyond the 7-day in-place window (in-place N-1 rollback covers the first 7 days — see [Emergency Rollback Procedures](#emergency-rollback-procedures))
 
 ### Blue-Green Procedure
 
@@ -280,8 +285,32 @@ Spreading across zones and hosts ensures pods migrate to new nodes automatically
 |--------|------------|----------------|
 | **Route 53 weighted routing** | Percentage-based | Fast (DNS TTL) |
 | **ALB weighted target groups** | Percentage-based | Instant |
+| **NLB weighted target groups** | Percentage-based | Instant (weight shift is manual — no automatic failover) |
 | **Global Accelerator** | Endpoint weights | Instant |
 | **External DNS cutover** | All-or-nothing | DNS TTL dependent |
+
+#### NLB Weighted Target-Group Cutover
+
+For L4 / internal-NLB blue/green cutover, use **NLB weighted target groups** (a weighted `forward` action), GA as of 2025-11-19. Point one NLB listener at two target groups — one registered to the blue cluster, one to the green — and shift weights to move traffic:
+
+```bash
+aws elbv2 modify-listener \
+  --listener-arn <listener-arn> \
+  --default-actions '[{
+    "Type": "forward",
+    "ForwardConfig": {
+      "TargetGroups": [
+        {"TargetGroupArn": "<blue-tg-arn>", "Weight": 90},
+        {"TargetGroupArn": "<green-tg-arn>", "Weight": 10}
+      ]
+    }
+  }]'
+```
+
+Constraints:
+- Use **`ip`-type** target groups with a `TargetGroupBinding` per cluster. Never share one target group between clusters — the two clusters' controllers will fight over registration/deregistration.
+- With the AWS Load Balancer Controller, set `multiClusterTargetGroup: true` so the controller does not deregister targets it did not create.
+- **NLB has no automatic failover** — weight shifts are manual, so watch health checks and roll weights back yourself if the green cluster misbehaves.
 
 ### Blue-Green Downsides to Consider
 
@@ -323,7 +352,7 @@ For workloads with PersistentVolumes:
 # List compatible versions for an add-on
 aws eks describe-addon-versions \
   --addon-name vpc-cni \
-  --kubernetes-version 1.31 \
+  --kubernetes-version 1.34 \
   --query 'addons[0].addonVersions[*].{Version:addonVersion,Default:compatibilities[0].defaultVersion}' \
   --output table
 ```
@@ -398,20 +427,20 @@ aws logs get-query-results --query-id $QUERY_ID
 brew install FairwindsOps/tap/pluto
 
 # Scan Helm releases in cluster
-pluto detect-helm --target-versions k8s=v1.31
+pluto detect-helm --target-versions k8s=v1.34
 
 # Scan manifest files (more accurate — recommended for CI)
-pluto detect-files -d manifests/ --target-versions k8s=v1.31
+pluto detect-files -d manifests/ --target-versions k8s=v1.34
 
 # Scan live cluster
-pluto detect-api-resources --target-versions k8s=v1.31
+pluto detect-api-resources --target-versions k8s=v1.34
 ```
 
 ### Using kube-no-trouble
 
 ```bash
 sh -c "$(curl -sSL https://git.io/install-kubent)"
-kubent --target-version 1.31
+kubent --target-version 1.34
 ```
 
 Scanning static manifests is generally more accurate than live cluster scanning (fewer false positives). Run `kubent`/`pluto` in CI pipelines to catch issues before deployment.
@@ -422,15 +451,18 @@ Scanning static manifests is generally more accurate than live cluster scanning 
 |---------|------------|-------------|
 | **1.25** | PodSecurityPolicy | Pod Security Admission (PSA) |
 | **1.25** | batch/v1beta1 CronJob | batch/v1 |
-| **1.25** | Dockershim (CRI) | containerd (EKS Optimized AMI default) |
 | **1.26** | flowcontrol.apiserver.k8s.io/v1beta1 | flowcontrol.apiserver.k8s.io/v1beta3 |
 | **1.27** | storage.k8s.io/v1beta1 CSIStorageCapacity | storage.k8s.io/v1 |
 | **1.29** | flowcontrol.apiserver.k8s.io/v1beta2 | flowcontrol.apiserver.k8s.io/v1 |
 | **1.32** | flowcontrol.apiserver.k8s.io/v1beta3 | flowcontrol.apiserver.k8s.io/v1 |
 
+> This table lists API removals as of 2026-08-04 and is not a complete list for versions beyond 1.32 — always verify against the live [Kubernetes deprecation guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/) and EKS release notes for your target version.
+>
+> **Note:** Dockershim is a container-runtime component, **not** an API removal. It was removed upstream in Kubernetes **1.24** (EKS-Optimized AMIs use containerd) — see the migration guidance below.
+
 ### Feature-Specific Migration Guidance
 
-**Dockershim removal (1.25):** EKS Optimized AMI for 1.25+ uses containerd, not Docker. If you mount the Docker socket (`/var/run/docker.sock`), detect dependencies with the [Detector for Docker Socket (DDS)](https://github.com/aws-containers/kubectl-detector-for-docker-socket) kubectl plugin before upgrading nodes.
+**Dockershim removal (1.24):** Dockershim was removed upstream in Kubernetes 1.24; EKS-Optimized AMIs for 1.24+ use containerd, not Docker. If you mount the Docker socket (`/var/run/docker.sock`), detect dependencies with the [Detector for Docker Socket (DDS)](https://github.com/aws-containers/kubectl-detector-for-docker-socket) kubectl plugin before upgrading nodes.
 
 **PodSecurityPolicy removal (1.25):** Migrate to built-in [Pod Security Standards (PSS)](https://docs.aws.amazon.com/eks/latest/userguide/pod-security-policy-removal-faq.html) or a policy-as-code solution (Kyverno, OPA/Gatekeeper) before upgrading to 1.25.
 
@@ -496,9 +528,13 @@ Karpenter does not add jitter to expiry — configure PDBs to prevent simultaneo
 
 **Force immediate node replacement:**
 
+To force replacement of a specific node, delete its NodeClaim — Karpenter drains the node (respecting PDBs) and provisions a replacement:
+
 ```bash
-kubectl annotate nodes --all karpenter.sh/voluntary-disruption=drifted --overwrite
+kubectl delete nodeclaim/<nodeclaim-name>
 ```
+
+There is no `karpenter.sh/voluntary-disruption` annotation that forces replacement across the fleet — setting such an annotation is a silent no-op. See the [Karpenter disruption docs](https://karpenter.sh/docs/concepts/disruption/).
 
 ### Managed Node Group Upgrades
 
@@ -530,6 +566,8 @@ For nodes deployed outside the EKS managed service, use your provisioning tool:
 
 ## Version Support Policy
 
+> **Version anchors as of 2026-08-04:** the standard-support versions are **1.34 / 1.35 / 1.36** (newest is 1.36). **1.31, 1.32, and 1.33 are all in extended support** (1.33 exited standard support 2026-07-29). These move roughly every quarter — always confirm the current/newest versions against the live [EKS Kubernetes version release calendar](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar) and the per-cluster API (below) rather than trusting a static list.
+
 ### EKS Version Lifecycle
 
 | Phase | Patching | Cost | Auto-upgrade? |
@@ -555,7 +593,7 @@ You can [disable extended support](https://docs.aws.amazon.com/eks/latest/usergu
 - **End of extended support:** query the API per cluster version
 - **After:** EKS auto-upgrades your cluster (may disrupt workloads)
 
-**Recommendation:** Upgrade every 3-4 months to stay within standard support. Budget one upgrade cycle per quarter. Look beyond the next version — review upcoming K8s releases to identify major changes early (e.g., Dockershim removal was announced well before 1.25).
+**Recommendation:** Upgrade every 3-4 months to stay within standard support. Budget one upgrade cycle per quarter. Look beyond the next version — review upcoming K8s releases to identify major changes early (e.g., Dockershim removal was announced well before 1.24).
 
 ### Additional Upgrade Tools
 
@@ -650,7 +688,7 @@ To verify SSM connectivity: check that the SSM agent is running on the node, the
 
 | Component | Can Rollback? | Method | Notes |
 |---|---|---|---|
-| **EKS control plane** | No | Cannot downgrade K8s version | Must rebuild cluster at previous version |
+| **EKS control plane** | Yes (within 7 days) | In-place rollback to N-1 via `update-cluster-version` type `VersionRollback` (gated by a `ROLLBACK_READINESS` insight); Auto Mode rolls back nodes automatically | Post-7-day: blue-green or rebuild is the fallback, not the only path. Add-ons/data-plane roll back separately. |
 | **Data plane nodes** | Yes | Replace with previous AMI | Karpenter: update EC2NodeClass AMI; MNG: update launch template |
 | **EKS managed add-ons** | Yes | Revert to previous version via API/Terraform | Some add-ons have minimum version requirements |
 | **Helm-managed add-ons** | Yes | `helm rollback` or GitOps revert | Check CRD compatibility |
@@ -697,4 +735,6 @@ Use when: catastrophic cluster failure, corrupted etcd state, or failed upgrade 
 **Sources:**
 - [AWS EKS Best Practices Guide — Cluster Upgrades](https://docs.aws.amazon.com/eks/latest/best-practices/cluster-upgrades.html)
 - [EKS Version Lifecycle](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)
+- [EKS control-plane version rollback](https://docs.aws.amazon.com/eks/latest/userguide/rollback-cluster.html) · [What's New — Amazon EKS version rollback](https://aws.amazon.com/about-aws/whats-new/2026/07/amazon-eks-version-rollback/)
 - [Karpenter Upgrade Guide](https://karpenter.sh/docs/upgrading/)
+- [Karpenter Disruption](https://karpenter.sh/docs/concepts/disruption/)

--- a/skills/eks-best-practices/references/cluster-upgrades.md
+++ b/skills/eks-best-practices/references/cluster-upgrades.md
@@ -146,7 +146,7 @@ aws eks describe-update \
 - Can only upgrade one minor version at a time (1.34 → 1.35, not 1.34 → 1.36)
 - Control plane upgrade takes 15-30 minutes
 - API server remains available during upgrade (brief API errors possible)
-- Native in-place rollback to N-1 is supported within **7 days** of an in-place upgrade (GA, all regions, all cluster types; Auto Mode also rolls back nodes automatically). `update-cluster-version` supports type `VersionRollback`; a `ROLLBACK_READINESS` insight gates it. Add-ons/data-plane roll back separately. Past the 7-day window, roll back via blue-green or cluster rebuild.
+- Native in-place rollback to N-1 is supported within **7 days** of an in-place upgrade (GA, all regions; Auto Mode also rolls back nodes automatically). `update-cluster-version` supports type `VersionRollback`; a `ROLLBACK_READINESS` insight gates it. Rollback into an extended-support version requires setting the cluster upgrade policy to `EXTENDED` first (rollback-cluster.html). Add-ons/data-plane roll back separately. Past the 7-day window, roll back via blue-green or cluster rebuild.
 
 ### Step 2: Upgrade Add-ons
 
@@ -285,7 +285,7 @@ Spreading across zones and hosts ensures pods migrate to new nodes automatically
 |--------|------------|----------------|
 | **Route 53 weighted routing** | Percentage-based | Fast (DNS TTL) |
 | **ALB weighted target groups** | Percentage-based | Instant |
-| **NLB weighted target groups** | Percentage-based | Instant (weight shift is manual — no automatic failover) |
+| **NLB weighted target groups** | Percentage-based | Fast (new flows, ≤~3 min; existing flows drain) |
 | **Global Accelerator** | Endpoint weights | Instant |
 | **External DNS cutover** | All-or-nothing | DNS TTL dependent |
 
@@ -309,8 +309,8 @@ aws elbv2 modify-listener \
 
 Constraints:
 - Use **`ip`-type** target groups with a `TargetGroupBinding` per cluster. Never share one target group between clusters — the two clusters' controllers will fight over registration/deregistration.
-- With the AWS Load Balancer Controller, set `multiClusterTargetGroup: true` so the controller does not deregister targets it did not create.
-- **NLB has no automatic failover** — weight shifts are manual, so watch health checks and roll weights back yourself if the green cluster misbehaves.
+- With the AWS Load Balancer Controller, set `multiClusterTargetGroup: true` so the controller does not deregister targets it did not create — the flag guards a manually-created target group from controller deregistration, so the LBC manages only targets it registered on the manually-provisioned target group.
+- **NLB has no automatic failover between weighted target groups** (unlike ALB automatic target weights), as of 2026-08-05 — weight shifts are manual, so watch health checks and roll weights back yourself if the green cluster misbehaves.
 
 ### Blue-Green Downsides to Consider
 
@@ -509,9 +509,10 @@ spec:
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
     budgets:
-    - nodes: "10%"                 # all-reasons fallback: at most 10% of nodes disrupted at once
+    - nodes: "10%"                 # fallback for churn-driven disruption (drift/underutilization)
+      reasons: ["Drifted","Underutilized"]
     - nodes: "100%"
-      reasons: ["Empty"]           # always reclaim empty nodes without throttling (outside the freeze window)
+      reasons: ["Empty"]           # reclaim empty nodes at full speed (not capped by the fallback above)
     - nodes: "0"                   # freeze ALL voluntary disruption during the scheduled window
       # NOTE: Karpenter budget schedules are evaluated in UTC, not cluster-local time.
       # 01:00 UTC = 09:00 in a UTC+8 region — anchor the cron to UTC accordingly.

--- a/skills/eks-best-practices/references/cluster-upgrades.md
+++ b/skills/eks-best-practices/references/cluster-upgrades.md
@@ -509,9 +509,13 @@ spec:
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
     budgets:
-    - nodes: "10%"    # Max 10% of nodes disrupted at a time
-    - nodes: "0"
-      schedule: "0 9 * * 1-5"  # No disruptions during business hours
+    - nodes: "10%"                 # all-reasons fallback: at most 10% of nodes disrupted at once
+    - nodes: "100%"
+      reasons: ["Empty"]           # always reclaim empty nodes without throttling (outside the freeze window)
+    - nodes: "0"                   # freeze ALL voluntary disruption during the scheduled window
+      # NOTE: Karpenter budget schedules are evaluated in UTC, not cluster-local time.
+      # 01:00 UTC = 09:00 in a UTC+8 region — anchor the cron to UTC accordingly.
+      schedule: "0 1 * * 1-5"      # 01:00 UTC Mon–Fri (e.g. 09:00 in UTC+8)
       duration: 8h
 ```
 

--- a/skills/eks-best-practices/references/cluster-upgrades.md
+++ b/skills/eks-best-practices/references/cluster-upgrades.md
@@ -577,7 +577,7 @@ For nodes deployed outside the EKS managed service, use your provisioning tool:
 | Phase | Patching | Cost | Auto-upgrade? |
 |-------|----------|------|----------------|
 | **Standard support** | Security + bug fixes | Standard pricing | No |
-| **Extended support** | CP security patches + VPC CNI/kube-proxy/CoreDNS + EKS AMI patches; full AWS support | Additional per-hour surcharge | No |
+| **Extended support** | CP security patches + VPC CNI/kube-proxy/CoreDNS + EKS AMI patches | Additional per-hour surcharge | No |
 | **End of extended support** | None | N/A | Yes — AWS auto-upgrades at a time it chooses |
 
 **Always get exact dates from the EKS API — do not compute them from release dates.** Standard and extended support windows have historically shifted; the API is the only trustworthy source.

--- a/skills/eks-best-practices/references/container-registry.md
+++ b/skills/eks-best-practices/references/container-registry.md
@@ -414,7 +414,7 @@ ECR archival storage provides a low-cost tier for images you need to retain but 
 | **Transition** | Via lifecycle policy `archive` action, or manual API call |
 | **Storage cost** | Lower than standard ECR storage |
 | **Restore time** | Up to 20 minutes |
-| **Restore duration** | Permanent -- restore moves the image back to the STANDARD storage class; there is no timed window after which it re-archives |
+| **Restore duration** | Permanent -- restore moves the image back to the STANDARD storage class; there is no timed window after which it re-archives (as of 2026-08-04) |
 | **Scanning** | Archived images cannot be scanned -- restore first |
 
 ### Lifecycle Policy Integration
@@ -475,7 +475,7 @@ Blob mounting allows image layers that already exist in one repository to be ref
 | **Enabled (opt-in)** | Push operations mount existing layers from other repos, saving bandwidth and time |
 
 Blob mounting is **off by default** -- opt in at the registry level with `aws ecr put-account-setting --name BLOB_MOUNTING --value ENABLED`. Constraints once enabled:
-- Not supported for pull-through-cache (PTC) images
+- Not supported for pull-through-cache (PTC) images (as of 2026-08-04)
 - Source and destination repositories must use identical encryption keys
 - Cross-repository mounts require the caller to hold `ecr:GetDownloadUrlForLayer` on the source repository
 

--- a/skills/eks-best-practices/references/container-registry.md
+++ b/skills/eks-best-practices/references/container-registry.md
@@ -128,10 +128,10 @@ DON'T:
 
 | Feature | Basic Scanning | Enhanced Scanning (Inspector) |
 |---|---|---|
-| **Engine** | Clair (open-source) | Amazon Inspector |
+| **Engine** | AWS-native (`AWS_NATIVE`) | Amazon Inspector |
 | **Coverage** | OS packages only | OS + programming language libraries |
-| **Trigger** | On-push only | Continuous (re-scans on new CVE disclosure) |
-| **Findings** | ECR console only | Security Hub + EventBridge |
+| **Trigger** | On-push, plus manual on-demand scans | Continuous (re-scans on new CVE disclosure) |
+| **Findings** | ECR console + EventBridge | Security Hub + EventBridge |
 | **Cost** | Free | Per-image pricing |
 | **Limitation** | -- | Cannot scan archived images (must restore first) |
 | **Recommendation** | Development only | Production |
@@ -279,8 +279,9 @@ ECR pull-through cache rules automatically cache images from upstream public reg
 | **Docker Hub** | `docker.io` | Yes (Secrets Manager) |
 | **ECR Public** | `public.ecr.aws` | No |
 | **GitHub Container Registry** | `ghcr.io` | Yes (Secrets Manager) |
-| **Quay.io** | `quay.io` | Yes (Secrets Manager) |
+| **Quay.io** | `quay.io` | No |
 | **Kubernetes Registry** | `registry.k8s.io` | No |
+| **ECR (another private ECR)** | `<account>.dkr.ecr.<region>.amazonaws.com` | Yes (IAM/cross-account) |
 | **GitLab Container Registry** | `registry.gitlab.com` | Yes (Secrets Manager) |
 | **Chainguard** | `cgr.dev` | Yes (Secrets Manager) |
 | **Azure Container Registry** | `<name>.azurecr.io` | Yes (Secrets Manager) |
@@ -413,7 +414,7 @@ ECR archival storage provides a low-cost tier for images you need to retain but 
 | **Transition** | Via lifecycle policy `archive` action, or manual API call |
 | **Storage cost** | Lower than standard ECR storage |
 | **Restore time** | Up to 20 minutes |
-| **Restore duration** | Restored copy available for a configurable number of days |
+| **Restore duration** | Permanent -- restore moves the image back to the STANDARD storage class; there is no timed window after which it re-archives |
 | **Scanning** | Archived images cannot be scanned -- restore first |
 
 ### Lifecycle Policy Integration
@@ -470,19 +471,26 @@ Blob mounting allows image layers that already exist in one repository to be ref
 
 | Setting | Effect |
 |---|---|
-| **Enabled (default)** | Push operations mount existing layers from other repos, saving bandwidth and time |
-| **Disabled** | Every push uploads all layers, even if identical copies exist in the registry |
+| **Disabled (default)** | Every push uploads all layers, even if identical copies exist in the registry |
+| **Enabled (opt-in)** | Push operations mount existing layers from other repos, saving bandwidth and time |
 
-Keep blob mounting enabled unless you have a specific security requirement to isolate layer access between repositories.
+Blob mounting is **off by default** -- opt in at the registry level with `aws ecr put-account-setting --name BLOB_MOUNTING --value ENABLED`. Constraints once enabled:
+- Not supported for pull-through-cache (PTC) images
+- Source and destination repositories must use identical encryption keys
+- Cross-repository mounts require the caller to hold `ecr:GetDownloadUrlForLayer` on the source repository
+
+Enable it when many images share common base layers, unless you have a specific security requirement to isolate layer access between repositories.
 
 ### Pull-Time Update Exclusions
 
-When pull-through cache is enabled, ECR checks the upstream registry for updates every 24 hours. Pull-time update exclusions let you pin specific repositories so ECR never re-checks upstream -- the cached version is treated as authoritative.
+Pull-time update exclusions are a registry setting that lists IAM role ARNs (up to 100 per account) whose image pulls do **not** update an image's `LastRecordedPullTime`. They have nothing to do with caching or pinning upstream versions.
 
-Use this for:
-- **Known-good images** you've validated and don't want upstream changes to override
-- **Air-gapped environments** where you've seeded images and upstream is unreachable
-- **Compliance scenarios** where you need a frozen, auditable copy
+The purpose is to protect `sinceImagePulled` lifecycle policies from being skewed by automated pulls. Security scanners, replication jobs, and other automation pull images frequently; without exclusions, those pulls keep refreshing `LastRecordedPullTime` and make images look "actively used," defeating lifecycle rules that expire images nobody actually deploys.
+
+Use this to:
+- **Exclude scanner roles** (e.g., Inspector or third-party CVE scanners) so their pulls don't reset the pull clock
+- **Exclude replication/automation roles** whose pulls shouldn't count as real usage
+- **Keep `sinceImagePulled` lifecycle policies accurate** so only genuinely-used images are retained
 
 ---
 
@@ -520,6 +528,8 @@ The workflow for Helm charts stored in ECR OCI follows three steps:
 - [Designing a secure container image registry](https://aws.amazon.com/blogs/containers/designing-a-secure-container-image-registry/)
 - [Amazon Inspector container scanning](https://docs.aws.amazon.com/inspector/latest/user/scanning-ecr.html)
 - [ECR Pull-Through Cache](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache.html)
+- [ECR Basic Scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning-basic.html)
+- [ECR Pull-Time Update Exclusions](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-time-update-exclusions.html)
 - [ECR Managed Signing](https://docs.aws.amazon.com/AmazonECR/latest/userguide/managed-signing.html)
 - [ECR Archival Storage](https://docs.aws.amazon.com/AmazonECR/latest/userguide/archive_restore_image.html)
 - [ECR Repository Creation Templates](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-creation-templates.html)

--- a/skills/eks-best-practices/references/cost-optimization.md
+++ b/skills/eks-best-practices/references/cost-optimization.md
@@ -33,7 +33,7 @@ The "See" pillar comes first because you can't optimize what you can't measure. 
 
 | Component | Cost Driver | Optimization Lever |
 |-----------|-----------|-------------------|
-| **EKS control plane** | $0.10/hour per cluster | Fewer clusters, multi-tenant |
+| **EKS control plane** | $0.10/hour per cluster (standard support); $0.60/hour under extended support (6x) | Stay in standard support, fewer clusters, multi-tenant |
 | **EC2 instances** | Instance type + hours | Right-sizing, Spot, Graviton |
 | **EBS volumes** | Volume type + size + IOPS | gp3, right-size, cleanup unused |
 | **Data transfer** | Cross-AZ, internet egress | Topology-aware routing, VPC endpoints |
@@ -41,10 +41,13 @@ The "See" pillar comes first because you can't optimize what you can't measure. 
 | **NAT Gateway** | Per GB processed + hourly | VPC endpoints for AWS services |
 | **Observability** | Log ingestion + metric storage | Filter, retain selectively, reduce cardinality |
 
+> **Control-plane support tier is the largest controllable control-plane cost lever.** Standard support is $0.10/hour per cluster; once a version exits standard support it moves to **extended support at $0.60/hour -- 6x the standard rate**. As of 2026-08-04, Kubernetes versions 1.31, 1.32, and 1.33 are all in extended support. Staying on a standard-support version (upgrade before standard support ends) avoids roughly **+$4,380/yr per cluster**. EKS Auto Mode adds a separate management fee on top of control-plane and EC2 costs.
+
 ### Quick Wins
 
 | Action | Typical Savings | Effort |
 |--------|----------------|--------|
+| Stay in EKS standard support | ~$4,380/yr per cluster ($0.60 vs $0.10/hr) | Low -- upgrade before standard support ends |
 | Switch to Graviton (arm64) | 20-40% | Low -- rebuild images for arm64 |
 | Use Spot for non-critical | 60-90% | Low -- Karpenter handles fallback |
 | Enable Karpenter consolidation | 20-30% | Low -- enable in NodePool |
@@ -281,13 +284,13 @@ kind: Service
 metadata:
   name: orders-service
 spec:
-  trafficDistribution: PreferClose
+  trafficDistribution: PreferSameZone   # formerly PreferClose (alias still works)
   selector:
     app: orders
   type: ClusterIP
 ```
 
-`PreferClose` routes to same-zone endpoints first, falling back to any endpoint when none are local. Can overload endpoints in high-traffic zones -- mitigate with per-zone deployments with independent HPAs, or topology spread constraints.
+`PreferSameZone` (the renamed `PreferClose`; the `PreferClose` alias still works) routes to same-zone endpoints first, falling back to any endpoint when none are local. A `PreferSameNode` option also exists to prefer node-local endpoints. Can overload endpoints in high-traffic zones -- mitigate with per-zone deployments with independent HPAs, or topology spread constraints.
 
 **Service Internal Traffic Policy** restricts traffic to the originating node:
 
@@ -333,7 +336,7 @@ Use **IP mode** to eliminate data transfer charges from LB-to-Pod traffic. Ensur
 | **gp3 root volume** | ~20% less than gp2 | Default choice for node root volumes |
 | **EC2 instance stores** | No additional cost | Caches, scratch space, temporary data |
 
-Instance stores are physically attached to the host -- free, but data is lost on termination. Use `HostPath` or the Local Persistent Volume Static Provisioner to expose them in Kubernetes.
+Instance stores are physically attached to the host -- free, but data is lost on termination. The **Instance Store CSI driver is GA as an EKS managed add-on (as of 2026-08-04)** and supersedes the `HostPath` / Local Persistent Volume Static Provisioner approach for exposing them in Kubernetes.
 
 ### Persistent Volumes: EBS
 
@@ -395,6 +398,8 @@ For FSx for Lustre, link to S3 for long-term storage -- lazy-load data into Lust
 | Container image optimization | Distroless/scratch base images, multi-stage builds |
 | Clean up dangling volumes | Direct savings -- Popeye or AWS Trusted Advisor |
 | EBS snapshot retention policy | Avoid unbounded snapshot growth via DLM or Velero TTL |
+
+> **Backup:** beyond Velero, **AWS Backup now supports EKS** (cluster-state and persistent-volume backups) as a managed option -- consider it alongside Velero for a native backup story.
 
 ---
 
@@ -482,7 +487,7 @@ AWS resource tags don't directly correlate with Kubernetes labels. Use Kubernete
 |------|-------|------|----------|
 | **AWS Cost Explorer** | Account-level | Free | High-level trends, SP/RI recommendations |
 | **Kubecost** | Cluster-level | Free (open source) | Per-namespace/pod cost allocation |
-| **CloudWatch Container Insights** | Cluster + pod | ~$0.30/container/month | Resource utilization monitoring |
+| **CloudWatch Container Insights** | Cluster + pod | $0.21 per 1M observations, tiered (e.g. ~$51.75/mo for a 10-node/20-pod cluster, as of 2026-08-04) | Resource utilization monitoring |
 | **AWS Billing + tags** | Account-level | Free | Chargeback by team/project |
 | **Karpenter metrics** | Node-level | Free | Consolidation efficiency |
 
@@ -502,7 +507,7 @@ helm install kubecost kubecost/cost-analyzer \
 | Namespace/label cost allocation | Yes | Yes |
 | Right-sizing recommendations | Yes | Yes |
 | Idle cost detection | Yes | Yes |
-| Multi-cluster | No | Yes |
+| Multi-cluster | Yes -- unlimited clusters up to 250 cores total | Yes (no core limit) |
 | SSO/RBAC | No | Yes |
 | Long-term storage | 15 days | Unlimited |
 

--- a/skills/eks-best-practices/references/eks-auto-mode.md
+++ b/skills/eks-best-practices/references/eks-auto-mode.md
@@ -27,7 +27,7 @@ Auto Mode is geared towards users that want the benefits of Kubernetes and EKS b
 | **Compliance (custom AMI pinning, air-gapped)** | Limited -- no custom AMIs | Full control |
 | **Cost** | Standard EC2 pricing + Auto Mode management fee on managed nodes | Standard EC2 pricing + self-managed operational cost |
 | **Mix with other compute** | Yes -- can run MNG alongside Auto Mode nodes | Yes -- can run MNG alongside Karpenter nodes |
-| **Troubleshooting managed components** | AWS Support ticket (components run off-cluster) | Direct access to pod logs |
+| **Troubleshooting managed components** | Self-service: `NodeDiagnostic`, `kubectl debug node`, `get-console-output`, CloudWatch Insights (managed controllers' own pod logs still not exposed) | Direct access to pod logs |
 
 **Choose Auto Mode when:** Minimal ops is the priority, standard Bottlerocket AMIs are acceptable, and you don't need custom AMI configurations or air-gapped setups.
 
@@ -74,7 +74,7 @@ A new Auto Mode cluster comes pre-configured with two NodePools:
 Provisions nodes with:
 - Capacity Type: On-Demand
 - Instance Types: C, M, or R families
-- Instance Generation: 4+
+- Instance Generation: 5 or newer
 - Architecture: AMD (x86_64)
 - OS: Linux
 - Disruption: max 10% of nodes disrupted at any time, consolidation when empty or underutilized
@@ -111,7 +111,14 @@ Currently the only supported AMIs are Amazon-provided Bottlerocket. No custom AM
 Because AMI customization is not supported, if you need host-level software for things like security scanning, deploy it as a Kubernetes DaemonSet.
 
 ### Troubleshooting Managed Components
-With EKS Auto Mode, components like the AWS Load Balancer Controller and Karpenter are managed outside your cluster. You won't have direct visibility into their logs. If troubleshooting is needed, create an AWS Support Ticket.
+With EKS Auto Mode, components like the AWS Load Balancer Controller and Karpenter are managed outside your cluster, so their own controller pod logs are not exposed. However, node-level troubleshooting is self-service and does not require a support ticket:
+
+- **`NodeDiagnostic`** — collect node log bundles and export them to S3
+- **`kubectl debug node`** — start a debugging container on the node
+- **`get-console-output`** — retrieve EC2 instance console output
+- **CloudWatch Insights** — Karpenter provisioning/scheduling decision events
+
+Open an AWS Support case only for issues that these self-service tools cannot surface (e.g. the internals of the off-cluster managed controllers).
 
 ### Mixed Compute
 You may run managed node groups alongside Auto Mode-managed nodes in the same cluster.

--- a/skills/eks-best-practices/references/karpenter.md
+++ b/skills/eks-best-practices/references/karpenter.md
@@ -24,7 +24,7 @@
 
 ### Run Karpenter on Fargate or a Dedicated MNG
 
-The Karpenter controller and webhook run as a Deployment that must be available before Karpenter can scale your cluster. Run them on infrastructure Karpenter does not manage -- either a small MNG (at least one worker node) or a Fargate profile for the `karpenter` namespace. If Karpenter runs on a node it manages, it could scale down that node and lose the ability to provision replacements.
+The Karpenter controller runs as a Deployment that must be available before Karpenter can scale your cluster. (The separate webhook Deployment was removed in Karpenter v1.0/1.1 -- webhooks are no longer a distinct component, so there is a single controller Deployment to schedule.) Run it on infrastructure Karpenter does not manage -- either a small MNG (at least one worker node) or a Fargate profile for the `karpenter` namespace. If Karpenter runs on a node it manages, it could scale down that node and lose the ability to provision replacements.
 
 ### Lock Down AMIs in Production
 
@@ -32,11 +32,11 @@ Pin well-known AMI versions for production clusters. Using `@latest` or methods 
 
 ```yaml
 amiSelectorTerms:
-- alias: al2023@v20240807  # Pin tested version in production
+- alias: al2023@v20240807  # Illustrative pin -- check the current AMI alias
 # Use al2023@latest only in dev/test
 ```
 
-Test newer AMI versions in non-production clusters before rolling to production.
+The `v20240807` alias above is a 2024-era example, not a recommended value -- look up the current tested AMI alias for your Kubernetes version and pin that. Test newer AMI versions in non-production clusters before rolling to production.
 
 ### No Custom Launch Templates
 
@@ -86,6 +86,8 @@ spec:
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
     consolidateAfter: 1m
+    budgets:
+    - nodes: "10%"   # Cap concurrent voluntary disruption (see Disruption Budgets)
 
   limits:
     cpu: "1000"
@@ -130,7 +132,7 @@ metadata:
 spec:
   role: KarpenterNodeRole-my-cluster
   amiSelectorTerms:
-  - alias: al2023@v20240807  # Pin AMI version in production
+  - alias: al2023@v20240807  # Illustrative pin -- check current AMI alias, not a hard-coded value
   subnetSelectorTerms:
   - tags:
       karpenter.sh/discovery: my-cluster
@@ -192,17 +194,80 @@ Do not use Karpenter interruption handling alongside AWS Node Termination Handle
 | Policy | Behavior | Use When |
 |--------|----------|----------|
 | **WhenEmpty** | Only replaces nodes with zero pods | Conservative -- minimal disruption |
-| **WhenEmptyOrUnderutilized** | Replaces underutilized nodes too | Default -- best cost optimization |
+| **WhenEmptyOrUnderutilized** | Replaces empty nodes and consolidates underutilized ones | Best cost optimization |
+| **Balanced** | Consolidates while weighing disruption cost against savings, favoring fewer, less disruptive actions | GA in Karpenter v1.14.0 (current) -- steadier middle ground between the two above |
 
 **Consolidation respects:**
 - Pod disruption budgets
 - `karpenter.sh/do-not-disrupt: "true"` annotation on pods or nodes
+
+These two protections gate **consolidation and drift** only. They do **not** block node **expiration** -- see [do-not-disrupt Does Not Block Expiration](#do-not-disrupt-does-not-block-expiration).
 
 ### Set requests=limits for Non-CPU Resources
 
 Consolidation packs pods based on resource **requests**, not limits. Pods with memory limits higher than requests can burst above requests. If several pods on the same node burst simultaneously, this can trigger OOM kills. Consolidation makes this more likely because it packs nodes more tightly.
 
 To prevent this, set `requests == limits` for memory and other non-CPU resources. CPU is the exception -- CPU is compressible and throttling (not OOM) is the consequence of exceeding limits.
+
+### Disruption Budgets
+
+`disruption.budgets` caps how much voluntary disruption Karpenter performs at once, across all NodePool-initiated actions. **When you define no budgets, the default is a single budget of `nodes: 10%`** -- Karpenter disrupts at most 10% of the NodePool's nodes concurrently.
+
+A budget's allowed node count is computed as:
+
+```
+allowed = roundup(total_nodes * percentage) - currently_deleting - not_ready
+```
+
+so `notReady` and in-flight deletions already count against the budget. A budget may be expressed as a percentage (`nodes: "10%"`) or an absolute count (`nodes: "5"`); `nodes: "0"` blocks all voluntary disruption for the window.
+
+**Reasons-based budgets** scope a budget to specific disruption reasons via the `reasons` field (`Drifted`, `Underutilized`, `Empty`). A budget with no `reasons` applies to every reason. This lets you, for example, allow empty-node reclamation to run wide open while throttling underutilization-driven consolidation:
+
+```yaml
+spec:
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    budgets:
+    - nodes: "20%"                    # applies to all reasons (fallback)
+    - nodes: "100%"
+      reasons: ["Empty"]              # reclaim empty nodes without throttling
+    - nodes: "5%"
+      reasons: ["Underutilized"]      # go slow on underutilization churn
+```
+
+**Scheduled / business-hours budgets** (e.g. a `nodes: "0"` block on a cron `schedule` + `duration` to freeze disruption during business hours) are documented once, alongside the drift-during-upgrade flow, rather than duplicated here. See:
+- [cluster-upgrades.md -- Karpenter Node Upgrades](cluster-upgrades.md#karpenter-node-upgrades) for the scheduled `nodes: "0"` business-hours block (plus always-allow-`Empty` at 100% and a 10% fallback)
+- [SKILL.md -- Data Plane with Karpenter](../SKILL.md#data-plane-with-karpenter) for the same budget in the upgrade-speed context
+- [reliability-core.md -- PDB Interaction with Karpenter](reliability-core.md#pdb-interaction-with-karpenter) for how budgets compose with Pod Disruption Budgets
+
+### do-not-disrupt Does Not Block Expiration
+
+`karpenter.sh/do-not-disrupt: "true"` and blocking PDBs gate the **graceful/voluntary** disruption methods -- consolidation and drift. **Expiration (`expireAfter`) is a forceful disruption method and is NOT blocked by these protections.** When a node reaches `expireAfter`, Karpenter proceeds with replacement regardless of the annotation; pod eviction is deferred at most until the node's configured `terminationGracePeriod` (see below), after which pods are force-drained. Do not rely on `do-not-disrupt` to keep an expired node alive indefinitely -- use it to protect against consolidation/drift churn, and tune `expireAfter` for node lifetime.
+
+### NodePool terminationGracePeriod (v1)
+
+The NodePool-level `terminationGracePeriod` (a v1 field, distinct from a pod's `terminationGracePeriodSeconds`) is the safety escape hatch against PDB deadlock. Once a node begins terminating, Karpenter waits at most this long for a graceful drain; when the deadline passes it **forces the drain, overriding blocking PDBs and `do-not-disrupt`**. This is what prevents a single stuck PDB from pinning a node forever.
+
+- It has **no default** -- when unset (nil), Karpenter waits **indefinitely** for pods to drain, so a blocking PDB or `do-not-disrupt` pod can stall the node.
+- Setting it bounds the maximum node lifetime: **max node lifetime = `terminationGracePeriod` + `expireAfter`** (the node can live up to `expireAfter`, then take up to `terminationGracePeriod` to finish draining).
+- Do not confuse it with the pod-level `terminationGracePeriodSeconds` (default 30s), which governs a single pod's shutdown, not the node's drain deadline.
+
+```yaml
+spec:
+  template:
+    spec:
+      expireAfter: 720h
+      terminationGracePeriod: 24h  # force drain 24h after termination begins, even past a blocking PDB
+```
+
+### Reducing Sudden Node Changes / Stabilizing Consolidation
+
+**Symptom:** nodes churn or the cluster sees sudden node changes as consolidation repeatedly repacks workloads. These levers, applied together, stabilize consolidation without turning it off:
+
+- **Raise `consolidateAfter`.** The examples in this doc use short values like `1m` to illustrate the field; short windows make Karpenter act on brief lulls. Values in the **15--60m** range let load settle before consolidation triggers, cutting churn.
+- **Add `disruption.budgets`** to cap how many nodes move at once (start from the default 10%, and consider reasons-based budgets to throttle only `Underutilized`).
+- **Use `WhenEmpty` on the single most interruption-sensitive NodePool** -- not generically across every NodePool. Reserve conservative consolidation for the workloads that most dislike being moved, and keep `WhenEmptyOrUnderutilized` (or `Balanced`) elsewhere so you still capture savings.
+- **Apply `do-not-disrupt` to the critical pods themselves** so consolidation and drift leave them in place (remember this does not stop expiration).
 
 ---
 
@@ -321,7 +386,9 @@ If routing Karpenter container logs to CloudWatch Logs, create a metrics filter 
 
 ### Use do-not-disrupt for Long-Running Workloads
 
-For batch jobs, ML training, or stateful workloads that are expensive to restart, annotate pods with `karpenter.sh/do-not-disrupt: "true"`. This prevents Karpenter from terminating the node even if `expireAfter` has been reached or consolidation would normally trigger. The annotation is respected until the pod terminates or the annotation is removed.
+For batch jobs, ML training, or stateful workloads that are expensive to restart, annotate pods with `karpenter.sh/do-not-disrupt: "true"`. This prevents Karpenter from disrupting the node via **consolidation or drift** while the pod runs; the annotation is respected until the pod terminates or the annotation is removed.
+
+**It does not, however, block expiration.** `expireAfter` is a forceful disruption method: when a node hits its expiry, Karpenter replaces it regardless of `do-not-disrupt` (pod eviction is deferred at most until the node's `terminationGracePeriod`). See [do-not-disrupt Does Not Block Expiration](#do-not-disrupt-does-not-block-expiration). For workloads that must not be interrupted mid-run, size `expireAfter` (and, if set, `terminationGracePeriod`) to outlast the work rather than relying on the annotation alone.
 
 Note: if the only non-daemonset pods left on a node are from completed Jobs (status succeeded or failed), Karpenter can still terminate that node.
 
@@ -370,6 +437,9 @@ When running EKS in a VPC with no internet access, Karpenter requires these VPC 
 | **SSM** | Karpenter queries SSM parameters for AMI IDs during node provisioning |
 | **EC2** | Standard EC2 API calls for instance provisioning |
 | **EKS** | EKS API calls |
+| **SQS** | Interruption handling polls the SQS interruption queue (required if you enable `--interruption-queue`, above) |
+| **ECR** (`ecr.api` + `ecr.dkr`) | Nodes pull container images from Amazon ECR |
+| **S3** (gateway endpoint) | ECR image layers and other artifacts are served from S3 |
 
 **No VPC endpoint exists for the Price List Query API.** Karpenter bundles on-demand pricing data in its binary, but this data only updates when Karpenter is upgraded. You'll see non-fatal errors about pricing data retrieval -- these are expected in private clusters.
 

--- a/skills/eks-best-practices/references/karpenter.md
+++ b/skills/eks-best-practices/references/karpenter.md
@@ -275,7 +275,7 @@ spec:
 
 ### Create Mutually Exclusive or Weighted NodePools
 
-If multiple NodePools match a pod's scheduling requirements and they are neither mutually exclusive (via taints/selectors) nor weighted, Karpenter **randomly chooses** which NodePool to use. This causes unpredictable scheduling. Design NodePools so they either:
+If multiple NodePools match a pod's scheduling requirements and they are neither mutually exclusive (via taints/selectors) nor weighted, Karpenter breaks the tie **deterministically**: NodePools are ordered by `weight` (descending), and on equal weight the NodePool whose name sorts **later in the alphabet** is tried first (Karpenter scheduler source, `OrderByWeight`, as of 2026-08-05). This ordering is easy to get wrong by accident, so scheduling is still hard to reason about. Design NodePools so they either:
 - **Don't overlap** -- use taints on specialized NodePools (GPU, high-memory) so only pods with matching tolerations schedule there
 - **Use weights** -- set `weight` to establish preference ordering among overlapping NodePools
 

--- a/skills/eks-best-practices/references/karpenter.md
+++ b/skills/eks-best-practices/references/karpenter.md
@@ -24,7 +24,7 @@
 
 ### Run Karpenter on Fargate or a Dedicated MNG
 
-The Karpenter controller runs as a Deployment that must be available before Karpenter can scale your cluster. (The separate webhook Deployment was removed in Karpenter v1.0/1.1 -- webhooks are no longer a distinct component, so there is a single controller Deployment to schedule.) Run it on infrastructure Karpenter does not manage -- either a small MNG (at least one worker node) or a Fargate profile for the `karpenter` namespace. If Karpenter runs on a node it manages, it could scale down that node and lose the ability to provision replacements.
+The Karpenter controller runs as a Deployment that must be available before Karpenter can scale your cluster. (Webhook containers were consolidated into the controller binary (v0.19.0), disabled by default (v0.33.0) -- a single controller Deployment today.) Run it on infrastructure Karpenter does not manage -- either a small MNG (at least one worker node) or a Fargate profile for the `karpenter` namespace. If Karpenter runs on a node it manages, it could scale down that node and lose the ability to provision replacements.
 
 ### Lock Down AMIs in Production
 
@@ -211,7 +211,7 @@ To prevent this, set `requests == limits` for memory and other non-CPU resources
 
 ### Disruption Budgets
 
-`disruption.budgets` caps how much voluntary disruption Karpenter performs at once, across all NodePool-initiated actions. **When you define no budgets, the default is a single budget of `nodes: 10%`** -- Karpenter disrupts at most 10% of the NodePool's nodes concurrently.
+`disruption.budgets` caps how much voluntary disruption Karpenter performs at once, across drift, emptiness, and consolidation (expiration exempt). **When you define no budgets, the default is a single budget of `nodes: 10%`** -- Karpenter disrupts at most 10% of the NodePool's nodes concurrently.
 
 A budget's allowed node count is computed as:
 
@@ -221,22 +221,23 @@ allowed = roundup(total_nodes * percentage) - currently_deleting - not_ready
 
 so `notReady` and in-flight deletions already count against the budget. A budget may be expressed as a percentage (`nodes: "10%"`) or an absolute count (`nodes: "5"`); `nodes: "0"` blocks all voluntary disruption for the window.
 
-**Reasons-based budgets** scope a budget to specific disruption reasons via the `reasons` field (`Drifted`, `Underutilized`, `Empty`). A budget with no `reasons` applies to every reason. This lets you, for example, allow empty-node reclamation to run wide open while throttling underutilization-driven consolidation:
+**Reasons-based budgets** scope a budget to specific disruption reasons via the `reasons` field (`Drifted`, `Underutilized`, `Empty`). A budget with no `reasons` applies to every reason. This lets you, for example, allow empty-node reclamation to proceed at full speed while throttling underutilization-driven consolidation:
 
 ```yaml
 spec:
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
     budgets:
-    - nodes: "20%"                    # applies to all reasons (fallback)
+    - nodes: "20%"                    # fallback for drift/underutilization churn
+      reasons: ["Drifted","Underutilized"]
     - nodes: "100%"
-      reasons: ["Empty"]              # reclaim empty nodes without throttling
+      reasons: ["Empty"]              # reclaim empty nodes at full speed (not capped by the fallback)
     - nodes: "5%"
-      reasons: ["Underutilized"]      # go slow on underutilization churn
+      reasons: ["Underutilized"]      # extra throttle on underutilization churn
 ```
 
 **Scheduled / business-hours budgets** (e.g. a `nodes: "0"` block on a cron `schedule` + `duration` to freeze disruption during business hours) are documented once, alongside the drift-during-upgrade flow, rather than duplicated here. See:
-- [cluster-upgrades.md -- Karpenter Node Upgrades](cluster-upgrades.md#karpenter-node-upgrades) for the canonical 3-budget pattern in one NodePool spec: a 10% all-reasons fallback, always-allow-`Empty` at 100%, and a scheduled `nodes: "0"` freeze window (UTC cron)
+- [cluster-upgrades.md -- Karpenter Node Upgrades](cluster-upgrades.md#karpenter-node-upgrades) for the canonical 3-budget pattern in one NodePool spec: a 10% fallback scoped to churn (drift/underutilization), an unthrottled `Empty` budget at 100%, and a scheduled `nodes: "0"` freeze window (UTC cron)
 - [SKILL.md -- Data Plane with Karpenter](../SKILL.md#data-plane-with-karpenter) for the same budget in the upgrade-speed context
 - [reliability-core.md -- PDB Interaction with Karpenter](reliability-core.md#pdb-interaction-with-karpenter) for how budgets compose with Pod Disruption Budgets
 
@@ -251,6 +252,7 @@ The NodePool-level `terminationGracePeriod` (a v1 field, distinct from a pod's `
 - It has **no default** -- when unset (nil), Karpenter waits **indefinitely** for pods to drain, so a blocking PDB or `do-not-disrupt` pod can stall the node.
 - Setting it bounds the maximum node lifetime: **max node lifetime = `terminationGracePeriod` + `expireAfter`** (the node can live up to `expireAfter`, then take up to `terminationGracePeriod` to finish draining).
 - Do not confuse it with the pod-level `terminationGracePeriodSeconds` (default 30s), which governs a single pod's shutdown, not the node's drain deadline.
+- With `terminationGracePeriod` set, a node can be disrupted via **Drift even when blocking PDBs or `do-not-disrupt` are present** -- the drain then proceeds up to the grace-period deadline, after which pods are force-evicted (see the [Karpenter disruption docs](https://karpenter.sh/docs/concepts/disruption/)).
 
 ```yaml
 spec:

--- a/skills/eks-best-practices/references/karpenter.md
+++ b/skills/eks-best-practices/references/karpenter.md
@@ -236,7 +236,7 @@ spec:
 ```
 
 **Scheduled / business-hours budgets** (e.g. a `nodes: "0"` block on a cron `schedule` + `duration` to freeze disruption during business hours) are documented once, alongside the drift-during-upgrade flow, rather than duplicated here. See:
-- [cluster-upgrades.md -- Karpenter Node Upgrades](cluster-upgrades.md#karpenter-node-upgrades) for the scheduled `nodes: "0"` business-hours block (plus always-allow-`Empty` at 100% and a 10% fallback)
+- [cluster-upgrades.md -- Karpenter Node Upgrades](cluster-upgrades.md#karpenter-node-upgrades) for the canonical 3-budget pattern in one NodePool spec: a 10% all-reasons fallback, always-allow-`Empty` at 100%, and a scheduled `nodes: "0"` freeze window (UTC cron)
 - [SKILL.md -- Data Plane with Karpenter](../SKILL.md#data-plane-with-karpenter) for the same budget in the upgrade-speed context
 - [reliability-core.md -- PDB Interaction with Karpenter](reliability-core.md#pdb-interaction-with-karpenter) for how budgets compose with Pod Disruption Budgets
 

--- a/skills/eks-best-practices/references/networking-ingress-dns.md
+++ b/skills/eks-best-practices/references/networking-ingress-dns.md
@@ -30,7 +30,7 @@
 | **AWS ALB (via LBC)** | HTTP/HTTPS, gRPC | Web apps, REST APIs | Native WAF, Cognito auth |
 | **AWS NLB (via LBC)** | TCP/UDP, TLS | Non-HTTP, ultra-low latency | Static IPs, preserve source IP |
 | **Gateway API + LBC** | HTTP/HTTPS | New standard, future-proof | Multi-team route management |
-| **VPC Lattice** | HTTP/HTTPS | Cross-VPC, service-to-service | No ingress controller needed |
+| **VPC Lattice** | HTTP/HTTPS | Cross-VPC, service-to-service | No ALB/NLB ingress controller (still runs the in-cluster Gateway API controller) |
 | **NGINX Ingress** | HTTP/HTTPS | Complex routing, rate limiting | Most configurable |
 | **Istio Gateway** | HTTP/HTTPS, TCP | Service mesh users | Integrated with Istio |
 
@@ -170,14 +170,25 @@ spec:
 
 Gateway API is the successor to the Ingress resource, offering role-oriented resource model and multi-team route management. **Recommended for new deployments.**
 
+**Two different AWS implementations back Gateway API — do not blend them.** The `controllerName` on the GatewayClass decides which one you get:
+
+| Implementation | GatewayClass `controllerName` | Provisions | Use for |
+|---|---|---|---|
+| **AWS Load Balancer Controller (LBC) Gateway API** | `gateway.k8s.aws/alb` (L7) or `gateway.k8s.aws/nlb` (L4) | An ALB (L7) or NLB (L4) | In-cluster ingress that would otherwise use an ALB/NLB Ingress or Service |
+| **VPC Lattice (Gateway API controller)** | `application-networking.k8s.aws/gateway-api-controller` | A VPC Lattice service network | Cross-VPC / cross-account service-to-service networking |
+
+Copy-pasting the Lattice `controllerName` when you actually want an ALB yields a Lattice service network, not a load balancer — a common mistake. The LBC Gateway API support is GA (v3.0.0, released 2025-01-23; current v3.5.0 as of 2026-08-04) and installs its own CRDs (`TargetGroupBinding` plus the LBC Gateway CRDs); both L7 (ALB) and L4 (NLB) Gateways are supported.
+
+**Example A — ALB via the LBC Gateway API** (in-cluster HTTP ingress):
+
 ```yaml
 # GatewayClass (one per cluster — defines which controller)
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
-  name: amazon-alb
+  name: alb
 spec:
-  controllerName: application-networking.k8s.aws/gateway-api-controller
+  controllerName: gateway.k8s.aws/alb   # LBC ALB Gateway (use gateway.k8s.aws/nlb for an L4/NLB Gateway)
 
 ---
 # Gateway (per team/environment — defines listeners)
@@ -186,7 +197,7 @@ kind: Gateway
 metadata:
   name: app-gateway
 spec:
-  gatewayClassName: amazon-alb
+  gatewayClassName: alb
   listeners:
   - name: https
     port: 443
@@ -216,6 +227,17 @@ spec:
       port: 80
 ```
 
+**Example B — VPC Lattice via the Gateway API controller** (cross-VPC service networking, *not* an ALB):
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: amazon-vpc-lattice
+spec:
+  controllerName: application-networking.k8s.aws/gateway-api-controller
+```
+
 **Why Gateway API over Ingress:**
 - **Role separation** — infrastructure teams manage GatewayClass/Gateway, application teams manage HTTPRoutes
 - **Multi-team** — multiple HTTPRoutes can attach to one Gateway without annotation conflicts
@@ -238,7 +260,7 @@ spec:
 |--------|---------|-----------|----------|
 | **VPC Lattice** | Fully managed | Low | Cross-VPC, AWS-native |
 | **Istio (on EKS)** | Self-managed | High | Full service mesh features |
-| **App Mesh** | AWS managed | Medium | **Maintenance mode — avoid for new projects** |
+| **App Mesh** | AWS managed | Medium | **End of support 2026-09-30 — do not adopt; console/resources become inaccessible after that date. Use Istio or Cilium mTLS instead.** |
 
 **VPC Lattice** is recommended for new AWS-native service-to-service networking:
 - No sidecar proxies needed
@@ -339,9 +361,11 @@ resource "aws_eks_cluster" "private" {
 | Access Method | Complexity | Use When |
 |--------------|-----------|----------|
 | **VPN/Direct Connect** | Medium | Existing corporate network |
-| **SSM Session Manager** | Low | Ad-hoc access via bastion |
+| **SSM Session Manager** | Low | Ad-hoc access via a bastion in the VPC (no inbound SSH, no public IP) |
 | **PrivateLink** | Medium | Cross-VPC or cross-account |
-| **Cloud9 in VPC** | Low | Development/testing |
+| **VS Code Remote / IDE over SSM** | Low | Development/testing from a workstation into a VPC bastion |
+
+> AWS Cloud9 is **closed to new customers** and is no longer a recommended in-VPC access path. Reach a private cluster through **SSM Session Manager** to a bastion (or VS Code Remote tunneling over that SSM session) instead.
 
 ---
 
@@ -358,6 +382,8 @@ For detailed network policy guidance including default-deny patterns, DNS allow 
 | **Cilium** | K8s + Cilium extended | Self-managed | L3/L4/L7 + DNS + identity |
 
 **Recommendation:** Use VPC CNI native network policies for most workloads. Use Cilium or Calico only if you need L7 policies or advanced features like DNS hostname rules.
+
+> Beyond the namespaced `NetworkPolicy` above, VPC CNI added cluster-scoped **`ClusterNetworkPolicy`** and an **admin-tier** enforcement model (in a later release, v1.21) for cluster-wide, higher-priority rules that a namespace owner can't override. Verify your installed VPC CNI version supports it before relying on the admin tier.
 
 ---
 

--- a/skills/eks-best-practices/references/networking-ingress-dns.md
+++ b/skills/eks-best-practices/references/networking-ingress-dns.md
@@ -177,7 +177,7 @@ Gateway API is the successor to the Ingress resource, offering role-oriented res
 | **AWS Load Balancer Controller (LBC) Gateway API** | `gateway.k8s.aws/alb` (L7) or `gateway.k8s.aws/nlb` (L4) | An ALB (L7) or NLB (L4) | In-cluster ingress that would otherwise use an ALB/NLB Ingress or Service |
 | **VPC Lattice (Gateway API controller)** | `application-networking.k8s.aws/gateway-api-controller` | A VPC Lattice service network | Cross-VPC / cross-account service-to-service networking |
 
-Copy-pasting the Lattice `controllerName` when you actually want an ALB yields a Lattice service network, not a load balancer — a common mistake. The LBC Gateway API support is GA (v3.0.0, released 2025-01-23; current v3.5.0 as of 2026-08-04) and installs its own CRDs (`TargetGroupBinding` plus the LBC Gateway CRDs); both L7 (ALB) and L4 (NLB) Gateways are supported.
+Copy-pasting the Lattice `controllerName` when you actually want an ALB yields a Lattice service network, not a load balancer — a common mistake. The LBC Gateway API support is GA (v3.0.0, released 2026-01-23; current v3.5.0 as of 2026-08-04) and installs its own CRDs (`TargetGroupBinding` plus the LBC Gateway CRDs); both L7 (ALB) and L4 (NLB) Gateways are supported.
 
 **Example A — ALB via the LBC Gateway API** (in-cluster HTTP ingress):
 
@@ -365,7 +365,7 @@ resource "aws_eks_cluster" "private" {
 | **PrivateLink** | Medium | Cross-VPC or cross-account |
 | **VS Code Remote / IDE over SSM** | Low | Development/testing from a workstation into a VPC bastion |
 
-> AWS Cloud9 is **closed to new customers** and is no longer a recommended in-VPC access path. Reach a private cluster through **SSM Session Manager** to a bastion (or VS Code Remote tunneling over that SSM session) instead.
+> AWS Cloud9 is **closed to new customers** (as of 2026-08-04) and is no longer a recommended in-VPC access path. Reach a private cluster through **SSM Session Manager** to a bastion (or VS Code Remote tunneling over that SSM session) instead.
 
 ---
 

--- a/skills/eks-best-practices/references/networking-ingress-dns.md
+++ b/skills/eks-best-practices/references/networking-ingress-dns.md
@@ -177,7 +177,7 @@ Gateway API is the successor to the Ingress resource, offering role-oriented res
 | **AWS Load Balancer Controller (LBC) Gateway API** | `gateway.k8s.aws/alb` (L7) or `gateway.k8s.aws/nlb` (L4) | An ALB (L7) or NLB (L4) | In-cluster ingress that would otherwise use an ALB/NLB Ingress or Service |
 | **VPC Lattice (Gateway API controller)** | `application-networking.k8s.aws/gateway-api-controller` | A VPC Lattice service network | Cross-VPC / cross-account service-to-service networking |
 
-Copy-pasting the Lattice `controllerName` when you actually want an ALB yields a Lattice service network, not a load balancer — a common mistake. The LBC Gateway API support is GA (v3.0.0, released 2026-01-23; current v3.5.0 as of 2026-08-04) and installs its own CRDs (`TargetGroupBinding` plus the LBC Gateway CRDs); both L7 (ALB) and L4 (NLB) Gateways are supported.
+Copy-pasting the Lattice `controllerName` when you actually want an ALB yields a Lattice service network, not a load balancer — a common mistake. The LBC Gateway API support is GA (v3.0.0, released 2026-01-23; current v3.5.0 as of 2026-08-04) and requires installing its CRDs (`TargetGroupBinding`, the LBC Gateway CRDs, and the upstream Gateway API CRDs) via a manual `kubectl apply` step, per the [v3.0.0 release notes'](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v3.0.0) Action-Required block; both L7 (ALB) and L4 (NLB) Gateways are supported.
 
 **Example A — ALB via the LBC Gateway API** (in-cluster HTTP ingress):
 

--- a/skills/eks-best-practices/references/networking.md
+++ b/skills/eks-best-practices/references/networking.md
@@ -162,10 +162,10 @@ Kubernetes labels nodes with `topology.kubernetes.io/zone` automatically, so the
 
 Deploy VPC CNI as an [EKS managed add-on](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html) rather than self-managed. Managed add-ons provide:
 - Validated compatibility with your EKS version
-- Drift handling — EKS-managed fields are enforced during add-on create/update/delete operations, not on a steady-state timer ([field management](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-field-management.html), as of 2026-08-05)
+- Drift handling — changes to EKS-managed fields conflict under server-side apply and may be overwritten: the AWS best-practices guide documents automatic overwrite of managed configuration roughly every 15 minutes ([VPC CNI BPG](https://docs.aws.amazon.com/eks/latest/best-practices/vpc-cni.html)), and add-on create/update applies conflict resolution (`OVERWRITE`/`PRESERVE`/`NONE`) ([field management](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-field-management.html)), as of 2026-08-05
 - Simpler upgrades via EKS API/Console/CLI
 
-Frequently-used fields like `WARM_ENI_TARGET`, `WARM_IP_TARGET`, and `MINIMUM_IP_TARGET` are **not** managed and won't be overwritten by drift prevention.
+Frequently-used fields like `WARM_ENI_TARGET`, `WARM_IP_TARGET`, and `MINIMUM_IP_TARGET` are **not** managed by EKS field management and won't be overwritten.
 
 ### EKS Auto Mode
 

--- a/skills/eks-best-practices/references/networking.md
+++ b/skills/eks-best-practices/references/networking.md
@@ -162,7 +162,7 @@ Kubernetes labels nodes with `topology.kubernetes.io/zone` automatically, so the
 
 Deploy VPC CNI as an [EKS managed add-on](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html) rather than self-managed. Managed add-ons provide:
 - Validated compatibility with your EKS version
-- Automatic drift prevention — EKS reconciles managed fields every 15 minutes
+- Drift handling — EKS-managed fields are enforced during add-on create/update/delete operations, not on a steady-state timer ([field management](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-field-management.html), as of 2026-08-05)
 - Simpler upgrades via EKS API/Console/CLI
 
 Frequently-used fields like `WARM_ENI_TARGET`, `WARM_IP_TARGET`, and `MINIMUM_IP_TARGET` are **not** managed and won't be overwritten by drift prevention.

--- a/skills/eks-best-practices/references/networking.md
+++ b/skills/eks-best-practices/references/networking.md
@@ -289,7 +289,8 @@ The strategies above — especially adding a secondary CIDR via `associate-vpc-c
 - **You own the VPC** — use the strategies above directly (secondary CIDR, custom networking, prefix delegation, IPv6).
 - **Subnets are shared and you don't own them** — you have three options:
   - Request the VPC owner add a **secondary CIDR** (or provision additional/larger subnets) for your cluster.
-  - Stretch the **existing** shared space you already have with **prefix delegation** or **IPv6**, which raise pod density without needing new CIDR space.
+  - Stretch the **existing** shared IPv4 space with **prefix delegation** — a VPC CNI / ENI-level setting that carves /28 prefixes from the subnet's current CIDR, so a participant can enable it on ENIs they own with no VPC change. (Subnet CIDR *reservations*, used to keep prefixes contiguous, are an owner-only operation.)
+  - **IPv6 is not a participant-only lever**: it requires the owner to assign an IPv6 CIDR to the VPC and dual-stack the subnets (a VPC/subnet modification, owner-only). Pursue IPv6 only if the owner has already made the shared subnets dual-stack — otherwise fold it into the owner request above.
   - Raise a **cross-team request** to the networking owner to re-plan address space if neither of the above closes the gap.
 
 ---
@@ -330,7 +331,7 @@ Because the switch is irreversible, enumerate reachability before enabling:
 2. **Confirm OIDC provider reachability** from the VPC.
 3. **Enumerate aggregated API services.**
 4. **Ensure route/NAT/NACL/SG allow the required flows** — outbound 443 plus inbound ephemeral (1024–65535).
-5. **Verify after switching** — trigger a webhook with a test pod, and watch the cluster log group `/aws/eks/<cluster-name>/cluster`.
+5. **Verify after switching** — trigger a webhook with a test pod, watch the cluster log group `/aws/eks/<cluster-name>/cluster`, and enable **VPC Flow Logs** on the egress subnets to confirm control-plane traffic is actually taking the customer-routed path.
 
 ---
 
@@ -351,7 +352,7 @@ Because the switch is irreversible, enumerate reachability before enabling:
 | **Load balancers** | ALB/NLB full support | ALB/NLB dual-stack (requires LBC, in-tree controller doesn't support IPv6) |
 | **Recommendation** | Default choice | Use when IPv4 exhaustion is a real concern |
 
-> **Network policy caveat:** VPC CNI network policy support is per-address-family — a cluster is either IPv4 or IPv6, so policies apply to whichever family the cluster runs (there is no dual-family enforcement in a single cluster). The newer `ClusterNetworkPolicy`/admin-tier enforcement (an addition in a later VPC CNI release, v1.21) is separate from the baseline `NetworkPolicy` support noted above; verify your installed VPC CNI version supports the tier you need.
+> **Network policy caveat:** VPC CNI network policy support is per-address-family — a cluster is either IPv4 or IPv6, so policies apply to whichever family the cluster runs (there is no dual-family enforcement in a single cluster, as of 2026-08-04). The newer `ClusterNetworkPolicy`/admin-tier enforcement (an addition in a later VPC CNI release, v1.21) is separate from the baseline `NetworkPolicy` support noted above; verify your installed VPC CNI version supports the tier you need.
 
 ### IPv6 Technical Details
 
@@ -449,7 +450,7 @@ aws eks describe-cluster --name CLUSTER_NAME \
 
 **Requirements not supported:**
 - Windows nodes and non-Nitro instances
-- **EKS Auto Mode** — the branch-ENI `SecurityGroupPolicy` path is not supported. On Auto Mode, attach security groups to pods by setting `podSecurityGroupSelectorTerms` on the NodeClass instead.
+- **EKS Auto Mode** — the branch-ENI `SecurityGroupPolicy` path is not supported (as of 2026-08-04). On Auto Mode, attach security groups to pods by setting `podSecurityGroupSelectorTerms` on the NodeClass instead.
 - NodeLocal DNSCache in strict mode
 - SG for Pods with custom networking uses the SG from SecurityGroupPolicy, **not** from ENIConfig
 

--- a/skills/eks-best-practices/references/networking.md
+++ b/skills/eks-best-practices/references/networking.md
@@ -13,8 +13,9 @@
 1. [VPC CNI Deep Dive](#vpc-cni-deep-dive)
 2. [VPC CNI Operations](#vpc-cni-operations)
 3. [Subnet Planning](#subnet-planning)
-4. [IPv4 vs IPv6](#ipv4-vs-ipv6)
-5. [Security Groups for Pods](#security-groups-for-pods)
+4. [Control Plane Egress (CUSTOMER_ROUTED)](#control-plane-egress-customer_routed)
+5. [IPv4 vs IPv6](#ipv4-vs-ipv6)
+6. [Security Groups for Pods](#security-groups-for-pods)
 
 ---
 
@@ -38,7 +39,7 @@ Each pod receives one secondary private IP from an ENI attached to the node. The
 
 **Max pods per node** = (Number of ENIs × IPs per ENI) - 1
 
-ENI counts and IPs-per-ENI vary by instance type and change over time — use the live [max-pods-calculator.sh](https://github.com/awslabs/amazon-eks-ami/blob/main/templates/al2/runtime/max-pods-calculator.sh) script as the source of truth rather than relying on a static table:
+ENI counts and IPs-per-ENI vary by instance type and change over time — use the live [max-pods-calculator.sh](https://github.com/awslabs/amazon-eks-ami/blob/v20241213/templates/al2/runtime/max-pods-calculator.sh) script as the source of truth rather than relying on a static table (the script moved out of the `main` branch when the AL2 tree was removed, so pin a tag such as `v20241213`; the `--cni-version` value in the examples below is illustrative — check your installed version with `kubectl describe daemonset aws-node -n kube-system`):
 
 ```bash
 ./max-pods-calculator.sh --instance-type m5.large --cni-version 1.9.0
@@ -281,6 +282,56 @@ kubernetes.io/cluster/<cluster-name> = shared  # or "owned"
 | **IPv6** | High | Unlimited | Irreversible; dual-stack complexity |
 | **Private NAT gateway** | Medium | N/A | Solves overlapping CIDRs; adds NAT GW cost |
 
+#### Who owns the VPC? (shared / RAM-shared subnets)
+
+The strategies above — especially adding a secondary CIDR via `associate-vpc-cidr-block` — assume you own the VPC and its subnets. When the cluster runs in **shared subnets you don't own** (for example, subnets shared into your account via AWS Resource Access Manager from a central networking account), you cannot self-service a secondary CIDR or new subnets: those API calls act on the owner account. Route by ownership:
+
+- **You own the VPC** — use the strategies above directly (secondary CIDR, custom networking, prefix delegation, IPv6).
+- **Subnets are shared and you don't own them** — you have three options:
+  - Request the VPC owner add a **secondary CIDR** (or provision additional/larger subnets) for your cluster.
+  - Stretch the **existing** shared space you already have with **prefix delegation** or **IPv6**, which raise pod density without needing new CIDR space.
+  - Raise a **cross-team request** to the networking owner to re-plan address space if neither of the above closes the gap.
+
+---
+
+## Control Plane Egress (CUSTOMER_ROUTED)
+
+By default, EKS sends control-plane-initiated traffic through an AWS-managed egress path. The `cluster.resourcesVpcConfig.controlPlaneEgressMode` field (GA as of 2026-08-04) lets you change this:
+
+| Value | Behavior |
+|-------|----------|
+| **`AWS_MANAGED`** (default) | Control-plane-initiated egress uses the AWS-managed path |
+| **`CUSTOMER_ROUTED`** | Control-plane-initiated traffic (to webhooks, OIDC providers, aggregated API servers, kubelet) routes through your VPC networking — subnets, route tables, and NAT — rather than AWS-managed egress |
+
+`CUSTOMER_ROUTED` is supported on **EKS Auto Mode** as well.
+
+> **One-way switch:** Once you enable `CUSTOMER_ROUTED`, you **cannot revert to `AWS_MANAGED`**. Plan the reachability and security requirements below *before* switching.
+
+### Egress Categories to Plan For
+
+| Target | Port | Path |
+|--------|------|------|
+| Admission webhooks | 443 | Through the customer VPC egress device |
+| OIDC provider | 443 | Through the customer VPC egress device |
+| Aggregated API servers | 443 | Through the customer VPC egress device |
+| Kubelet API | 10250 | Reaches nodes via the **cluster ENI** — does **not** traverse the egress device |
+
+etcd, CloudWatch, and internal EKS traffic stay on the AWS-managed path.
+
+### NACL / Security Group Requirement
+
+The egress path must allow **outbound 443** *and* **inbound ephemeral ports 1024–65535** (return traffic). A "just allow 443" summary is wrong — omitting the inbound ephemeral range breaks the return path.
+
+### Pre-Switch Checklist
+
+Because the switch is irreversible, enumerate reachability before enabling:
+
+1. **Enumerate all admission webhooks** and their endpoints — distinguish external endpoints from in-cluster ones.
+2. **Confirm OIDC provider reachability** from the VPC.
+3. **Enumerate aggregated API services.**
+4. **Ensure route/NAT/NACL/SG allow the required flows** — outbound 443 plus inbound ephemeral (1024–65535).
+5. **Verify after switching** — trigger a webhook with a test pod, and watch the cluster log group `/aws/eks/<cluster-name>/cluster`.
+
 ---
 
 ## IPv4 vs IPv6
@@ -299,6 +350,8 @@ kubernetes.io/cluster/<cluster-name> = shared  # or "owned"
 | **Network policy** | Full support | Full support (VPC CNI 1.14+) |
 | **Load balancers** | ALB/NLB full support | ALB/NLB dual-stack (requires LBC, in-tree controller doesn't support IPv6) |
 | **Recommendation** | Default choice | Use when IPv4 exhaustion is a real concern |
+
+> **Network policy caveat:** VPC CNI network policy support is per-address-family — a cluster is either IPv4 or IPv6, so policies apply to whichever family the cluster runs (there is no dual-family enforcement in a single cluster). The newer `ClusterNetworkPolicy`/admin-tier enforcement (an addition in a later VPC CNI release, v1.21) is separate from the baseline `NetworkPolicy` support noted above; verify your installed VPC CNI version supports the tier you need.
 
 ### IPv6 Technical Details
 
@@ -396,6 +449,7 @@ aws eks describe-cluster --name CLUSTER_NAME \
 
 **Requirements not supported:**
 - Windows nodes and non-Nitro instances
+- **EKS Auto Mode** — the branch-ENI `SecurityGroupPolicy` path is not supported. On Auto Mode, attach security groups to pods by setting `podSecurityGroupSelectorTerms` on the NodeClass instead.
 - NodeLocal DNSCache in strict mode
 - SG for Pods with custom networking uses the SG from SecurityGroupPolicy, **not** from ENIConfig
 
@@ -425,6 +479,8 @@ multus:
 ```
 
 Multus is deployed via `kubectl_manifest` resources that apply the upstream thick-plugin DaemonSet manifests directly into `kube-system` (not via Helm). The only config keys that matter are `enabled` and `image`.
+
+> The `v4.1.x` image tags above are illustrative — the upstream project has moved on (current is v4.3.0). Check the [Multus releases](https://github.com/k8snetworkplumbingwg/multus-cni/releases) and pin a current tag that includes the pod-lookup race fix rather than copying these values verbatim.
 
 **When it is safe to enable:**
 - You are using thin-plugin mode (`multus-cni:v4.1.0-thin` or later) which avoids the race entirely
@@ -485,5 +541,6 @@ node_sg_additional_rules:
 - [AWS EKS Best Practices Guide — Prefix Mode](https://docs.aws.amazon.com/eks/latest/best-practices/prefix-mode-linux.html)
 - [AWS EKS Best Practices Guide — Custom Networking](https://docs.aws.amazon.com/eks/latest/best-practices/custom-networking.html)
 - [AWS EKS Best Practices Guide — Subnets](https://docs.aws.amazon.com/eks/latest/best-practices/subnets.html)
+- [Amazon EKS User Guide — Control plane egress](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-egress.html)
 - [AWS EKS Best Practices Guide — IPv6](https://docs.aws.amazon.com/eks/latest/best-practices/ipv6.html)
 - [AWS EKS Best Practices Guide — Security Groups Per Pod](https://docs.aws.amazon.com/eks/latest/best-practices/sgpp.html)

--- a/skills/eks-best-practices/references/networking.md
+++ b/skills/eks-best-practices/references/networking.md
@@ -162,7 +162,7 @@ Kubernetes labels nodes with `topology.kubernetes.io/zone` automatically, so the
 
 Deploy VPC CNI as an [EKS managed add-on](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html) rather than self-managed. Managed add-ons provide:
 - Validated compatibility with your EKS version
-- Drift handling — changes to EKS-managed fields conflict under server-side apply and may be overwritten: the AWS best-practices guide documents automatic overwrite of managed configuration roughly every 15 minutes ([VPC CNI BPG](https://docs.aws.amazon.com/eks/latest/best-practices/vpc-cni.html)), and add-on create/update applies conflict resolution (`OVERWRITE`/`PRESERVE`/`NONE`) ([field management](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-field-management.html)), as of 2026-08-05
+- Drift handling — changes to EKS-managed fields conflict under server-side apply and may be overwritten: the AWS best-practices guide documents automatic overwrite of managed configuration roughly every 15 minutes ([VPC CNI BPG](https://docs.aws.amazon.com/eks/latest/best-practices/vpc-cni.html)), and add-on create/update applies conflict resolution (`OVERWRITE`/`PRESERVE`/`NONE`) ([CreateAddon API](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html)), as of 2026-08-05
 - Simpler upgrades via EKS API/Console/CLI
 
 Frequently-used fields like `WARM_ENI_TARGET`, `WARM_IP_TARGET`, and `MINIMUM_IP_TARGET` are **not** managed by EKS field management and won't be overwritten.
@@ -331,7 +331,9 @@ Because the switch is irreversible, enumerate reachability before enabling:
 2. **Confirm OIDC provider reachability** from the VPC.
 3. **Enumerate aggregated API services.**
 4. **Ensure route/NAT/NACL/SG allow the required flows** — outbound 443 plus inbound ephemeral (1024–65535).
-5. **Verify after switching** — trigger a webhook with a test pod, watch the cluster log group `/aws/eks/<cluster-name>/cluster`, and enable **VPC Flow Logs** on the egress subnets to confirm control-plane traffic is actually taking the customer-routed path.
+5. **Confirm DNS resolution** — the VPC DHCP options set includes `AmazonProvidedDNS` and can resolve both VPC-private and public hostnames (external webhooks/OIDC endpoints).
+6. **IPv6 clusters: configure both an IPv6 `::/0` route via an egress-only internet gateway and an IPv4 `0.0.0.0/0` route via NAT.**
+7. **Verify after switching** — trigger a webhook with a test pod, watch the cluster log group `/aws/eks/<cluster-name>/cluster`, and enable **VPC Flow Logs** on the egress subnets to confirm control-plane traffic is actually taking the customer-routed path.
 
 ---
 

--- a/skills/eks-best-practices/references/observability.md
+++ b/skills/eks-best-practices/references/observability.md
@@ -490,7 +490,7 @@ fields @timestamp, @message
 
 An admission webhook configured with `failurePolicy: Ignore` fails **open** — when the webhook is unreachable or errors, the API request is admitted anyway and no error is surfaced to the caller. This is silent by design, so a broken policy/mutation webhook (e.g. a down Kyverno, OPA/Gatekeeper, or sidecar-injection webhook) can stop enforcing without any obvious signal.
 
-The kube-apiserver audit log does record these events: a fail-open admission surfaces as an annotation on the audit record, `failed-open.validating.webhook.admission.k8s.io/round_0_index_<n>` (validating webhooks) and `failed-open.mutation.webhook.admission.k8s.io/round_0_index_<n>` (mutating webhooks) — one indexed annotation per bypassed webhook, naming the webhook configuration that was bypassed. The mutating-side spelling (`mutation`) and the validating-side spelling (`validating`) are asymmetric — match them exactly.
+The kube-apiserver audit log does record these events: a fail-open admission surfaces as an annotation on the audit record, `failed-open.validating.webhook.admission.k8s.io/round_0_index_<n>` (validating webhooks) and `failed-open.mutation.webhook.admission.k8s.io/round_<r>_index_<n>` (mutating webhooks — `<r>` is `0`, or `1` when a mutating webhook fails open on reinvocation) — one indexed annotation per bypassed webhook, naming the webhook that was bypassed. The mutating-side spelling (`mutation`) and the validating-side spelling (`validating`) are asymmetric — match them exactly.
 
 Alarm on these the same way you alarm on 401/403 spikes — a CloudWatch Logs **metric filter** on the control-plane audit log group, paired with a CloudWatch **alarm**:
 

--- a/skills/eks-best-practices/references/observability.md
+++ b/skills/eks-best-practices/references/observability.md
@@ -299,9 +299,16 @@ Remediation:
 
 ### Fluent Bit Configuration
 
+There is no `aws-for-fluent-bit` EKS add-on. Two supported paths:
+
 ```bash
-# Deploy as EKS add-on (recommended)
-aws eks create-addon --cluster-name my-cluster --addon-name aws-for-fluent-bit
+# Recommended: the CloudWatch Observability EKS add-on installs Fluent Bit
+# for CloudWatch Logs (alongside Container Insights and Application Signals)
+aws eks create-addon --cluster-name my-cluster --addon-name amazon-cloudwatch-observability
+
+# Alternative: deploy the community Fluent Bit DaemonSet directly (name: fluent-bit)
+# e.g. via the aws-for-fluent-bit Helm chart / manifests
+helm install fluent-bit eks/aws-for-fluent-bit --namespace amazon-cloudwatch --create-namespace
 ```
 
 **Scaling Fluent Bit for large clusters:**
@@ -372,13 +379,15 @@ spec:
           exporters: [awsxray]
 ```
 
-### X-Ray vs OpenTelemetry
+### OpenTelemetry (primary) vs X-Ray SDKs
 
-| Factor | AWS X-Ray | OpenTelemetry + Jaeger/Tempo |
-|--------|-----------|------------------------------|
-| **Setup** | Simple with ADOT | More configuration |
+The **X-Ray SDKs and the X-Ray daemon have been in maintenance mode since 2026-02-25** — they receive no new features. OpenTelemetry (via AWS Distro for OpenTelemetry, ADOT) is AWS's primary, recommended instrumentation standard for new work; instrument with OTel/ADOT rather than the X-Ray SDKs. The **X-Ray service and its APIs continue** as a trace backend/console — ADOT still exports traces to X-Ray (see the `awsxray` exporter above), so you can standardize on OTel instrumentation while keeping X-Ray as a backend.
+
+| Factor | AWS X-Ray (service/backend) | OpenTelemetry + Jaeger/Tempo |
+|--------|-----------------------------|------------------------------|
+| **Instrumentation** | X-Ray SDKs in maintenance mode since 2026-02-25 — use ADOT to feed X-Ray | ADOT / OTel SDKs (primary standard) |
 | **AWS integration** | Native (Lambda, API GW, etc.) | Manual |
-| **Vendor lock-in** | AWS-specific | Vendor-neutral |
+| **Vendor lock-in** | AWS-specific backend | Vendor-neutral |
 | **Querying** | X-Ray console, CloudWatch | Grafana (richer) |
 | **Cost** | Per trace recorded | Storage-dependent |
 
@@ -477,6 +486,34 @@ fields @timestamp, @message
 | sort @timestamp desc
 ```
 
+### Detecting Failed-Open Admission Webhooks
+
+An admission webhook configured with `failurePolicy: Ignore` fails **open** — when the webhook is unreachable or errors, the API request is admitted anyway and no error is surfaced to the caller. This is silent by design, so a broken policy/mutation webhook (e.g. a down Kyverno, OPA/Gatekeeper, or sidecar-injection webhook) can stop enforcing without any obvious signal.
+
+The kube-apiserver audit log does record these events: a fail-open admission surfaces as an annotation on the audit record, `failed-open.validation.webhook.admission.k8s.io` (validating webhooks) and `failed-open.mutation.webhook.admission.k8s.io` (mutating webhooks), naming the webhook configuration that was bypassed.
+
+Alarm on these the same way you alarm on 401/403 spikes — a CloudWatch Logs **metric filter** on the control-plane audit log group, paired with a CloudWatch **alarm**:
+
+```bash
+# Metric filter: count audit records carrying a failed-open webhook annotation
+aws logs put-metric-filter \
+  --log-group-name /aws/eks/my-cluster/cluster \
+  --filter-name webhook-failed-open \
+  --filter-pattern '{ ($.annotations."failed-open.validation.webhook.admission.k8s.io" = "*") || ($.annotations."failed-open.mutation.webhook.admission.k8s.io" = "*") }' \
+  --metric-transformations \
+      metricName=WebhookFailedOpen,metricNamespace=EKS/Admission,metricValue=1,defaultValue=0
+
+# Alarm on any occurrence
+aws cloudwatch put-metric-alarm \
+  --alarm-name eks-webhook-failed-open \
+  --namespace EKS/Admission --metric-name WebhookFailedOpen \
+  --statistic Sum --period 300 --evaluation-periods 1 \
+  --threshold 0 --comparison-operator GreaterThanThreshold \
+  --treat-missing-data notBreaching
+```
+
+Any non-zero value means an admission webhook silently failed open and enforcement gaps may exist — investigate the named webhook's availability before assuming policy is being applied.
+
 ### Amazon GuardDuty for EKS
 
 | Finding | Severity | Meaning |
@@ -485,7 +522,7 @@ fields @timestamp, @message
 | `Persistence:Kubernetes/ContainerWithSensitiveMount` | Medium | Sensitive host path mounted |
 | `Policy:Kubernetes/ExposedDashboard` | Medium | K8s dashboard exposed |
 | `CredentialAccess:Kubernetes/MaliciousIPCaller` | High | API call from known malicious IP |
-| `Impact:Runtime/CryptoCurrencyMiningDetected` | High | Crypto mining in container |
+| `Impact:Runtime/CryptoMinerExecuted` | High | Crypto mining in container |
 
 ### CloudTrail for EKS
 

--- a/skills/eks-best-practices/references/observability.md
+++ b/skills/eks-best-practices/references/observability.md
@@ -299,7 +299,7 @@ Remediation:
 
 ### Fluent Bit Configuration
 
-There is no `aws-for-fluent-bit` EKS add-on. Two supported paths:
+There is no `aws-for-fluent-bit` EKS add-on (as of 2026-08-04). Two supported paths:
 
 ```bash
 # Recommended: the CloudWatch Observability EKS add-on installs Fluent Bit
@@ -490,16 +490,22 @@ fields @timestamp, @message
 
 An admission webhook configured with `failurePolicy: Ignore` fails **open** — when the webhook is unreachable or errors, the API request is admitted anyway and no error is surfaced to the caller. This is silent by design, so a broken policy/mutation webhook (e.g. a down Kyverno, OPA/Gatekeeper, or sidecar-injection webhook) can stop enforcing without any obvious signal.
 
-The kube-apiserver audit log does record these events: a fail-open admission surfaces as an annotation on the audit record, `failed-open.validation.webhook.admission.k8s.io` (validating webhooks) and `failed-open.mutation.webhook.admission.k8s.io` (mutating webhooks), naming the webhook configuration that was bypassed.
+The kube-apiserver audit log does record these events: a fail-open admission surfaces as an annotation on the audit record, `failed-open.validating.webhook.admission.k8s.io/round_0_index_<n>` (validating webhooks) and `failed-open.mutation.webhook.admission.k8s.io/round_0_index_<n>` (mutating webhooks) — one indexed annotation per bypassed webhook, naming the webhook configuration that was bypassed. The mutating-side spelling (`mutation`) and the validating-side spelling (`validating`) are asymmetric — match them exactly.
 
 Alarm on these the same way you alarm on 401/403 spikes — a CloudWatch Logs **metric filter** on the control-plane audit log group, paired with a CloudWatch **alarm**:
+
+> **Prerequisite:** EKS control-plane **audit logging is disabled by default**. Enable the `audit` log type first — nothing below matches until audit events reach the `/aws/eks/<cluster>/cluster` log group:
+> ```bash
+> aws eks update-cluster-config --name my-cluster \
+>   --logging '{"clusterLogging":[{"types":["audit"],"enabled":true}]}'
+> ```
 
 ```bash
 # Metric filter: count audit records carrying a failed-open webhook annotation
 aws logs put-metric-filter \
   --log-group-name /aws/eks/my-cluster/cluster \
   --filter-name webhook-failed-open \
-  --filter-pattern '{ ($.annotations."failed-open.validation.webhook.admission.k8s.io" = "*") || ($.annotations."failed-open.mutation.webhook.admission.k8s.io" = "*") }' \
+  --filter-pattern '?"failed-open.validating.webhook.admission.k8s.io" ?"failed-open.mutation.webhook.admission.k8s.io"' \
   --metric-transformations \
       metricName=WebhookFailedOpen,metricNamespace=EKS/Admission,metricValue=1,defaultValue=0
 
@@ -511,6 +517,13 @@ aws cloudwatch put-metric-alarm \
   --threshold 0 --comparison-operator GreaterThanThreshold \
   --treat-missing-data notBreaching
 ```
+
+> Metric filters count matching log events but can't extract the indexed annotation name. To see *which* webhook failed open, query the audit log group in CloudWatch Logs Insights instead:
+> ```
+> fields @timestamp, @message
+> | filter @message like /failed-open\.(validating|mutation)\.webhook\.admission\.k8s\.io/
+> | sort @timestamp desc
+> ```
 
 Any non-zero value means an admission webhook silently failed open and enforcement gaps may exist — investigate the named webhook's availability before assuming policy is being applied.
 

--- a/skills/eks-best-practices/references/reliability-advanced.md
+++ b/skills/eks-best-practices/references/reliability-advanced.md
@@ -29,7 +29,7 @@ velero install \
   --bucket my-velero-bucket \
   --backup-location-config region=us-east-1 \
   --snapshot-location-config region=us-east-1 \
-  --plugins velero/velero-plugin-for-aws:v1.8.0
+  --plugins velero/velero-plugin-for-aws:v1.8.0  # illustrative pin — check the current release (e.g. v1.14.2) and match it to your Velero version
 
 # Schedule daily backups
 velero schedule create daily-backup \
@@ -57,16 +57,23 @@ velero schedule create daily-backup \
 
 ## EKS Zonal Shift (ARC Integration)
 
-Amazon Application Recovery Controller (ARC) zonal shift allows you to shift traffic away from an impaired Availability Zone for EKS workloads. When an AZ experiences degradation, zonal shift removes that AZ from the load balancer target group, redirecting traffic to healthy AZs without requiring application changes.
+Amazon Application Recovery Controller (ARC) zonal shift allows you to shift away from an impaired Availability Zone for EKS workloads. With the EKS-integrated ARC zonal shift enabled on the cluster, a shift does far more than reroute load balancer traffic — it acts across both the data plane and Kubernetes' own service routing:
+
+- **Nodes in the impaired AZ are cordoned** so no new pods schedule there.
+- **The EndpointSlice controller strips pod endpoints in the impaired AZ**, so east-west (in-cluster `ClusterIP`) traffic is shifted away too — not just external ALB/NLB traffic.
+- **Managed Node Group AZRebalance is suspended** so the ASG does not fight the shift by rebalancing capacity back into the impaired AZ.
+- **EKS Auto Mode stops provisioning** new capacity in the impaired AZ for the duration of the shift.
 
 | Aspect | Detail |
 |---|---|
-| **What it does** | Removes an AZ from ALB/NLB target groups, shifting traffic to healthy AZs |
+| **What it does** | Cordons impaired-AZ nodes, strips impaired-AZ pod endpoints (ClusterIP + ALB/NLB), suspends MNG AZRebalance, and stops Auto Mode provisioning in that AZ |
 | **Trigger** | Manual via console/API, or automated via zonal autoshift |
 | **Duration** | Up to 72 hours per shift, extendable |
-| **EKS impact** | Pods in the shifted AZ stop receiving traffic but continue running |
-| **Pod scheduling** | Existing pods remain; new pods still schedule to all AZs unless topology constraints prevent it |
-| **Prerequisites** | Multi-AZ deployment, topology spread constraints, sufficient capacity in remaining AZs |
+| **EKS impact** | Impaired-AZ pods are removed from Service endpoints (external and in-cluster); nodes are cordoned so nothing new lands there |
+| **Pod scheduling** | Impaired-AZ nodes are cordoned — new pods do not schedule into the AZ for the shift's duration |
+| **Prerequisites** | EKS-integrated ARC zonal shift enabled, multi-AZ deployment, topology spread constraints, sufficient capacity in remaining AZs |
+
+**Karpenter and Auto Mode integration:** Karpenter (as of 2026-05) and EKS Auto Mode (as of 2026-07) integrate with ARC zonal shift, so provisioning honors an active shift and stops adding capacity in the impaired AZ. This integration is what makes the older "traffic-only" characterization of zonal shift stale — with it enabled, the shift reaches scheduling and in-cluster routing, not just the load balancer.
 
 **When to use zonal shift:**
 - AZ-level impairment (network, storage, compute degradation)
@@ -74,9 +81,9 @@ Amazon Application Recovery Controller (ARC) zonal shift allows you to shift tra
 - Proactive shift during planned AZ maintenance
 
 **Limitations:**
-- Does not evict or reschedule pods — only affects traffic routing
+- Does not evict or reschedule already-running pods — it cordons nodes and removes endpoints, but existing pods in the impaired AZ keep running until they terminate on their own
 - Requires sufficient capacity in remaining AZs to handle full load
-- Works with ALB and NLB only (not ClusterIP or NodePort services)
+- Requires the EKS-integrated ARC zonal shift to be enabled on the cluster; without it, only the load-balancer traffic path shifts
 
 DO:
 - Ensure topology spread constraints distribute pods across all AZs before relying on zonal shift
@@ -85,7 +92,7 @@ DO:
 
 DON'T:
 - Use zonal shift as a substitute for proper multi-AZ pod distribution
-- Assume pods will automatically move — zonal shift only affects traffic, not scheduling
+- Assume already-running pods will be evicted or moved — the shift cordons nodes and strips endpoints, but does not reschedule pods that are already running
 
 ---
 
@@ -187,7 +194,7 @@ Create a new Deployment identical to the current version, verify pods are health
 
 ### Canary Deployments
 
-Deploy the new version with fewer replicas alongside the existing Deployment, divert a small percentage of traffic, and progressively increase if metrics are healthy. Use [Flagger](https://github.com/weaveworks/flagger) with Istio or AWS App Mesh for automated canary progression.
+Deploy the new version with fewer replicas alongside the existing Deployment, divert a small percentage of traffic, and progressively increase if metrics are healthy. Use [Flagger](https://github.com/fluxcd/flagger) with Istio for automated canary progression. (AWS App Mesh reaches end of support on 2026-09-30 — do not adopt it for new canary/mesh work; prefer Istio or Cilium-based service mesh instead.)
 
 ---
 
@@ -251,3 +258,4 @@ Prerequisite reading: [reliability-core.md](reliability-core.md).
 - [AWS EKS Best Practices Guide — High Availability](https://aws.github.io/aws-eks-best-practices/reliability/docs/)
 - [AWS Prescriptive Guidance — HA and Resiliency for EKS](https://docs.aws.amazon.com/prescriptive-guidance/latest/ha-resiliency-amazon-eks-apps/introduction.html)
 - [AWS FIS for EKS](https://docs.aws.amazon.com/fis/latest/userguide/fis-actions-reference.html)
+- [EKS Zonal Shift (ARC integration)](https://docs.aws.amazon.com/eks/latest/userguide/zone-shift.html)

--- a/skills/eks-best-practices/references/reliability-core.md
+++ b/skills/eks-best-practices/references/reliability-core.md
@@ -216,7 +216,7 @@ Karpenter respects PDBs during:
 - **Drift replacement** — Waits for PDB budget before cordoning
 - **Expiry** — Respects PDB during node replacement
 
-If a PDB blocks node drain for >15 minutes (default), Karpenter's `terminationGracePeriod` on the NodePool determines behavior.
+If a PDB blocks node drain, Karpenter waits indefinitely by default — there is no built-in timeout. The NodePool's `terminationGracePeriod` is an opt-in force-delete deadline that has **no default** (when unset, `nil`, Karpenter waits indefinitely for the PDB to allow eviction). Once set, it forces drain after that deadline even if a PDB is still blocking.
 
 ---
 

--- a/skills/eks-best-practices/references/reliability-core.md
+++ b/skills/eks-best-practices/references/reliability-core.md
@@ -216,7 +216,7 @@ Karpenter respects PDBs during:
 - **Drift replacement** — Waits for PDB budget before cordoning
 - **Expiry** — Respects PDB during node replacement
 
-If a PDB blocks node drain, Karpenter waits indefinitely by default — there is no built-in timeout. The NodePool's `terminationGracePeriod` is an opt-in force-delete deadline that has **no default** (when unset, `nil`, Karpenter waits indefinitely for the PDB to allow eviction). Once set, it forces drain after that deadline even if a PDB is still blocking.
+If a PDB blocks node drain, Karpenter waits indefinitely by default — there is no built-in timeout (as of 2026-08-04). The NodePool's `terminationGracePeriod` is an opt-in force-delete deadline that has **no default** (when unset, `nil`, Karpenter waits indefinitely for the PDB to allow eviction). Once set, it forces drain after that deadline even if a PDB is still blocking.
 
 ---
 

--- a/skills/eks-best-practices/references/scalability.md
+++ b/skills/eks-best-practices/references/scalability.md
@@ -51,6 +51,8 @@ When investigating scaling issues, check metrics in both upstream and downstream
 
 EKS automatically scales the control plane (API servers across 2+ AZs, etcd across 3 AZs), but there are limits on how fast it scales.
 
+For large clusters that hit these auto-scaling limits, **EKS Provisioned Control Plane (PCP)** directly addresses the API-scaling concern: it offers a 99.99% SLA, an 8XL control-plane tier (added 2026-03), and faster pod autoscaling (added 2026-07). See [Amazon EKS Provisioned Control Plane](https://docs.aws.amazon.com/eks/latest/userguide/scale-cluster.html). Consider it before relying solely on the Terraform-level burst knobs below.
+
 ### Burst Limits
 
 Avoid scaling spikes that increase cluster size by more than ~10% at a time (e.g., 1,000 to 1,100 nodes, or 4,000 to 4,500 pods at once). The control plane auto-scales but needs time to adapt. New clusters will not immediately support hundreds of nodes.
@@ -89,7 +91,7 @@ If you see 429s from your controllers, they're likely making excessive LIST call
 | Metric | What It Tells You |
 |--------|-------------------|
 | `etcd_request_duration_seconds` | etcd latency per operation |
-| `apiserver_storage_size_bytes` (EKS >= 1.28) | etcd database size |
+| `apiserver_storage_size_bytes` | etcd database size |
 
 When etcd's database size exceeds its limit, it emits a "no space" alarm and the cluster becomes **read-only** -- no new pods, no scaling, no deployments.
 
@@ -168,7 +170,7 @@ spec:
 
 Keep worker nodes up to date with the latest EKS-optimized AMIs:
 
-- **Karpenter** automatically uses the latest AMI for new nodes
+- **Karpenter** (v1) selects AMIs via `amiSelectorTerms` on the EC2NodeClass -- it does not auto-track the latest AMI unless you use the `@latest` alias, which is discouraged in production (pin a specific AMI/alias instead)
 - **MNG** requires updating the ASG launch template for patch releases; minor versions are available as managed upgrades
 - Use Bottlerocket for automatic, minimal-downtime updates
 
@@ -248,7 +250,7 @@ Use separate EKS clusters for different application environments (dev, test, pro
 | ELB Type | Default Target Quota | Per-AZ Limit |
 |----------|---------------------|--------------|
 | ALB | 1,000 targets | -- |
-| NLB | 3,000 targets | 500 per AZ |
+| NLB | 3,000 targets | 500 per AZ (500 per LB total with cross-zone load balancing enabled) |
 
 If a service exceeds these targets, split across multiple LBs or use an in-cluster ingress controller. Use Route 53 (weighted DNS), Global Accelerator, or CloudFront to present multiple LBs as a single endpoint.
 
@@ -256,7 +258,7 @@ If a service exceeds these targets, split across multiple LBs or use an in-clust
 
 EndpointSlices reduce API server load compared to Endpoints for large, frequently-scaling services. They include topology information for features like topology-aware routing.
 
-Verify your controllers use them -- for the AWS Load Balancer Controller, enable `--enable-endpoint-slices`.
+Verify your controllers use them -- for older AWS Load Balancer Controller versions, enable `--enable-endpoint-slices`; it is on by default since LBC v2.7+ (and in v3), so no action is needed on current versions.
 
 ### Reduce Control Plane Watches
 

--- a/skills/eks-best-practices/references/scalability.md
+++ b/skills/eks-best-practices/references/scalability.md
@@ -377,7 +377,7 @@ Karpenter does not have this limitation -- it handles large clusters without sha
 | Node autoscaling | 1,000+ nodes | Use Karpenter or shard CAS |
 | kubectl | Automation/scripts | Enable cache-dir, disable compression |
 | Node efficiency | Any scale | Prefer 4xlarge-12xlarge, match churn to node size |
-| Pod networking | IP exhaustion | Use prefix delegation or IPv6 |
+| Pod networking | IP exhaustion | Use prefix delegation; IPv6 (dual-stack) for larger address space |
 
 **For clusters beyond 1,000 nodes or 50,000 pods**, AWS recommends engaging your support team or TAM for specialist guidance. EKS can support up to 100,000 nodes with appropriate planning.
 

--- a/skills/eks-best-practices/references/security-runtime-network.md
+++ b/skills/eks-best-practices/references/security-runtime-network.md
@@ -21,17 +21,18 @@
 
 ### Amazon GuardDuty for EKS
 
-**Enable EKS Runtime Monitoring** as the first line of defense. GuardDuty analyzes K8s audit logs, VPC flow logs, and DNS logs using ML and threat intelligence to detect threats without manual configuration.
+**Enable Runtime Monitoring** as the first line of defense. GuardDuty's EKS protection is now delivered through the unified **Runtime Monitoring** feature (the separate "EKS Runtime Monitoring" console path has been removed; AWS recommends migrating to unified Runtime Monitoring). GuardDuty combines two complementary sources of signal:
 
-**Enable both:**
-- **EKS Audit Log Monitoring** — analyzes K8s audit logs for threats
-- **EKS Runtime Monitoring** — agent-based, detects container-level threats
+- **EKS Protection (audit-log analysis)** — analyzes K8s control-plane audit logs for threats; no agent required.
+- **Runtime Monitoring (agent-based)** — the GuardDuty security agent observes container-level runtime behavior (process, file, and network activity) on your nodes.
 
-**Key finding types:**
-- `Execution:Runtime/CryptocurrencyMiningDetected`
-- `PrivilegeEscalation:Runtime/DockerSocketAccess`
-- `Persistence:Runtime/ReverseShell`
-- `UnauthorizedAccess:IAMUser/AnomalousBehavior`
+These are distinct data sources — audit-log analysis and the runtime agent — so keep them conceptually separate rather than conflating them. GuardDuty applies ML and threat intelligence across both to detect threats without manual rule configuration.
+
+**Key runtime finding types:**
+- `CryptoCurrency:Runtime/BitcoinTool.B`
+- `Impact:Runtime/CryptoMinerExecuted`
+- `PrivilegeEscalation:Runtime/DockerSocketAccessed`
+- `Execution:Runtime/ReverseShell`
 
 GuardDuty produces security findings viewable in the console or via EventBridge for automated response.
 
@@ -104,6 +105,8 @@ helm install falco falcosecurity/falco \
 
 ```yaml
 # Enable network policy support in VPC CNI
+# NOTE: the addon-version below is illustrative -- check the current version with
+# `aws eks describe-addon-versions --addon-name vpc-cni` rather than pinning this value.
 aws eks create-addon --cluster-name my-cluster \
   --addon-name vpc-cni \
   --addon-version v1.14.0-eksbuild.3 \
@@ -111,6 +114,8 @@ aws eks create-addon --cluster-name my-cluster \
 ```
 
 Network policy support is NOT enabled by default — you must enable the `ENABLE_NETWORK_POLICY` flag on the VPC CNI add-on.
+
+Newer VPC CNI releases (v1.21+) also add a cluster-scoped **ClusterNetworkPolicy** admin tier and **strict mode** enforcement on top of the standard namespaced `NetworkPolicy` API — check the current VPC CNI version to see whether these are available in your cluster.
 
 ### Start with Default Deny + DNS Allow
 
@@ -235,7 +240,7 @@ Consider third-party engines when you need advanced features:
 | **Cilium** | Layer 7 (HTTP), DNS hostname rules, eBPF-native |
 | **Calico Enterprise** | Map K8s NP to AWS security groups, compliance reporting |
 
-**Migration:** If switching from Calico/Cilium to VPC CNI network policies, use the [K8s Network Policy Migrator](https://github.com/awslabs/k8s-network-policy-migrator) tool to convert CRDs to native K8s NetworkPolicy resources. Test in a separate cluster before production.
+**Migration:** If switching from Calico/Cilium to VPC CNI network policies, the [K8s Network Policy Migrator](https://github.com/awslabs/k8s-network-policy-migrator) tool can convert CRDs to native K8s NetworkPolicy resources. Note this tool has been **dormant since 2023-08** (no updates), so validate its output against current CRD schemas and always test in a separate cluster before production.
 
 ### Ensure Network Policies Exist via OPA
 
@@ -280,7 +285,9 @@ Traffic between Nitro instance types (C5n, G4, I3en, M5dn, M5n, P3dn, R5dn, R5n,
 For end-to-end encryption between pods:
 - **Istio** — automatic mTLS between all meshed services
 - **Linkerd** — automatic mTLS with minimal configuration
-- **App Mesh** — mTLS with X.509 certificates or Envoy SDS
+- **Cilium** — transparent mTLS / WireGuard-based node-to-node encryption via eBPF
+
+> **Do not adopt AWS App Mesh.** App Mesh reaches **end of support on 2026-09-30**, after which its console and resources become inaccessible. Do not start new App Mesh mTLS deployments; migrate existing ones to Istio, Cilium mTLS, or Linkerd.
 
 ### Ingress and Load Balancer TLS
 

--- a/skills/eks-best-practices/references/security-runtime-network.md
+++ b/skills/eks-best-practices/references/security-runtime-network.md
@@ -21,7 +21,7 @@
 
 ### Amazon GuardDuty for EKS
 
-**Enable Runtime Monitoring** as the first line of defense. GuardDuty's EKS protection is now delivered through the unified **Runtime Monitoring** feature (the separate "EKS Runtime Monitoring" console path has been removed; AWS recommends migrating to unified Runtime Monitoring). GuardDuty combines two complementary sources of signal:
+**Enable Runtime Monitoring** as the first line of defense. GuardDuty's EKS protection is now delivered through the unified **Runtime Monitoring** feature (the separate "EKS Runtime Monitoring" console path has been removed (as of 2026-08-05, per the GuardDuty User Guide); AWS recommends migrating to unified Runtime Monitoring). GuardDuty combines two complementary sources of signal:
 
 - **EKS Protection (audit-log analysis)** — analyzes K8s control-plane audit logs for threats; no agent required.
 - **Runtime Monitoring (agent-based)** — the GuardDuty security agent observes container-level runtime behavior (process, file, and network activity) on your nodes.

--- a/skills/eks-best-practices/references/security-supply-chain.md
+++ b/skills/eks-best-practices/references/security-supply-chain.md
@@ -41,7 +41,7 @@ Reducing the attack surface of container images is a primary security goal:
   ENTRYPOINT ["/server"]
   ```
 - **Add the USER directive** to Dockerfiles to run as non-root by default
-- **Lint Dockerfiles** with tools like [dockerfile_lint](https://github.com/projectatomic/dockerfile_lint) to enforce best practices in CI
+- **Lint Dockerfiles** with tools like [hadolint](https://github.com/hadolint/hadolint) to enforce best practices in CI
 
 ### Software Bill of Materials (SBOMs)
 
@@ -68,7 +68,7 @@ aws ecr put-registry-scanning-configuration \
 
 | Scanning Type | Provider | Cost | Features |
 |--------------|----------|------|----------|
-| **Basic** | Clair (via ECR) | Free | On-push or on-demand |
+| **Basic** | AWS-native (`AWS_NATIVE`, via ECR) | Free | On-push or on-demand |
 | **Enhanced** | Amazon Inspector | Paid | Continuous, OS + language packages |
 
 Additional scanning tools: Grype, Trivy, Snyk, Prisma Cloud (twistcli), Aqua.

--- a/skills/eks-best-practices/references/security.md
+++ b/skills/eks-best-practices/references/security.md
@@ -434,7 +434,7 @@ The ExternalId requirement mitigates confused-deputy attacks by ensuring only th
 
 ### Bring Your Own KMS Key (Customer-Managed CMK)
 
-Envelope encryption for Kubernetes secrets is already **on by default** on every cluster (see [Data Encryption](#data-encryption)). `associate-encryption-config` does **not** turn encryption on — its current role is to layer your own customer-managed KMS key (CMK) over the default AWS-owned key, giving you CloudTrail visibility into key usage and direct control over the key (disable/rotate/scope via key policy). It still scopes only `resources: ["secrets"]`.
+Envelope encryption for Kubernetes secrets is already **on by default** on every cluster (see [Data Encryption](#data-encryption)). `associate-encryption-config` does **not** turn encryption on — its current role is to layer your own customer-managed KMS key (CMK) over the default AWS-owned key, giving you CloudTrail visibility into key usage and direct control over the key (disable/rotate/scope via key policy). On ≥1.28, default envelope encryption covers all Kubernetes API data; associating a CMK makes it the KEK for all of it. The `associate-encryption-config` API still accepts only `resources: ["secrets"]` as input, but the effect extends to all API data.
 
 ```bash
 # Associate a customer-managed CMK for secrets (adds key control + CloudTrail visibility;
@@ -501,7 +501,7 @@ fields @timestamp, @message
 - Use separate namespaces to isolate secrets from different applications — secrets in a namespace are accessible to all pods in that namespace
 - Don't store secrets in ConfigMaps
 - Don't commit secrets to Git (even base64-encoded)
-- In **vanilla Kubernetes**, Secrets are only base64-encoded (not encrypted at rest); don't rely on that. **On EKS this is not the case** — every cluster has default envelope encryption for secrets plus disk-level etcd encryption, so EKS Secrets are encrypted at rest out of the box. Layer a customer-managed CMK when you need key control (see above)
+- In **vanilla Kubernetes**, Secrets are only base64-encoded (not encrypted at rest); don't rely on that. **On EKS this is not the case** — on clusters ≥1.28 default envelope encryption covers all Kubernetes API data (not just secrets) plus disk-level etcd encryption, so EKS Secrets are encrypted at rest out of the box. Layer a customer-managed CMK when you need key control (see above)
 
 ### Secrets Operating Models
 
@@ -580,7 +580,7 @@ ESO syncs to K8s Secret in target namespace
 
 | Component | Mechanism | Default |
 |-----------|-----------|---------|
-| **etcd (secrets)** | KMS envelope encryption (AWS-owned KEK) | On by default (all clusters ≥ 1.28) |
+| **etcd (all K8s API data)** | KMS envelope encryption (AWS-owned KEK) | On by default (all clusters ≥ 1.28); covers all API data, not just secrets |
 | **EBS volumes** | EBS encryption with KMS | Configure in StorageClass |
 | **EFS** | Encryption at rest | Configure at file system creation |
 | **FSx for Lustre** | Service-managed key or CMK | Service-managed by default |

--- a/skills/eks-best-practices/references/security.md
+++ b/skills/eks-best-practices/references/security.md
@@ -291,7 +291,7 @@ spec:
 - Drop ALL capabilities and add back only what's needed
 - Use `readOnlyRootFilesystem: true` where possible
 - Set `seccompProfile: RuntimeDefault`
-- Never run Docker-in-Docker or mount the Docker socket — use buildah, CodeBuild, or BuildKit instead (Kaniko is archived — prefer buildah/CodeBuild/BuildKit)
+- Never run Docker-in-Docker or mount the Docker socket — use buildah, CodeBuild, or BuildKit instead (Kaniko is archived — prefer buildah/CodeBuild/BuildKit) (as of 2026-08-04)
 - Restrict `hostPath` usage — if necessary, mount as `readOnly: true` and limit allowed prefixes via policy
 - Don't enable `privileged: true`, `hostNetwork`, `hostPID`, or `hostIPC` for application workloads
 - Set resource requests and limits on every container to prevent DoS and resource contention

--- a/skills/eks-best-practices/references/security.md
+++ b/skills/eks-best-practices/references/security.md
@@ -33,7 +33,7 @@
 **Minimum node IAM policies:**
 - `AmazonEKSWorkerNodePolicy`
 - `AmazonEKS_CNI_Policy` (or use IRSA/Pod Identity for VPC CNI)
-- `AmazonEC2ContainerRegistryReadOnly`
+- `AmazonEC2ContainerRegistryPullOnly` (current guidance; narrower than the older `AmazonEC2ContainerRegistryReadOnly`)
 
 Move VPC CNI permissions to IRSA/Pod Identity to reduce node role scope. Never add application-level permissions (S3, DynamoDB) to node roles — use Pod Identity or IRSA instead.
 
@@ -99,7 +99,7 @@ aws eks associate-access-policy \
 
 **Migration path:** `CONFIG_MAP` -> `API_AND_CONFIG_MAP` -> `API`. These transitions are **irreversible** — you cannot switch from `API` back to `CONFIG_MAP`.
 
-**Available access policies:**
+**Available access policies (illustrative — 15+ EKS access policies exist; list the full set with `aws eks list-access-policies`):**
 - `AmazonEKSClusterAdminPolicy` -> cluster-admin
 - `AmazonEKSAdminPolicy` -> admin (namespace-scopable)
 - `AmazonEKSEditPolicy` -> edit (namespace-scopable)
@@ -131,7 +131,6 @@ If `stsendpoint` equals `sts.amazonaws.com`, the client is using the global endp
 | **Cross-account** | Built-in support | Manual trust policy per account |
 | **Session tags** | Automatic (cluster, namespace, SA) | Not available |
 | **Role chaining** | Supported | Not supported |
-| **EKS version** | 1.24+ | 1.14+ |
 | **Fargate support** | Not yet | Supported |
 | **Recommendation** | Preferred for new workloads | Use for older clusters or Fargate |
 
@@ -199,6 +198,8 @@ metadata:
 - Use `StringEquals` (not `StringLike`) for sub conditions
 - Never use wildcard `*` in IRSA trust policy conditions
 - Don't share service accounts across applications with different privilege needs
+
+> **PrivateLink for the cluster OIDC endpoint** (GA as of 2026-08-04): the cluster OIDC issuer endpoint can be reached over PrivateLink, giving IRSA token validation a fully private path with no public internet egress — useful for private/isolated clusters. See [Interface VPC endpoints for the OIDC endpoint](https://docs.aws.amazon.com/eks/latest/userguide/authenticate-oidc-identity-provider.html).
 
 ---
 
@@ -290,7 +291,7 @@ spec:
 - Drop ALL capabilities and add back only what's needed
 - Use `readOnlyRootFilesystem: true` where possible
 - Set `seccompProfile: RuntimeDefault`
-- Never run Docker-in-Docker or mount the Docker socket — use Kaniko, buildah, or CodeBuild instead
+- Never run Docker-in-Docker or mount the Docker socket — use buildah, CodeBuild, or BuildKit instead (Kaniko is archived — prefer buildah/CodeBuild/BuildKit)
 - Restrict `hostPath` usage — if necessary, mount as `readOnly: true` and limit allowed prefixes via policy
 - Don't enable `privileged: true`, `hostNetwork`, `hostPID`, or `hostIPC` for application workloads
 - Set resource requests and limits on every container to prevent DoS and resource contention
@@ -431,10 +432,13 @@ The ExternalId requirement mitigates confused-deputy attacks by ensuring only th
 | **Sealed Secrets (Bitnami)** | Low | Manual | Encrypt secrets for Git storage |
 | **Direct SDK calls** | Low | N/A | Application handles own secret retrieval |
 
-### Enable Envelope Encryption
+### Bring Your Own KMS Key (Customer-Managed CMK)
+
+Envelope encryption for Kubernetes secrets is already **on by default** on every cluster (see [Data Encryption](#data-encryption)). `associate-encryption-config` does **not** turn encryption on — its current role is to layer your own customer-managed KMS key (CMK) over the default AWS-owned key, giving you CloudTrail visibility into key usage and direct control over the key (disable/rotate/scope via key policy). It still scopes only `resources: ["secrets"]`.
 
 ```bash
-# Enable KMS encryption for Kubernetes secrets
+# Associate a customer-managed CMK for secrets (adds key control + CloudTrail visibility;
+# does NOT enable encryption — that is already on by default)
 aws eks associate-encryption-config \
   --cluster-name my-cluster \
   --encryption-config '[{
@@ -490,14 +494,14 @@ fields @timestamp, @message
 
 ### Secrets Best Practices
 
-- Enable envelope encryption with KMS for etcd secrets
+- Envelope encryption for etcd secrets is on by default; layer a customer-managed KMS CMK when you need key control and CloudTrail visibility
 - Use ESO or Secrets Store CSI for production workloads
 - Set `refreshInterval` for automatic rotation pickup
 - **Use volume mounts instead of environment variables** — env var values can appear in logs, `kubectl describe`, and crash dumps. Secrets mounted as volumes use tmpfs (RAM-backed) and are removed when the pod is deleted
 - Use separate namespaces to isolate secrets from different applications — secrets in a namespace are accessible to all pods in that namespace
 - Don't store secrets in ConfigMaps
 - Don't commit secrets to Git (even base64-encoded)
-- Don't rely on default Kubernetes encryption (base64 only, not encrypted at rest)
+- In **vanilla Kubernetes**, Secrets are only base64-encoded (not encrypted at rest); don't rely on that. **On EKS this is not the case** — every cluster has default envelope encryption for secrets plus disk-level etcd encryption, so EKS Secrets are encrypted at rest out of the box. Layer a customer-managed CMK when you need key control (see above)
 
 ### Secrets Operating Models
 
@@ -576,7 +580,7 @@ ESO syncs to K8s Secret in target namespace
 
 | Component | Mechanism | Default |
 |-----------|-----------|---------|
-| **etcd (secrets)** | KMS envelope encryption | Off — must enable |
+| **etcd (secrets)** | KMS envelope encryption (AWS-owned KEK) | On by default (all clusters ≥ 1.28) |
 | **EBS volumes** | EBS encryption with KMS | Configure in StorageClass |
 | **EFS** | Encryption at rest | Configure at file system creation |
 | **FSx for Lustre** | Service-managed key or CMK | Service-managed by default |
@@ -616,7 +620,7 @@ spec:
     volumeHandle: <file_system_id>
 ```
 
-**Use EFS access points** to simplify shared dataset access with different POSIX file permissions. Each EFS file system supports up to 120 access points.
+**Use EFS access points** to simplify shared dataset access with different POSIX file permissions. Each EFS file system supports up to 10,000 access points (adjustable quota).
 
 ### CMK Rotation
 
@@ -638,3 +642,5 @@ Configure KMS to automatically rotate your CMKs. This rotates keys once a year w
 - [AWS EKS Best Practices Guide — IAM](https://docs.aws.amazon.com/eks/latest/best-practices/identity-and-access-management.html)
 - [AWS EKS Best Practices Guide — Pod Security](https://docs.aws.amazon.com/eks/latest/best-practices/pod-security.html)
 - [AWS EKS Best Practices Guide — Data Encryption](https://docs.aws.amazon.com/eks/latest/best-practices/data-encryption-and-secrets-management.html)
+- [Amazon EKS — Envelope encryption of Kubernetes secrets](https://docs.aws.amazon.com/eks/latest/userguide/envelope-encryption.html)
+- [Amazon EFS — Quotas and limits](https://docs.aws.amazon.com/efs/latest/ug/limits.html)

--- a/skills/eks-best-practices/references/terraform-examples.md
+++ b/skills/eks-best-practices/references/terraform-examples.md
@@ -102,7 +102,7 @@ module "eks" {
 
 | Feature | eks-auto-mode | eks-capabilities | eks-managed-node-group | self-managed-node-group | karpenter | eks-hybrid-nodes |
 |---------|:---:|:---:|:---:|:---:|:---:|:---:|
-| **K8s Version** | 1.33 | 1.34 | 1.33 | 1.33 | 1.33 | 1.33 |
+| **K8s Version** | 1.34 | 1.34 | 1.34 | 1.34 | 1.34 | 1.34 |
 | **Compute** | Auto Mode | Auto Mode | MNG | ASG | MNG + Karpenter | Hybrid + Cilium |
 | **AL2023** | — | — | ✅ | ✅ | — | — |
 | **Bottlerocket** | — | — | ✅ | ✅ | — | — |
@@ -128,8 +128,8 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 21.0"
 
-  cluster_name    = "auto-mode-cluster"
-  cluster_version = "1.33"
+  name               = "auto-mode-cluster"
+  kubernetes_version = "1.34"
 
   # Enable Auto Mode
   compute_config = {
@@ -140,7 +140,7 @@ module "eks" {
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
-  cluster_addons = {
+  addons = {
     coredns                = {}
     eks-pod-identity-agent = {}
     kube-proxy             = {}
@@ -216,8 +216,8 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 21.0"
 
-  cluster_name    = "mng-al2023"
-  cluster_version = "1.33"
+  name               = "mng-al2023"
+  kubernetes_version = "1.34"
 
   eks_managed_node_groups = {
     default = {
@@ -242,7 +242,7 @@ module "eks" {
     }
   }
 
-  cluster_addons = {
+  addons = {
     coredns                = {}
     eks-pod-identity-agent = { before_compute = true }
     kube-proxy             = {}
@@ -303,8 +303,8 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 21.0"
 
-  cluster_name    = "karpenter-cluster"
-  cluster_version = "1.33"
+  name               = "karpenter-cluster"
+  kubernetes_version = "1.34"
 
   # MNG for system pods (Karpenter controller runs here)
   eks_managed_node_groups = {
@@ -321,7 +321,7 @@ module "eks" {
     "karpenter.sh/discovery" = "karpenter-cluster"
   }
 
-  cluster_addons = {
+  addons = {
     coredns                = {}
     eks-pod-identity-agent = {}
     kube-proxy             = {}
@@ -334,8 +334,6 @@ module "karpenter" {
   source = "terraform-aws-modules/eks/aws//modules/karpenter"
 
   cluster_name          = module.eks.cluster_name
-  enable_pod_identity   = true
-  create_pod_identity_association = true
 
   node_iam_role_additional_policies = {
     AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
@@ -397,8 +395,8 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 21.0"
 
-  cluster_name    = "hybrid-cluster"
-  cluster_version = "1.33"
+  name               = "hybrid-cluster"
+  kubernetes_version = "1.34"
 
   # Enable hybrid node support
   remote_network_config = {
@@ -591,8 +589,8 @@ VPC (3 AZs)
 module "eks" {
   source = "terraform-aws-modules/eks/aws"
 
-  cluster_endpoint_public_access  = false
-  cluster_endpoint_private_access = true
+  endpoint_public_access  = false
+  endpoint_private_access = true
 
   # MNG for system pods
   eks_managed_node_groups = {

--- a/skills/eks-best-practices/references/terraform-examples.md
+++ b/skills/eks-best-practices/references/terraform-examples.md
@@ -511,7 +511,8 @@ module "vpc" {
 ### Standard Add-on Block
 
 ```hcl
-cluster_addons = {
+# v21 (terraform-aws-modules/eks ~> 21.0): the argument is `addons` — it was `cluster_addons` in v20.
+addons = {
   coredns = {
     most_recent = true
   }


### PR DESCRIPTION
## Summary

A whole-skill currency pass over `eks-best-practices`, verifying consequential claims against live AWS documentation, upstream source code, and empirical checks (as of 2026-08-05), plus a set of targeted content enrichments. 17 source files + regenerated website mirrors.

### Corrections (highlights)

- **EKS control-plane version rollback** (launched 2026-07): corrected 4 sites that claimed CP rollback is impossible; decision tables no longer steer to blue-green solely for rollback capability. [Docs](https://docs.aws.amazon.com/eks/latest/userguide/rollback-cluster.html)
- **Removed fabricated identifiers**: a nonexistent `karpenter.sh/voluntary-disruption` annotation, incorrect GuardDuty runtime finding names, a nonexistent `aws-for-fluent-bit` EKS add-on, `kubectl version --short` (removed in 1.28), and invented ECR pull-time-exclusion semantics.
- **Terraform examples**: updated all `terraform-aws-eks` examples to v21 argument names (`name`, `kubernetes_version`, `addons`, endpoint args) — previously every example failed `terraform validate` against `~> 21.0`; now empirically validated. [Upgrade guide](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-21.0.md)
- **Extended support**: corrected scope (CP security patches + VPC CNI/kube-proxy/CoreDNS + EKS AMI patches, per the [EKS FAQ](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)) and surfaced the extended-support pricing tier as a first-class cost lever.
- **App Mesh EOS (2026-09-30)**: removed remaining recommendations; **X-Ray SDK maintenance mode** and **Container Insights pricing model** corrected.
- **Envelope encryption**: default on ≥1.28 covers all Kubernetes API data (not "secrets only"); CMK association framed as key-control layering. [Docs](https://docs.aws.amazon.com/eks/latest/userguide/envelope-encryption.html)
- **Karpenter equal-weight NodePool tie-break**: replaced "randomly chooses" with the actual deterministic ordering (weight desc; on ties, lexicographically-later name first, per `OrderByWeight` in kubernetes-sigs/karpenter).
- **EKS managed-field drift handling**: presents both documented behaviors (BPG ~15-min overwrite; add-on create/update conflict resolution).
- **AWS Load Balancer Controller v3**: Gateway API CRD install documented as the manual Action-Required step it is.

### Enrichments

- **Karpenter disruption budgets**: `reasons`-scoped budgets, a 3-budget business-hours freeze pattern (UTC cron noted), NodePool `terminationGracePeriod` v1 semantics, and a consolidation-stabilization playbook.
- **Shared-subnet / RAM-shared-VPC IP exhaustion** path and constraints.
- **NLB weighted target-group cutover** for cluster migration (GA 2025-11-19).
- **CUSTOMER_ROUTED control-plane egress** with a pre-switch checklist (one-way switch; DNS + IPv6 prerequisites). [Docs](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-egress.html)
- **Failed-open webhook audit monitoring** pattern.

### Verification

- Every correction is grounded in a cited live source; time-sensitive and absence claims carry "as of" dates.
- Terraform examples pass `terraform validate` against module v21.
- `validate-frontmatter.py` clean; website mirrors regenerated via the standard generators; eval assertions untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)