### PR TITLE
chore(deps): batch bump colord, js-yaml, svgo in /misc/website

### DIFF
--- a/misc/website/package-lock.json
+++ b/misc/website/package-lock.json
@@ -6918,9 +6918,9 @@
       "license": "MIT"
     },
     "node_modules/colord": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.10.0.tgz",
+      "integrity": "sha512-AidJptpBJmjTclAp9BkLwJi0T93fo5epJnbaZslpg6QVzpHjAiveF55mE9AcUJiGMqRHgMDY8soMsQtuNYMHfw==",
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -9198,9 +9198,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -10319,9 +10319,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -17018,9 +17018,9 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
-      "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.5.tgz",
+      "integrity": "sha512-8SQMzdrvWaD8deUmrnYB+ASyxBVgWUOilg+A75nE/76WdLpj6LopCwiAVvkzkcqy/9b7t2Mg7faFLjg0ZRcZ3w==",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",


### PR DESCRIPTION
## What

Batches three dependabot npm bumps in `misc/website` into a single PR so CI validates all three together against one consistent lockfile:

| Package | From | To | Supersedes |
|---|---|---|---|
| colord | 2.9.3 | 2.10.0 | `#215` |
| js-yaml (nested under gray-matter) | 3.15.1 | 3.15.2 | `#216` |
| svgo | 3.3.4 | 3.3.5 | `#217` |

All three are **transitive** deps (none are declared in `package.json`), so this regenerates a single consistent `package-lock.json` via a targeted `npm update colord js-yaml svgo` rather than cherry-picking the three dependabot lockfiles (which conflict with each other).

### Incidental in-range change
The update also moved the **top-level** `js-yaml` `4.3.1 → 4.3.2` (a within-range patch on the 4.x tree, distinct from `#216`'s nested 3.15.x). This is a natural side-effect of npm's consistent resolution, kept rather than hand-editing the lockfile back.

## Verification
- `npm ci` — clean (lockfile consistent with `package.json`)
- `npm run build` — SUCCESS (docusaurus). The one broken-anchor warning is pre-existing on `terraform-skill/references/module-patterns` and unrelated to this change.

## Supersedes
Replaces `#215`, `#216`, `#217`. Do **not** hand-close them — dependabot will auto-close on its next scan once this merges.