### PR TITLE
fix(eks-cost-intelligence): drop invalid namespace="all" from list_k8s_resources calls

### DIFF
--- a/misc/website/docs/skills/eks/eks-cost-intelligence/references/compute-efficiency.md
+++ b/misc/website/docs/skills/eks/eks-cost-intelligence/references/compute-efficiency.md
@@ -607,8 +607,7 @@ kubectl get pods --all-namespaces -o json | \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Pod",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 # Filter results for containers where resources.requests is null/empty
 ```

--- a/misc/website/docs/skills/eks/eks-cost-intelligence/references/cost-data-collection.md
+++ b/misc/website/docs/skills/eks/eks-cost-intelligence/references/cost-data-collection.md
@@ -653,8 +653,7 @@ aws logs start-query \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Deployment",
-  api_version="apps/v1",
-  namespace="all"
+  api_version="apps/v1"
 )
 ```
 
@@ -745,8 +744,7 @@ for deploy in deployments.items:
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="PersistentVolumeClaim",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 ```
 
@@ -830,8 +828,7 @@ for pvc in pvcs.items:
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Service",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 ```
 

--- a/misc/website/docs/skills/eks/eks-cost-intelligence/references/idle-resources.md
+++ b/misc/website/docs/skills/eks/eks-cost-intelligence/references/idle-resources.md
@@ -110,8 +110,7 @@ kubectl get deployments --all-namespaces -o json | \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Deployment",
-  api_version="apps/v1",
-  namespace="all"
+  api_version="apps/v1"
 )
 # Filter results for spec.replicas == 0
 # Check status.conditions[].lastTransitionTime for idle duration
@@ -275,8 +274,7 @@ aws elb describe-load-balancers --query 'LoadBalancerDescriptions[*].{
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Service",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 # Filter for spec.type == "LoadBalancer"
 # Then check endpoints for each:
@@ -575,8 +573,7 @@ kubectl get pods --all-namespaces -o json | \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Pod",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 # Parse spec.volumes, spec.containers[].envFrom, spec.containers[].env[].valueFrom
 # to build set of referenced ConfigMaps and Secrets

--- a/misc/website/docs/skills/eks/eks-cost-intelligence/references/networking-costs.md
+++ b/misc/website/docs/skills/eks/eks-cost-intelligence/references/networking-costs.md
@@ -122,8 +122,7 @@ kubectl get endpoints --all-namespaces -o json | \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Service",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 # Filter for services missing topology-mode annotation
 # Then check EndpointSlices for zone distribution:
@@ -280,16 +279,14 @@ aws elbv2 describe-target-health \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Ingress",
-  api_version="networking.k8s.io/v1",
-  namespace="all"
+  api_version="networking.k8s.io/v1"
 )
 # Check annotations for alb.ingress.kubernetes.io/target-type
 
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Service",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 # Filter type=LoadBalancer, check target-type annotations
 ```
@@ -683,8 +680,7 @@ aws cloudwatch get-metric-data \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="EndpointSlice",
-  api_version="discovery.k8s.io/v1",
-  namespace="all"
+  api_version="discovery.k8s.io/v1"
 )
 # Analyze zone distribution across endpoints
 

--- a/misc/website/docs/skills/eks/eks-cost-intelligence/references/observability-costs.md
+++ b/misc/website/docs/skills/eks/eks-cost-intelligence/references/observability-costs.md
@@ -408,15 +408,13 @@ list_k8s_resources(
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="ServiceMonitor",
-  api_version="monitoring.coreos.com/v1",
-  namespace="all"
+  api_version="monitoring.coreos.com/v1"
 )
 
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="PodMonitor",
-  api_version="monitoring.coreos.com/v1",
-  namespace="all"
+  api_version="monitoring.coreos.com/v1"
 )
 ```
 
@@ -636,8 +634,7 @@ kubectl get deployments --all-namespaces -o json | \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Deployment",
-  api_version="apps/v1",
-  namespace="all"
+  api_version="apps/v1"
 )
 # Parse containers[].env for LOG_LEVEL=debug/trace patterns
 # Parse containers[].args for --debug/--verbose/--trace flags
@@ -830,8 +827,7 @@ kubectl get ds -A -l app.kubernetes.io/name=adot-collector --no-headers 2>/dev/n
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="DaemonSet",
-  api_version="apps/v1",
-  namespace="all"
+  api_version="apps/v1"
 )
 # Filter for fluent-bit, fluentd, cloudwatch-agent, adot-collector
 

