### PR TITLE
fix(eks-recon): drive by_namespace rollup, kube-* null counts, unhealthy_pod_eviction_policy (#192)

### DIFF
--- a/devops-agent/eks-recon/references/workloads.md
+++ b/devops-agent/eks-recon/references/workloads.md
@@ -294,11 +294,10 @@ Eviction API currently permits for the pods this PDB selects. `0` means it curre
 voluntary eviction of covered healthy pods, which can stall a drain of the nodes hosting them
 (a PDB selecting zero pods also reports `0`). **Always** record `spec.unhealthyPodEvictionPolicy`
 (→ `unhealthy_pod_eviction_policy`) — it governs whether running-but-not-ready (unhealthy)
-covered pods can be evicted, judged by whether the budget is currently met
-(`currentHealthy >= desiredHealthy`), independent of the `disruptions_allowed` counter
+covered pods can be evicted, independent of the `disruptions_allowed` counter
 (`AlwaysAllow` = evict such pods regardless of budget health; `IfHealthyBudget`, the unset
-default, = only while `currentHealthy >= desiredHealthy`) — this is what lets a drain make
-progress when a covered workload is unhealthy. Emit the value verbatim; use `null` only when
+default, = only while the budget is met, `currentHealthy >= desiredHealthy`) — this is what
+lets a drain make progress when a covered workload is unhealthy. Emit the value verbatim; use `null` only when
 the field is genuinely unset — never drop the key.
 
 **Via Kubernetes API** — list PDBs across all namespaces (VERIFIED live: PDBs expose
@@ -499,7 +498,8 @@ Per-Namespace Rollup step drives `by_namespace`).
 
 ```yaml
 workloads:
-  summary:
+  summary:                         # agent rolls these up from the per-type section counts above;
+                                   # namespaces_with_workloads = distinct namespaces across those lists
     deployments: int               # kube-*-scoped total (§1 excludes kube-*); a true 0 is a valid fact
     statefulsets: int
     daemonsets: int

--- a/devops-agent/eks-recon/references/workloads.md
+++ b/devops-agent/eks-recon/references/workloads.md
@@ -293,10 +293,13 @@ Also record `status.disruptionsAllowed` — the point-in-time count of voluntary
 Eviction API currently permits for the pods this PDB selects. `0` means it currently rejects
 voluntary eviction of covered healthy pods, which can stall a drain of the nodes hosting them
 (a PDB selecting zero pods also reports `0`). **Always** record `spec.unhealthyPodEvictionPolicy`
-(→ `unhealthy_pod_eviction_policy`) — it governs whether unhealthy covered pods are evictable
-while `disruptions_allowed` is `0` (`AlwaysAllow` = evict regardless of budget health;
-`IfHealthyBudget`, the unset default, = only once the budget is healthy). Emit the value
-verbatim; use `null` only when the field is genuinely unset — never drop the key.
+(→ `unhealthy_pod_eviction_policy`) — it governs whether running-but-not-ready (unhealthy)
+covered pods can be evicted, judged by whether the budget is currently met
+(`currentHealthy >= desiredHealthy`), independent of the `disruptions_allowed` counter
+(`AlwaysAllow` = evict such pods regardless of budget health; `IfHealthyBudget`, the unset
+default, = only while `currentHealthy >= desiredHealthy`) — this is what lets a drain make
+progress when a covered workload is unhealthy. Emit the value verbatim; use `null` only when
+the field is genuinely unset — never drop the key.
 
 **Via Kubernetes API** — list PDBs across all namespaces (VERIFIED live: PDBs expose
 MIN AVAILABLE / MAX UNAVAILABLE):
@@ -451,7 +454,8 @@ Ingresses, HPAs, and PDBs per namespace.
 `deployments` and `services` are `null` for `kube-*` namespaces — their §1/§5 listings scope
 `kube-*` out, so a count here would not be corroborated by the detailed lists (`null` ≠ `0`:
 `null` = column scoped out for that row). `statefulsets`, `ingresses`, `hpas`, and `pdbs`
-include `kube-*`. A namespace row exists wherever any column has a count, so rows may be partial.
+include `kube-*`. A row exists for any namespace containing at least one of the six workload
+types, so rows may be partial.
 
 *Reference pseudocode (agent-side aggregation), not executable:*
 ```python
@@ -473,8 +477,8 @@ for ns in sorted(namespaces_with_any_workload):
 **Example output:**
 ```json
 [
-  {"namespace": "production", "deployments": 8, "statefulsets": 2, "services": 5, "ingresses": 1, "hpas": 3, "pdbs": 2},
-  {"namespace": "kube-system", "deployments": null, "statefulsets": 0, "services": null, "ingresses": 0, "hpas": 0, "pdbs": 1}
+  {"namespace": "kube-system", "deployments": null, "statefulsets": 0, "services": null, "ingresses": 0, "hpas": 0, "pdbs": 1},
+  {"namespace": "production", "deployments": 8, "statefulsets": 2, "services": 5, "ingresses": 1, "hpas": 3, "pdbs": 2}
 ]
 ```
 
@@ -509,8 +513,8 @@ workloads:
 
   # kube-* scope split across these columns: ONLY deployments and services exclude kube-*
   # namespaces (their §1/§5 listings filter kube-* out). statefulsets, ingresses, hpas, and pdbs
-  # INCLUDE kube-* (their listings apply no namespace filter). A namespace row exists wherever ANY
-  # column has a count, so rows may be partial. For a scoped-out column emit `null`, NOT 0 (schema
+  # INCLUDE kube-* (their listings apply no namespace filter). A row exists wherever ANY of the six
+  # workload types is present, so rows may be partial. For a scoped-out column emit `null`, NOT 0 (schema
   # header rule: null = fact not detected/collected) — e.g. a kube-system row shows `null` for
   # deployments and services (column scoped out, not "zero found"; kube-system always runs CoreDNS
   # Deployments + kube-dns Services) but real counts for statefulsets/ingresses/hpas/pdbs.