--- a/misc/website/docs/skills/eks/eks-cost-intelligence/references/spot-graviton-adoption.md
+++ b/misc/website/docs/skills/eks/eks-cost-intelligence/references/spot-graviton-adoption.md
@@ -353,8 +353,7 @@ kubectl get deployments,statefulsets --all-namespaces -o json | \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Deployment",
-  api_version="apps/v1",
-  namespace="all"
+  api_version="apps/v1"
 )
 # Filter for spec.template.spec.nodeSelector["kubernetes.io/arch"] == "amd64"
 # or nodeAffinity expressions restricting to amd64
@@ -362,8 +361,7 @@ list_k8s_resources(
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="StatefulSet",
-  api_version="apps/v1",
-  namespace="all"
+  api_version="apps/v1"
 )
 # Same filtering logic
 ```
@@ -647,15 +645,13 @@ kubectl get nodes -o json | \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Deployment",
-  api_version="apps/v1",
-  namespace="all"
+  api_version="apps/v1"
 )
 
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="PodDisruptionBudget",
-  api_version="policy/v1",
-  namespace="all"
+  api_version="policy/v1"
 )
 
 list_k8s_resources(

--- a/misc/website/docs/skills/eks/eks-cost-intelligence/references/storage-costs.md
+++ b/misc/website/docs/skills/eks/eks-cost-intelligence/references/storage-costs.md
@@ -122,8 +122,7 @@ aws ec2 describe-volumes \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="PersistentVolumeClaim",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 # Filter results for storageClassName == "gp2"
 
@@ -291,16 +290,14 @@ comm -23 \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="PersistentVolumeClaim",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 
 # Step 2: Get all running pods to check volume mounts
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Pod",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 # Cross-reference: find PVCs in Bound state not referenced by any running pod's spec.volumes
 ```

--- a/skills/eks-cost-intelligence/references/compute-efficiency.md
+++ b/skills/eks-cost-intelligence/references/compute-efficiency.md
@@ -596,8 +596,7 @@ kubectl get pods --all-namespaces -o json | \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Pod",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 # Filter results for containers where resources.requests is null/empty
 ```

--- a/skills/eks-cost-intelligence/references/cost-data-collection.md
+++ b/skills/eks-cost-intelligence/references/cost-data-collection.md
@@ -642,8 +642,7 @@ aws logs start-query \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Deployment",
-  api_version="apps/v1",
-  namespace="all"
+  api_version="apps/v1"
 )
 ```
 
@@ -734,8 +733,7 @@ for deploy in deployments.items:
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="PersistentVolumeClaim",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 ```
 
@@ -819,8 +817,7 @@ for pvc in pvcs.items:
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Service",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 ```
 

--- a/skills/eks-cost-intelligence/references/idle-resources.md
+++ b/skills/eks-cost-intelligence/references/idle-resources.md
@@ -99,8 +99,7 @@ kubectl get deployments --all-namespaces -o json | \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Deployment",
-  api_version="apps/v1",
-  namespace="all"
+  api_version="apps/v1"
 )
 # Filter results for spec.replicas == 0
 # Check status.conditions[].lastTransitionTime for idle duration
@@ -264,8 +263,7 @@ aws elb describe-load-balancers --query 'LoadBalancerDescriptions[*].{
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Service",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 # Filter for spec.type == "LoadBalancer"
 # Then check endpoints for each:
@@ -564,8 +562,7 @@ kubectl get pods --all-namespaces -o json | \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Pod",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 # Parse spec.volumes, spec.containers[].envFrom, spec.containers[].env[].valueFrom
 # to build set of referenced ConfigMaps and Secrets

--- a/skills/eks-cost-intelligence/references/networking-costs.md
+++ b/skills/eks-cost-intelligence/references/networking-costs.md
@@ -111,8 +111,7 @@ kubectl get endpoints --all-namespaces -o json | \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Service",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 # Filter for services missing topology-mode annotation
 # Then check EndpointSlices for zone distribution:
@@ -269,16 +268,14 @@ aws elbv2 describe-target-health \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Ingress",
-  api_version="networking.k8s.io/v1",
-  namespace="all"
+  api_version="networking.k8s.io/v1"
 )
 # Check annotations for alb.ingress.kubernetes.io/target-type
 
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Service",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 # Filter type=LoadBalancer, check target-type annotations
 ```
@@ -672,8 +669,7 @@ aws cloudwatch get-metric-data \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="EndpointSlice",
-  api_version="discovery.k8s.io/v1",
-  namespace="all"
+  api_version="discovery.k8s.io/v1"
 )
 # Analyze zone distribution across endpoints
 

--- a/skills/eks-cost-intelligence/references/observability-costs.md
+++ b/skills/eks-cost-intelligence/references/observability-costs.md
@@ -397,15 +397,13 @@ list_k8s_resources(
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="ServiceMonitor",
-  api_version="monitoring.coreos.com/v1",
-  namespace="all"
+  api_version="monitoring.coreos.com/v1"
 )
 
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="PodMonitor",
-  api_version="monitoring.coreos.com/v1",
-  namespace="all"
+  api_version="monitoring.coreos.com/v1"
 )
 ```
 
@@ -625,8 +623,7 @@ kubectl get deployments --all-namespaces -o json | \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Deployment",
-  api_version="apps/v1",
-  namespace="all"
+  api_version="apps/v1"
 )
 # Parse containers[].env for LOG_LEVEL=debug/trace patterns
 # Parse containers[].args for --debug/--verbose/--trace flags
@@ -819,8 +816,7 @@ kubectl get ds -A -l app.kubernetes.io/name=adot-collector --no-headers 2>/dev/n
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="DaemonSet",
-  api_version="apps/v1",
-  namespace="all"
+  api_version="apps/v1"
 )
 # Filter for fluent-bit, fluentd, cloudwatch-agent, adot-collector
 

--- a/skills/eks-cost-intelligence/references/spot-graviton-adoption.md
+++ b/skills/eks-cost-intelligence/references/spot-graviton-adoption.md
@@ -342,8 +342,7 @@ kubectl get deployments,statefulsets --all-namespaces -o json | \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Deployment",
-  api_version="apps/v1",
-  namespace="all"
+  api_version="apps/v1"
 )
 # Filter for spec.template.spec.nodeSelector["kubernetes.io/arch"] == "amd64"
 # or nodeAffinity expressions restricting to amd64
@@ -351,8 +350,7 @@ list_k8s_resources(
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="StatefulSet",
-  api_version="apps/v1",
-  namespace="all"
+  api_version="apps/v1"
 )
 # Same filtering logic
 ```
@@ -636,15 +634,13 @@ kubectl get nodes -o json | \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Deployment",
-  api_version="apps/v1",
-  namespace="all"
+  api_version="apps/v1"
 )
 
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="PodDisruptionBudget",
-  api_version="policy/v1",
-  namespace="all"
+  api_version="policy/v1"
 )
 
 list_k8s_resources(

--- a/skills/eks-cost-intelligence/references/storage-costs.md
+++ b/skills/eks-cost-intelligence/references/storage-costs.md
@@ -111,8 +111,7 @@ aws ec2 describe-volumes \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="PersistentVolumeClaim",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 # Filter results for storageClassName == "gp2"
 
@@ -280,16 +279,14 @@ comm -23 \
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="PersistentVolumeClaim",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 
 # Step 2: Get all running pods to check volume mounts
 list_k8s_resources(
   cluster_name="<cluster>",
   kind="Pod",
-  api_version="v1",
-  namespace="all"
+  api_version="v1"
 )
 # Cross-reference: find PVCs in Bound state not referenced by any running pod's spec.volumes
 ```


### PR DESCRIPTION
## Summary
`list_k8s_resources` treats `namespace="all"` as a literal namespace named "all", which matches nothing and **silently returns zero resources**. The correct idiom is to omit the `namespace` argument, which lists across all namespaces.

This removes the invalid `namespace="all"` literal from all 22 `list_k8s_resources(...)` discovery calls in `eks-cost-intelligence` (7 reference files) and regenerates the Docusaurus website mirrors.

## Why it matters
Each affected discovery call silently saw zero resources, breaking the cost analysis paths that depend on it (idle detection, Spot/Graviton adoption, storage, networking, observability, compute efficiency).

## Verification
- Reproduced live against an EKS cluster: `list_k8s_resources(..., namespace="all")` returns count 0; omitting `namespace` returns resources across all namespaces.
- grep confirms zero remaining `namespace="all"` in source and website mirrors; `list_k8s_resources(` call count unchanged (44, none dropped).
- `misc/update-pages.sh --check` passes.
- `eks-recon` already uses the correct pattern and is unchanged.

This is the final actionable residual of the EKS-MCP AWS-hosted alignment.

Closes #182