--- a/devops-agent/eks-recon/references/workloads.md
+++ b/devops-agent/eks-recon/references/workloads.md
@@ -24,6 +24,7 @@
   - [Vertical Pod Autoscalers](#10-vertical-pod-autoscalers)
   - [API Versions In Use](#11-api-versions-in-use)
 - [Summary Statistics](#summary-statistics)
+  - [Per-Namespace Rollup](#per-namespace-rollup)
 - [Output Schema](#output-schema)
 - [Additional Fact Collection](#additional-fact-collection)
   - [Pod Phase and Replica Counts](#pod-phase-and-replica-counts)
@@ -291,8 +292,11 @@ availability guarantee for the pods matched by its selector. Record existence, t
 Also record `status.disruptionsAllowed` — the point-in-time count of voluntary evictions the
 Eviction API currently permits for the pods this PDB selects. `0` means it currently rejects
 voluntary eviction of covered healthy pods, which can stall a drain of the nodes hosting them
-(a PDB selecting zero pods also reports `0`). Record `spec.unhealthyPodEvictionPolicy` too — it
-governs whether unhealthy covered pods are evictable at `0`.
+(a PDB selecting zero pods also reports `0`). **Always** record `spec.unhealthyPodEvictionPolicy`
+(→ `unhealthy_pod_eviction_policy`) — it governs whether unhealthy covered pods are evictable
+while `disruptions_allowed` is `0` (`AlwaysAllow` = evict regardless of budget health;
+`IfHealthyBudget`, the unset default, = only once the budget is healthy). Emit the value
+verbatim; use `null` only when the field is genuinely unset — never drop the key.
 
 **Via Kubernetes API** — list PDBs across all namespaces (VERIFIED live: PDBs expose
 MIN AVAILABLE / MAX UNAVAILABLE):
@@ -315,7 +319,7 @@ selector-only PDB). The `selector` matchLabels identify the covered workloads.
   "min_available": 1,
   "max_unavailable": null,
   "disruptions_allowed": 2,
-  "unhealthy_pod_eviction_policy": null,
+  "unhealthy_pod_eviction_policy": "AlwaysAllow",
   "selector": {"app": "api-gateway"}
 }
 ```
@@ -435,6 +439,45 @@ objects and counts per `kind`.
 ]
 ```
 
+### Per-Namespace Rollup
+
+Aggregate the per-type listings collected above into the `by_namespace` schema block — one
+row per namespace, with a count column per workload type. Do this explicitly: the schema
+advertises per-namespace `hpas`/`pdbs` counts and the `deployments`/`services` kube-* handling,
+but no other step produces them, so on a complete run they are otherwise dropped. Roll up from
+the already-collected lists (no additional read) — count Deployments, StatefulSets, Services,
+Ingresses, HPAs, and PDBs per namespace.
+
+`deployments` and `services` are `null` for `kube-*` namespaces — their §1/§5 listings scope
+`kube-*` out, so a count here would not be corroborated by the detailed lists (`null` ≠ `0`:
+`null` = column scoped out for that row). `statefulsets`, `ingresses`, `hpas`, and `pdbs`
+include `kube-*`. A namespace row exists wherever any column has a count, so rows may be partial.
+
+*Reference pseudocode (agent-side aggregation), not executable:*
+```python
+# Roll the already-collected per-type lists up into by_namespace rows.
+by_namespace = []
+for ns in sorted(namespaces_with_any_workload):
+    sys = ns.startswith("kube-")
+    by_namespace.append({
+        "namespace": ns,
+        "deployments": None if sys else count(deployments, ns),   # §1 scopes kube-* out
+        "statefulsets": count(statefulsets, ns),
+        "services": None if sys else count(services, ns),          # §5 scopes kube-* out
+        "ingresses": count(ingresses, ns),
+        "hpas": count(hpas, ns),
+        "pdbs": count(pdbs, ns),
+    })
+```
+
+**Example output:**
+```json
+[
+  {"namespace": "production", "deployments": 8, "statefulsets": 2, "services": 5, "ingresses": 1, "hpas": 3, "pdbs": 2},
+  {"namespace": "kube-system", "deployments": null, "statefulsets": 0, "services": null, "ingresses": 0, "hpas": 0, "pdbs": 1}
+]
+```
+
 ---
 
 ## Output Schema
@@ -442,7 +485,10 @@ objects and counts per `kind`.
 This is the **single canonical schema** for the workloads module — it carries every
 workloads fact. The `workloads-recon` agent emits exactly this shape (plus the shared
 `cluster:` block from `references/cluster-basics.md`). Use `null` where a fact was not
-detected; never omit a key. Aggregate containers use the `{count, list}` wrapper.
+detected; never omit a key. Aggregate containers use the `{count, list}` wrapper. Every key
+must trace to a collection step above — including derived/rolled-up keys (`summary`,
+`by_namespace`, `services.by_type`); a schema key with no driving step is a defect (the
+Per-Namespace Rollup step drives `by_namespace`).
 
 > **PVCs are owned by the storage module.** This schema does not carry a `storage.pvcs`
 > block — see the storage module for PVC inventory (status, storage class, capacity).
@@ -474,8 +520,8 @@ workloads:
       statefulsets: int
       services: int|null             # null for kube-* rows: §5 scopes kube-* out, so not counted here (never 0)
       ingresses: int
-      hpas: int                    # per-namespace HPA count (rolled up from the hpas.list below)
-      pdbs: int                    # per-namespace PDB count (rolled up from the pdbs.list below)
+      hpas: int                    # per-namespace HPA count (from the Per-Namespace Rollup step)
+      pdbs: int                    # per-namespace PDB count (from the Per-Namespace Rollup step)
 
   deployments:
     count: int

--- a/misc/website/docs/devops-agent/eks-recon/references/workloads.md
+++ b/misc/website/docs/devops-agent/eks-recon/references/workloads.md
@@ -305,11 +305,10 @@ Eviction API currently permits for the pods this PDB selects. `0` means it curre
 voluntary eviction of covered healthy pods, which can stall a drain of the nodes hosting them
 (a PDB selecting zero pods also reports `0`). **Always** record `spec.unhealthyPodEvictionPolicy`
 (→ `unhealthy_pod_eviction_policy`) — it governs whether running-but-not-ready (unhealthy)
-covered pods can be evicted, judged by whether the budget is currently met
-(`currentHealthy >= desiredHealthy`), independent of the `disruptions_allowed` counter
+covered pods can be evicted, independent of the `disruptions_allowed` counter
 (`AlwaysAllow` = evict such pods regardless of budget health; `IfHealthyBudget`, the unset
-default, = only while `currentHealthy >= desiredHealthy`) — this is what lets a drain make
-progress when a covered workload is unhealthy. Emit the value verbatim; use `null` only when
+default, = only while the budget is met, `currentHealthy >= desiredHealthy`) — this is what
+lets a drain make progress when a covered workload is unhealthy. Emit the value verbatim; use `null` only when
 the field is genuinely unset — never drop the key.
 
 **Via Kubernetes API** — list PDBs across all namespaces (VERIFIED live: PDBs expose
@@ -510,7 +509,8 @@ Per-Namespace Rollup step drives `by_namespace`).
 
 ```yaml
 workloads:
-  summary:
+  summary:                         # agent rolls these up from the per-type section counts above;
+                                   # namespaces_with_workloads = distinct namespaces across those lists
     deployments: int               # kube-*-scoped total (§1 excludes kube-*); a true 0 is a valid fact
     statefulsets: int
     daemonsets: int

--- a/misc/website/docs/devops-agent/eks-recon/references/workloads.md
+++ b/misc/website/docs/devops-agent/eks-recon/references/workloads.md
@@ -304,10 +304,13 @@ Also record `status.disruptionsAllowed` — the point-in-time count of voluntary
 Eviction API currently permits for the pods this PDB selects. `0` means it currently rejects
 voluntary eviction of covered healthy pods, which can stall a drain of the nodes hosting them
 (a PDB selecting zero pods also reports `0`). **Always** record `spec.unhealthyPodEvictionPolicy`
-(→ `unhealthy_pod_eviction_policy`) — it governs whether unhealthy covered pods are evictable
-while `disruptions_allowed` is `0` (`AlwaysAllow` = evict regardless of budget health;
-`IfHealthyBudget`, the unset default, = only once the budget is healthy). Emit the value
-verbatim; use `null` only when the field is genuinely unset — never drop the key.
+(→ `unhealthy_pod_eviction_policy`) — it governs whether running-but-not-ready (unhealthy)
+covered pods can be evicted, judged by whether the budget is currently met
+(`currentHealthy >= desiredHealthy`), independent of the `disruptions_allowed` counter
+(`AlwaysAllow` = evict such pods regardless of budget health; `IfHealthyBudget`, the unset
+default, = only while `currentHealthy >= desiredHealthy`) — this is what lets a drain make
+progress when a covered workload is unhealthy. Emit the value verbatim; use `null` only when
+the field is genuinely unset — never drop the key.
 
 **Via Kubernetes API** — list PDBs across all namespaces (VERIFIED live: PDBs expose
 MIN AVAILABLE / MAX UNAVAILABLE):
@@ -462,7 +465,8 @@ Ingresses, HPAs, and PDBs per namespace.
 `deployments` and `services` are `null` for `kube-*` namespaces — their §1/§5 listings scope
 `kube-*` out, so a count here would not be corroborated by the detailed lists (`null` ≠ `0`:
 `null` = column scoped out for that row). `statefulsets`, `ingresses`, `hpas`, and `pdbs`
-include `kube-*`. A namespace row exists wherever any column has a count, so rows may be partial.
+include `kube-*`. A row exists for any namespace containing at least one of the six workload
+types, so rows may be partial.
 
 *Reference pseudocode (agent-side aggregation), not executable:*
 ```python
@@ -484,8 +488,8 @@ for ns in sorted(namespaces_with_any_workload):
 **Example output:**
 ```json
 [
-  {"namespace": "production", "deployments": 8, "statefulsets": 2, "services": 5, "ingresses": 1, "hpas": 3, "pdbs": 2},
-  {"namespace": "kube-system", "deployments": null, "statefulsets": 0, "services": null, "ingresses": 0, "hpas": 0, "pdbs": 1}
+  {"namespace": "kube-system", "deployments": null, "statefulsets": 0, "services": null, "ingresses": 0, "hpas": 0, "pdbs": 1},
+  {"namespace": "production", "deployments": 8, "statefulsets": 2, "services": 5, "ingresses": 1, "hpas": 3, "pdbs": 2}
 ]
 ```
 
@@ -520,8 +524,8 @@ workloads:
 
   # kube-* scope split across these columns: ONLY deployments and services exclude kube-*
   # namespaces (their §1/§5 listings filter kube-* out). statefulsets, ingresses, hpas, and pdbs
-  # INCLUDE kube-* (their listings apply no namespace filter). A namespace row exists wherever ANY
-  # column has a count, so rows may be partial. For a scoped-out column emit `null`, NOT 0 (schema
+  # INCLUDE kube-* (their listings apply no namespace filter). A row exists wherever ANY of the six
+  # workload types is present, so rows may be partial. For a scoped-out column emit `null`, NOT 0 (schema
   # header rule: null = fact not detected/collected) — e.g. a kube-system row shows `null` for
   # deployments and services (column scoped out, not "zero found"; kube-system always runs CoreDNS
   # Deployments + kube-dns Services) but real counts for statefulsets/ingresses/hpas/pdbs.

--- a/misc/website/docs/devops-agent/eks-recon/references/workloads.md
+++ b/misc/website/docs/devops-agent/eks-recon/references/workloads.md
@@ -35,6 +35,7 @@ This page is generated from [devops-agent/eks-recon/references/workloads.md](htt
   - [Vertical Pod Autoscalers](#10-vertical-pod-autoscalers)
   - [API Versions In Use](#11-api-versions-in-use)
 - [Summary Statistics](#summary-statistics)
+  - [Per-Namespace Rollup](#per-namespace-rollup)
 - [Output Schema](#output-schema)
 - [Additional Fact Collection](#additional-fact-collection)
   - [Pod Phase and Replica Counts](#pod-phase-and-replica-counts)
@@ -302,8 +303,11 @@ availability guarantee for the pods matched by its selector. Record existence, t
 Also record `status.disruptionsAllowed` — the point-in-time count of voluntary evictions the
 Eviction API currently permits for the pods this PDB selects. `0` means it currently rejects
 voluntary eviction of covered healthy pods, which can stall a drain of the nodes hosting them
-(a PDB selecting zero pods also reports `0`). Record `spec.unhealthyPodEvictionPolicy` too — it
-governs whether unhealthy covered pods are evictable at `0`.
+(a PDB selecting zero pods also reports `0`). **Always** record `spec.unhealthyPodEvictionPolicy`
+(→ `unhealthy_pod_eviction_policy`) — it governs whether unhealthy covered pods are evictable
+while `disruptions_allowed` is `0` (`AlwaysAllow` = evict regardless of budget health;
+`IfHealthyBudget`, the unset default, = only once the budget is healthy). Emit the value
+verbatim; use `null` only when the field is genuinely unset — never drop the key.
 
 **Via Kubernetes API** — list PDBs across all namespaces (VERIFIED live: PDBs expose
 MIN AVAILABLE / MAX UNAVAILABLE):
@@ -326,7 +330,7 @@ selector-only PDB). The `selector` matchLabels identify the covered workloads.
   "min_available": 1,
   "max_unavailable": null,
   "disruptions_allowed": 2,
-  "unhealthy_pod_eviction_policy": null,
+  "unhealthy_pod_eviction_policy": "AlwaysAllow",
   "selector": {"app": "api-gateway"}
 }
 ```
@@ -446,6 +450,45 @@ objects and counts per `kind`.
 ]
 ```
 
+### Per-Namespace Rollup
+
+Aggregate the per-type listings collected above into the `by_namespace` schema block — one
+row per namespace, with a count column per workload type. Do this explicitly: the schema
+advertises per-namespace `hpas`/`pdbs` counts and the `deployments`/`services` kube-* handling,
+but no other step produces them, so on a complete run they are otherwise dropped. Roll up from
+the already-collected lists (no additional read) — count Deployments, StatefulSets, Services,
+Ingresses, HPAs, and PDBs per namespace.
+
+`deployments` and `services` are `null` for `kube-*` namespaces — their §1/§5 listings scope
+`kube-*` out, so a count here would not be corroborated by the detailed lists (`null` ≠ `0`:
+`null` = column scoped out for that row). `statefulsets`, `ingresses`, `hpas`, and `pdbs`
+include `kube-*`. A namespace row exists wherever any column has a count, so rows may be partial.
+
+*Reference pseudocode (agent-side aggregation), not executable:*
+```python
+# Roll the already-collected per-type lists up into by_namespace rows.
+by_namespace = []
+for ns in sorted(namespaces_with_any_workload):
+    sys = ns.startswith("kube-")
+    by_namespace.append({
+        "namespace": ns,
+        "deployments": None if sys else count(deployments, ns),   # §1 scopes kube-* out
+        "statefulsets": count(statefulsets, ns),
+        "services": None if sys else count(services, ns),          # §5 scopes kube-* out
+        "ingresses": count(ingresses, ns),
+        "hpas": count(hpas, ns),
+        "pdbs": count(pdbs, ns),
+    })
+```
+
+**Example output:**
+```json
+[
+  {"namespace": "production", "deployments": 8, "statefulsets": 2, "services": 5, "ingresses": 1, "hpas": 3, "pdbs": 2},
+  {"namespace": "kube-system", "deployments": null, "statefulsets": 0, "services": null, "ingresses": 0, "hpas": 0, "pdbs": 1}
+]
+```
+
 ---
 
 ## Output Schema
@@ -453,7 +496,10 @@ objects and counts per `kind`.
 This is the **single canonical schema** for the workloads module — it carries every
 workloads fact. The `workloads-recon` agent emits exactly this shape (plus the shared
 `cluster:` block from `references/cluster-basics.md`). Use `null` where a fact was not
-detected; never omit a key. Aggregate containers use the `{count, list}` wrapper.
+detected; never omit a key. Aggregate containers use the `{count, list}` wrapper. Every key
+must trace to a collection step above — including derived/rolled-up keys (`summary`,
+`by_namespace`, `services.by_type`); a schema key with no driving step is a defect (the
+Per-Namespace Rollup step drives `by_namespace`).
 
 > **PVCs are owned by the storage module.** This schema does not carry a `storage.pvcs`
 > block — see the storage module for PVC inventory (status, storage class, capacity).
@@ -485,8 +531,8 @@ workloads:
       statefulsets: int
       services: int|null             # null for kube-* rows: §5 scopes kube-* out, so not counted here (never 0)
       ingresses: int
-      hpas: int                    # per-namespace HPA count (rolled up from the hpas.list below)
-      pdbs: int                    # per-namespace PDB count (rolled up from the pdbs.list below)
+      hpas: int                    # per-namespace HPA count (from the Per-Namespace Rollup step)
+      pdbs: int                    # per-namespace PDB count (from the Per-Namespace Rollup step)
 
   deployments:
     count: int

--- a/misc/website/docs/skills/eks/eks-recon/references/workloads.md
+++ b/misc/website/docs/skills/eks/eks-recon/references/workloads.md
@@ -373,10 +373,13 @@ Also record `status.disruptionsAllowed` — the point-in-time count of voluntary
 Eviction API currently permits for the pods this PDB selects. `0` means it currently rejects
 voluntary eviction of covered healthy pods, which can stall a drain of the nodes hosting them
 (a PDB selecting zero pods also reports `0`). **Always** record `spec.unhealthyPodEvictionPolicy`
-(→ `unhealthy_pod_eviction_policy`) — it governs whether unhealthy covered pods are evictable
-while `disruptions_allowed` is `0` (`AlwaysAllow` = evict regardless of budget health;
-`IfHealthyBudget`, the unset default, = only once the budget is healthy). Emit the value
-verbatim; use `null` only when the field is genuinely unset — never drop the key.
+(→ `unhealthy_pod_eviction_policy`) — it governs whether running-but-not-ready (unhealthy)
+covered pods can be evicted, judged by whether the budget is currently met
+(`currentHealthy >= desiredHealthy`), independent of the `disruptions_allowed` counter
+(`AlwaysAllow` = evict such pods regardless of budget health; `IfHealthyBudget`, the unset
+default, = only while `currentHealthy >= desiredHealthy`) — this is what lets a drain make
+progress when a covered workload is unhealthy. Emit the value verbatim; use `null` only when
+the field is genuinely unset — never drop the key.
 
 **MCP:**
 ```
@@ -547,7 +550,7 @@ kubectl get deploy,statefulsets,daemonsets,jobs -A -o json | jq -r '
 
 ### Per-Namespace Rollup
 
-Roll the per-type listings up into the `by_namespace` schema block — one row per namespace
+Populate the `by_namespace` schema block — one row per namespace
 with a count column per workload type. Run this explicitly: the schema advertises per-namespace
 `hpas`/`pdbs` counts and the `deployments`/`services` kube-* handling, but nothing above emits
 them, so on a complete run they are otherwise dropped.
@@ -579,13 +582,14 @@ kubectl get deploy,statefulset,service,ingress,hpa,pdb -A -o json | jq '
 ```
 
 A multi-type `kubectl get` tags each item with its `.kind`, so a single read covers all six
-types. A namespace row exists wherever any column has a count, so rows may be partial.
+types. A row exists for any namespace containing at least one of the six workload types, so
+rows may be partial.
 
 **Example output:**
 ```json
 [
-  {"namespace": "production", "deployments": 8, "statefulsets": 2, "services": 5, "ingresses": 1, "hpas": 3, "pdbs": 2},
-  {"namespace": "kube-system", "deployments": null, "statefulsets": 0, "services": null, "ingresses": 0, "hpas": 0, "pdbs": 1}
+  {"namespace": "kube-system", "deployments": null, "statefulsets": 0, "services": null, "ingresses": 0, "hpas": 0, "pdbs": 1},
+  {"namespace": "production", "deployments": 8, "statefulsets": 2, "services": 5, "ingresses": 1, "hpas": 3, "pdbs": 2}
 ]
 ```
 
@@ -620,8 +624,8 @@ workloads:
 
   # kube-* scope split across these columns: ONLY deployments and services exclude kube-*
   # namespaces (their §1/§5 jq blocks filter kube-* out). statefulsets, ingresses, hpas, and pdbs
-  # INCLUDE kube-* (their listings apply no namespace filter). A namespace row exists wherever ANY
-  # column has a count, so rows may be partial. For a scoped-out column emit `null`, NOT 0 (schema
+  # INCLUDE kube-* (their listings apply no namespace filter). A row exists wherever ANY of the six
+  # workload types is present, so rows may be partial. For a scoped-out column emit `null`, NOT 0 (schema
   # header rule: null = fact not detected/collected) — e.g. a kube-system row shows `null` for
   # deployments and services (column scoped out, not "zero found"; kube-system always runs CoreDNS
   # Deployments + kube-dns Services) but real counts for statefulsets/ingresses/hpas/pdbs.

--- a/misc/website/docs/skills/eks/eks-recon/references/workloads.md
+++ b/misc/website/docs/skills/eks/eks-recon/references/workloads.md
@@ -35,6 +35,7 @@ This page is generated from [skills/eks-recon/references/workloads.md](https://g
    - [List Vertical Pod Autoscalers](#10-list-vertical-pod-autoscalers)
    - [Enumerate API Versions In Use](#11-enumerate-api-versions-in-use)
 4. [Generate Summary Statistics](#generate-summary-statistics)
+   - [Per-Namespace Rollup](#per-namespace-rollup)
 5. [Output Schema](#output-schema)
 6. [Additional Fact Collection](#additional-fact-collection)
    - [Pod Phase and Replica Counts](#pod-phase-and-replica-counts)
@@ -371,8 +372,11 @@ availability guarantee for the pods matched by its selector. Record existence, t
 Also record `status.disruptionsAllowed` — the point-in-time count of voluntary evictions the
 Eviction API currently permits for the pods this PDB selects. `0` means it currently rejects
 voluntary eviction of covered healthy pods, which can stall a drain of the nodes hosting them
-(a PDB selecting zero pods also reports `0`). Record `spec.unhealthyPodEvictionPolicy` too — it
-governs whether unhealthy covered pods are evictable at `0`.
+(a PDB selecting zero pods also reports `0`). **Always** record `spec.unhealthyPodEvictionPolicy`
+(→ `unhealthy_pod_eviction_policy`) — it governs whether unhealthy covered pods are evictable
+while `disruptions_allowed` is `0` (`AlwaysAllow` = evict regardless of budget health;
+`IfHealthyBudget`, the unset default, = only once the budget is healthy). Emit the value
+verbatim; use `null` only when the field is genuinely unset — never drop the key.
 
 **MCP:**
 ```
@@ -410,7 +414,7 @@ selector-only PDB). The `selector` matchLabels identify the covered workloads.
   "min_available": 1,
   "max_unavailable": null,
   "disruptions_allowed": 2,
-  "unhealthy_pod_eviction_policy": null,
+  "unhealthy_pod_eviction_policy": "AlwaysAllow",
   "selector": {"app": "api-gateway"}
 }
 ```
@@ -541,6 +545,50 @@ kubectl get deploy,statefulsets,daemonsets,jobs -A -o json | jq -r '
 ]
 ```
 
+### Per-Namespace Rollup
+
+Roll the per-type listings up into the `by_namespace` schema block — one row per namespace
+with a count column per workload type. Run this explicitly: the schema advertises per-namespace
+`hpas`/`pdbs` counts and the `deployments`/`services` kube-* handling, but nothing above emits
+them, so on a complete run they are otherwise dropped.
+
+`deployments` and `services` are `null` for `kube-*` namespaces — their §1/§5 listings scope
+`kube-*` out, so a count here would not be corroborated by the detailed lists (`null` ≠ `0`:
+`null` = column scoped out for that row). `statefulsets`, `ingresses`, `hpas`, and `pdbs`
+include `kube-*`.
+
+```bash
+# Per-namespace rollup -> drives workloads.by_namespace (schema shape)
+kubectl get deploy,statefulset,service,ingress,hpa,pdb -A -o json | jq '
+  [.items[] | {ns: .metadata.namespace, kind: .kind}] |
+  group_by(.ns) |
+  map(
+    (.[0].ns) as $ns |
+    (map(.kind) | group_by(.) | map({key: .[0], value: length}) | from_entries) as $c |
+    ($ns | startswith("kube-")) as $sys |
+    {
+      namespace: $ns,
+      deployments: (if $sys then null else ($c.Deployment // 0) end),
+      statefulsets: ($c.StatefulSet // 0),
+      services: (if $sys then null else ($c.Service // 0) end),
+      ingresses: ($c.Ingress // 0),
+      hpas: ($c.HorizontalPodAutoscaler // 0),
+      pdbs: ($c.PodDisruptionBudget // 0)
+    }
+  )'
+```
+
+A multi-type `kubectl get` tags each item with its `.kind`, so a single read covers all six
+types. A namespace row exists wherever any column has a count, so rows may be partial.
+
+**Example output:**
+```json
+[
+  {"namespace": "production", "deployments": 8, "statefulsets": 2, "services": 5, "ingresses": 1, "hpas": 3, "pdbs": 2},
+  {"namespace": "kube-system", "deployments": null, "statefulsets": 0, "services": null, "ingresses": 0, "hpas": 0, "pdbs": 1}
+]
+```
+
 ---
 
 ## Output Schema
@@ -548,7 +596,10 @@ kubectl get deploy,statefulsets,daemonsets,jobs -A -o json | jq -r '
 This is the **single canonical schema** for the workloads module — it carries every
 workloads fact. The `workloads-recon` agent emits exactly this shape (plus the shared
 `cluster:` block from `references/cluster-basics.md`). Use `null` where a fact was not
-detected; never omit a key. Aggregate containers use the `{count, list}` wrapper.
+detected; never omit a key. Aggregate containers use the `{count, list}` wrapper. Every key
+must trace to a collection step above — including derived/rolled-up keys (`summary`,
+`by_namespace`, `services.by_type`); a schema key with no driving step is a defect (the
+Per-Namespace Rollup step drives `by_namespace`).
 
 > **PVCs are owned by the storage module.** This schema does not carry a `storage.pvcs`
 > block — see the storage module for PVC inventory (status, storage class, capacity).
@@ -580,8 +631,8 @@ workloads:
       statefulsets: int
       services: int|null             # null for kube-* rows: §5 scopes kube-* out, so not counted here (never 0)
       ingresses: int
-      hpas: int                    # per-namespace HPA count (rolled up from hpas.list)
-      pdbs: int                    # per-namespace PDB count (rolled up from pdbs.list)
+      hpas: int                    # per-namespace HPA count (from the Per-Namespace Rollup step)
+      pdbs: int                    # per-namespace PDB count (from the Per-Namespace Rollup step)
 
   deployments:
     count: int

--- a/misc/website/docs/skills/eks/eks-recon/references/workloads.md
+++ b/misc/website/docs/skills/eks/eks-recon/references/workloads.md
@@ -374,11 +374,10 @@ Eviction API currently permits for the pods this PDB selects. `0` means it curre
 voluntary eviction of covered healthy pods, which can stall a drain of the nodes hosting them
 (a PDB selecting zero pods also reports `0`). **Always** record `spec.unhealthyPodEvictionPolicy`
 (→ `unhealthy_pod_eviction_policy`) — it governs whether running-but-not-ready (unhealthy)
-covered pods can be evicted, judged by whether the budget is currently met
-(`currentHealthy >= desiredHealthy`), independent of the `disruptions_allowed` counter
+covered pods can be evicted, independent of the `disruptions_allowed` counter
 (`AlwaysAllow` = evict such pods regardless of budget health; `IfHealthyBudget`, the unset
-default, = only while `currentHealthy >= desiredHealthy`) — this is what lets a drain make
-progress when a covered workload is unhealthy. Emit the value verbatim; use `null` only when
+default, = only while the budget is met, `currentHealthy >= desiredHealthy`) — this is what
+lets a drain make progress when a covered workload is unhealthy. Emit the value verbatim; use `null` only when
 the field is genuinely unset — never drop the key.
 
 **MCP:**
@@ -610,7 +609,8 @@ Per-Namespace Rollup step drives `by_namespace`).
 
 ```yaml
 workloads:
-  summary:
+  summary:                         # agent rolls these up from the per-type section counts above;
+                                   # namespaces_with_workloads = distinct namespaces across those lists
     deployments: int               # kube-*-scoped total (§1 excludes kube-*); a true 0 is a valid fact
     statefulsets: int
     daemonsets: int

--- a/skills/eks-recon/references/workloads.md
+++ b/skills/eks-recon/references/workloads.md
@@ -363,11 +363,10 @@ Eviction API currently permits for the pods this PDB selects. `0` means it curre
 voluntary eviction of covered healthy pods, which can stall a drain of the nodes hosting them
 (a PDB selecting zero pods also reports `0`). **Always** record `spec.unhealthyPodEvictionPolicy`
 (→ `unhealthy_pod_eviction_policy`) — it governs whether running-but-not-ready (unhealthy)
-covered pods can be evicted, judged by whether the budget is currently met
-(`currentHealthy >= desiredHealthy`), independent of the `disruptions_allowed` counter
+covered pods can be evicted, independent of the `disruptions_allowed` counter
 (`AlwaysAllow` = evict such pods regardless of budget health; `IfHealthyBudget`, the unset
-default, = only while `currentHealthy >= desiredHealthy`) — this is what lets a drain make
-progress when a covered workload is unhealthy. Emit the value verbatim; use `null` only when
+default, = only while the budget is met, `currentHealthy >= desiredHealthy`) — this is what
+lets a drain make progress when a covered workload is unhealthy. Emit the value verbatim; use `null` only when
 the field is genuinely unset — never drop the key.
 
 **MCP:**
@@ -599,7 +598,8 @@ Per-Namespace Rollup step drives `by_namespace`).
 
 ```yaml
 workloads:
-  summary:
+  summary:                         # agent rolls these up from the per-type section counts above;
+                                   # namespaces_with_workloads = distinct namespaces across those lists
     deployments: int               # kube-*-scoped total (§1 excludes kube-*); a true 0 is a valid fact
     statefulsets: int
     daemonsets: int

--- a/skills/eks-recon/references/workloads.md
+++ b/skills/eks-recon/references/workloads.md
@@ -24,6 +24,7 @@
    - [List Vertical Pod Autoscalers](#10-list-vertical-pod-autoscalers)
    - [Enumerate API Versions In Use](#11-enumerate-api-versions-in-use)
 4. [Generate Summary Statistics](#generate-summary-statistics)
+   - [Per-Namespace Rollup](#per-namespace-rollup)
 5. [Output Schema](#output-schema)
 6. [Additional Fact Collection](#additional-fact-collection)
    - [Pod Phase and Replica Counts](#pod-phase-and-replica-counts)
@@ -360,8 +361,11 @@ availability guarantee for the pods matched by its selector. Record existence, t
 Also record `status.disruptionsAllowed` — the point-in-time count of voluntary evictions the
 Eviction API currently permits for the pods this PDB selects. `0` means it currently rejects
 voluntary eviction of covered healthy pods, which can stall a drain of the nodes hosting them
-(a PDB selecting zero pods also reports `0`). Record `spec.unhealthyPodEvictionPolicy` too — it
-governs whether unhealthy covered pods are evictable at `0`.
+(a PDB selecting zero pods also reports `0`). **Always** record `spec.unhealthyPodEvictionPolicy`
+(→ `unhealthy_pod_eviction_policy`) — it governs whether unhealthy covered pods are evictable
+while `disruptions_allowed` is `0` (`AlwaysAllow` = evict regardless of budget health;
+`IfHealthyBudget`, the unset default, = only once the budget is healthy). Emit the value
+verbatim; use `null` only when the field is genuinely unset — never drop the key.
 
 **MCP:**
 ```
@@ -399,7 +403,7 @@ selector-only PDB). The `selector` matchLabels identify the covered workloads.
   "min_available": 1,
   "max_unavailable": null,
   "disruptions_allowed": 2,
-  "unhealthy_pod_eviction_policy": null,
+  "unhealthy_pod_eviction_policy": "AlwaysAllow",
   "selector": {"app": "api-gateway"}
 }
 ```
@@ -530,6 +534,50 @@ kubectl get deploy,statefulsets,daemonsets,jobs -A -o json | jq -r '
 ]
 ```
 
+### Per-Namespace Rollup
+
+Roll the per-type listings up into the `by_namespace` schema block — one row per namespace
+with a count column per workload type. Run this explicitly: the schema advertises per-namespace
+`hpas`/`pdbs` counts and the `deployments`/`services` kube-* handling, but nothing above emits
+them, so on a complete run they are otherwise dropped.
+
+`deployments` and `services` are `null` for `kube-*` namespaces — their §1/§5 listings scope
+`kube-*` out, so a count here would not be corroborated by the detailed lists (`null` ≠ `0`:
+`null` = column scoped out for that row). `statefulsets`, `ingresses`, `hpas`, and `pdbs`
+include `kube-*`.
+
+```bash
+# Per-namespace rollup -> drives workloads.by_namespace (schema shape)
+kubectl get deploy,statefulset,service,ingress,hpa,pdb -A -o json | jq '
+  [.items[] | {ns: .metadata.namespace, kind: .kind}] |
+  group_by(.ns) |
+  map(
+    (.[0].ns) as $ns |
+    (map(.kind) | group_by(.) | map({key: .[0], value: length}) | from_entries) as $c |
+    ($ns | startswith("kube-")) as $sys |
+    {
+      namespace: $ns,
+      deployments: (if $sys then null else ($c.Deployment // 0) end),
+      statefulsets: ($c.StatefulSet // 0),
+      services: (if $sys then null else ($c.Service // 0) end),
+      ingresses: ($c.Ingress // 0),
+      hpas: ($c.HorizontalPodAutoscaler // 0),
+      pdbs: ($c.PodDisruptionBudget // 0)
+    }
+  )'
+```
+
+A multi-type `kubectl get` tags each item with its `.kind`, so a single read covers all six
+types. A namespace row exists wherever any column has a count, so rows may be partial.
+
+**Example output:**
+```json
+[
+  {"namespace": "production", "deployments": 8, "statefulsets": 2, "services": 5, "ingresses": 1, "hpas": 3, "pdbs": 2},
+  {"namespace": "kube-system", "deployments": null, "statefulsets": 0, "services": null, "ingresses": 0, "hpas": 0, "pdbs": 1}
+]
+```
+
 ---
 
 ## Output Schema
@@ -537,7 +585,10 @@ kubectl get deploy,statefulsets,daemonsets,jobs -A -o json | jq -r '
 This is the **single canonical schema** for the workloads module — it carries every
 workloads fact. The `workloads-recon` agent emits exactly this shape (plus the shared
 `cluster:` block from `references/cluster-basics.md`). Use `null` where a fact was not
-detected; never omit a key. Aggregate containers use the `{count, list}` wrapper.
+detected; never omit a key. Aggregate containers use the `{count, list}` wrapper. Every key
+must trace to a collection step above — including derived/rolled-up keys (`summary`,
+`by_namespace`, `services.by_type`); a schema key with no driving step is a defect (the
+Per-Namespace Rollup step drives `by_namespace`).
 
 > **PVCs are owned by the storage module.** This schema does not carry a `storage.pvcs`
 > block — see the storage module for PVC inventory (status, storage class, capacity).
@@ -569,8 +620,8 @@ workloads:
       statefulsets: int
       services: int|null             # null for kube-* rows: §5 scopes kube-* out, so not counted here (never 0)
       ingresses: int
-      hpas: int                    # per-namespace HPA count (rolled up from hpas.list)
-      pdbs: int                    # per-namespace PDB count (rolled up from pdbs.list)
+      hpas: int                    # per-namespace HPA count (from the Per-Namespace Rollup step)
+      pdbs: int                    # per-namespace PDB count (from the Per-Namespace Rollup step)
 
   deployments:
     count: int

--- a/skills/eks-recon/references/workloads.md
+++ b/skills/eks-recon/references/workloads.md
@@ -362,10 +362,13 @@ Also record `status.disruptionsAllowed` — the point-in-time count of voluntary
 Eviction API currently permits for the pods this PDB selects. `0` means it currently rejects
 voluntary eviction of covered healthy pods, which can stall a drain of the nodes hosting them
 (a PDB selecting zero pods also reports `0`). **Always** record `spec.unhealthyPodEvictionPolicy`
-(→ `unhealthy_pod_eviction_policy`) — it governs whether unhealthy covered pods are evictable
-while `disruptions_allowed` is `0` (`AlwaysAllow` = evict regardless of budget health;
-`IfHealthyBudget`, the unset default, = only once the budget is healthy). Emit the value
-verbatim; use `null` only when the field is genuinely unset — never drop the key.
+(→ `unhealthy_pod_eviction_policy`) — it governs whether running-but-not-ready (unhealthy)
+covered pods can be evicted, judged by whether the budget is currently met
+(`currentHealthy >= desiredHealthy`), independent of the `disruptions_allowed` counter
+(`AlwaysAllow` = evict such pods regardless of budget health; `IfHealthyBudget`, the unset
+default, = only while `currentHealthy >= desiredHealthy`) — this is what lets a drain make
+progress when a covered workload is unhealthy. Emit the value verbatim; use `null` only when
+the field is genuinely unset — never drop the key.
 
 **MCP:**
 ```
@@ -536,7 +539,7 @@ kubectl get deploy,statefulsets,daemonsets,jobs -A -o json | jq -r '
 
 ### Per-Namespace Rollup
 
-Roll the per-type listings up into the `by_namespace` schema block — one row per namespace
+Populate the `by_namespace` schema block — one row per namespace
 with a count column per workload type. Run this explicitly: the schema advertises per-namespace
 `hpas`/`pdbs` counts and the `deployments`/`services` kube-* handling, but nothing above emits
 them, so on a complete run they are otherwise dropped.
@@ -568,13 +571,14 @@ kubectl get deploy,statefulset,service,ingress,hpa,pdb -A -o json | jq '
 ```
 
 A multi-type `kubectl get` tags each item with its `.kind`, so a single read covers all six
-types. A namespace row exists wherever any column has a count, so rows may be partial.
+types. A row exists for any namespace containing at least one of the six workload types, so
+rows may be partial.
 
 **Example output:**
 ```json
 [
-  {"namespace": "production", "deployments": 8, "statefulsets": 2, "services": 5, "ingresses": 1, "hpas": 3, "pdbs": 2},
-  {"namespace": "kube-system", "deployments": null, "statefulsets": 0, "services": null, "ingresses": 0, "hpas": 0, "pdbs": 1}
+  {"namespace": "kube-system", "deployments": null, "statefulsets": 0, "services": null, "ingresses": 0, "hpas": 0, "pdbs": 1},
+  {"namespace": "production", "deployments": 8, "statefulsets": 2, "services": 5, "ingresses": 1, "hpas": 3, "pdbs": 2}
 ]
 ```
 
@@ -609,8 +613,8 @@ workloads:
 
   # kube-* scope split across these columns: ONLY deployments and services exclude kube-*
   # namespaces (their §1/§5 jq blocks filter kube-* out). statefulsets, ingresses, hpas, and pdbs
-  # INCLUDE kube-* (their listings apply no namespace filter). A namespace row exists wherever ANY
-  # column has a count, so rows may be partial. For a scoped-out column emit `null`, NOT 0 (schema
+  # INCLUDE kube-* (their listings apply no namespace filter). A row exists wherever ANY of the six
+  # workload types is present, so rows may be partial. For a scoped-out column emit `null`, NOT 0 (schema
   # header rule: null = fact not detected/collected) — e.g. a kube-system row shows `null` for
   # deployments and services (column scoped out, not "zero found"; kube-system always runs CoreDNS
   # Deployments + kube-dns Services) but real counts for statefulsets/ingresses/hpas/pdbs.


### PR DESCRIPTION
## Summary

Fixes #192. `eks-recon` #184 added workloads-schema fields that had **no driving collection step**, so a complete CLI run reports `modules: N/N` yet silently omits them. This adds the missing collection and hardens the schema-vs-collection contract, in both lanes.

- **Per-Namespace Rollup step** drives the `by_namespace` schema block (per-namespace `deployments`, `statefulsets`, `services`, `ingresses`, `hpas`, `pdbs`). This forces the previously-dropped per-namespace HPA/PDB counts and the kube-* `null`-not-`0` handling (`deployments`/`services` are `null` for kube-* rows, since §1/§5 scope kube-* out) to be produced instead of living only in a schema comment.
- **`unhealthy_pod_eviction_policy`** promoted: directive "always record" prose plus a non-null example (`AlwaysAllow`), so the trailing field is no longer treated as optional and dropped. The prose states the correct governing axis: the policy governs eviction of running-but-not-ready (unhealthy) covered pods, judged by whether the budget is currently met (`currentHealthy >= desiredHealthy`), independent of the `disruptions_allowed` counter (verified vs the PDB v1 API reference and KEP-3017).
- **Schema-completeness rule**: every schema key must trace to a collection step (a key with no driving step is a defect).

## Lanes

Applied to both lanes in their native styles and regenerated the website twins:
- `skills/eks-recon/references/workloads.md` — executable `kubectl | jq` (rollup jq validated on a fixture).
- `devops-agent/eks-recon/references/workloads.md` — prose + reference pseudocode (no executable pipelines, per the DevOps Agent runtime).

Shared aggregate manifests (`docs/skills/index.md`, `static/manifests/skills.json`) are unchanged — this is a prose-only edit that does not touch any skill name/description.

## Review

Whole-branch adversarial review over two rounds (12-lens, verification-gated): APPROVED. jq `.kind` correctness confirmed empirically (a multi-type `kubectl get` stamps `.kind` on each item); kube-* null handling confirmed schema-faithful; lane parity verified; twins regenerate byte-identically.